### PR TITLE
feat: add deploy workflow with rollback

### DIFF
--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ============================================================
+# FRC Central Server — Deploy Script
+# Runs on the server via SSH from GitHub Actions
+# Usage: ./deploy.sh <version> <instance>
+# Example: ./deploy.sh 3.1.0-alpha.1 alpha
+# ============================================================
+
+VERSION="${1:?Usage: deploy.sh <version> <instance>}"
+INSTANCE="${2:?Usage: deploy.sh <version> <instance>}"
+
+BASE_DIR="/opt/frc-backend-central"
+INSTANCE_DIR="${BASE_DIR}/${INSTANCE}"
+RELEASES_DIR="${BASE_DIR}/releases"
+RELEASE_DIR="${RELEASES_DIR}/${VERSION}"
+JAR_NAME="frc-central-server.jar"
+SERVICE_NAME="frc-${INSTANCE}.service"
+HEALTH_URL="http://localhost:$(grep SERVER_PORT "${INSTANCE_DIR}/.env" | cut -d= -f2)/actuator/health"
+HEALTH_TIMEOUT=60
+HEALTH_INTERVAL=5
+
+# --- Validations ---
+if [[ ! -d "${INSTANCE_DIR}" ]]; then
+  echo "ERROR: Instance directory ${INSTANCE_DIR} does not exist"
+  exit 1
+fi
+
+if [[ ! -f "${RELEASE_DIR}/${JAR_NAME}" ]]; then
+  echo "ERROR: JAR not found at ${RELEASE_DIR}/${JAR_NAME}"
+  exit 1
+fi
+
+# --- Save current version for rollback ---
+PREVIOUS_VERSION=""
+if [[ -f "${INSTANCE_DIR}/.current-version" ]]; then
+  PREVIOUS_VERSION=$(cat "${INSTANCE_DIR}/.current-version")
+fi
+echo "Current version: ${PREVIOUS_VERSION:-none}"
+echo "Deploying version: ${VERSION}"
+
+# --- Update symlink ---
+ln -sfn "${RELEASE_DIR}" "${INSTANCE_DIR}/current"
+echo "${VERSION}" > "${INSTANCE_DIR}/.current-version"
+echo "Symlink updated: current -> ${RELEASE_DIR}"
+
+# --- Restart service ---
+echo "Restarting ${SERVICE_NAME}..."
+sudo systemctl restart "${SERVICE_NAME}"
+
+# --- Health check ---
+echo "Waiting for health check at ${HEALTH_URL} (timeout: ${HEALTH_TIMEOUT}s)..."
+ELAPSED=0
+while [[ ${ELAPSED} -lt ${HEALTH_TIMEOUT} ]]; do
+  sleep "${HEALTH_INTERVAL}"
+  ELAPSED=$((ELAPSED + HEALTH_INTERVAL))
+
+  HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${HEALTH_URL}" 2>/dev/null || echo "000")
+  echo "  [${ELAPSED}s] HTTP ${HTTP_STATUS}"
+
+  if [[ "${HTTP_STATUS}" == "200" ]]; then
+    echo "Health check PASSED — ${INSTANCE} running version ${VERSION}"
+    exit 0
+  fi
+done
+
+# --- Health check failed — Rollback ---
+echo "ERROR: Health check failed after ${HEALTH_TIMEOUT}s"
+
+if [[ -n "${PREVIOUS_VERSION}" && -d "${RELEASES_DIR}/${PREVIOUS_VERSION}" ]]; then
+  echo "Rolling back to ${PREVIOUS_VERSION}..."
+  ln -sfn "${RELEASES_DIR}/${PREVIOUS_VERSION}" "${INSTANCE_DIR}/current"
+  echo "${PREVIOUS_VERSION}" > "${INSTANCE_DIR}/.current-version"
+  sudo systemctl restart "${SERVICE_NAME}"
+  echo "Rollback complete. Service restarted with version ${PREVIOUS_VERSION}"
+else
+  echo "WARNING: No previous version to rollback to. Manual intervention required."
+fi
+
+exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,83 @@
+name: Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to deploy (e.g. 3.1.0-alpha.1)'
+        required: true
+        type: string
+      instance:
+        description: 'Target instance'
+        required: true
+        type: choice
+        options:
+          - alpha
+          - farmacia
+          - bodega
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.instance == 'bodega' && 'production' || inputs.instance == 'farmacia' && 'beta' || 'alpha' }}
+
+    steps:
+      - name: Download JAR from GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Downloading frc-central-server.jar from release v${{ inputs.version }}..."
+          curl -fSL \
+            -H "Authorization: token ${GH_TOKEN}" \
+            -H "Accept: application/octet-stream" \
+            -o frc-central-server.jar \
+            "$(curl -fSL \
+                -H "Authorization: token ${GH_TOKEN}" \
+                -H "Accept: application/vnd.github.v3+json" \
+                "https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ inputs.version }}" \
+              | jq -r '.assets[] | select(.name == "frc-central-server.jar") | .url')"
+          ls -lh frc-central-server.jar
+
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/scripts/deploy.sh
+          sparse-checkout-cone-mode: false
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H ${{ secrets.DEPLOY_HOST }} >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Upload JAR to server
+        run: |
+          VERSION="${{ inputs.version }}"
+          INSTANCE="${{ inputs.instance }}"
+
+          echo "Creating release directory and uploading JAR..."
+          ssh -i ~/.ssh/deploy_key deploy@${{ secrets.DEPLOY_HOST }} \
+            "mkdir -p /opt/frc-backend-central/releases/${VERSION}"
+
+          scp -i ~/.ssh/deploy_key \
+            frc-central-server.jar \
+            deploy@${{ secrets.DEPLOY_HOST }}:/opt/frc-backend-central/releases/${VERSION}/frc-central-server.jar
+
+      - name: Upload deploy script
+        run: |
+          scp -i ~/.ssh/deploy_key \
+            .github/scripts/deploy.sh \
+            deploy@${{ secrets.DEPLOY_HOST }}:/tmp/deploy.sh
+
+      - name: Execute deploy
+        run: |
+          ssh -i ~/.ssh/deploy_key deploy@${{ secrets.DEPLOY_HOST }} \
+            "chmod +x /tmp/deploy.sh && /tmp/deploy.sh '${{ inputs.version }}' '${{ inputs.instance }}'"
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## Deploy Summary" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version:** ${{ inputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Instance:** ${{ inputs.instance }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Status:** ${{ job.status }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Adds `deploy.yml` workflow (manual dispatch with version + instance selection)
- Adds `deploy.sh` script with automatic rollback on health check failure
- Targets: alpha (testing), farmacia (beta), bodega (production with approval gate)

## Test plan
- [ ] Merge to develop (triggers release)
- [ ] Run deploy workflow targeting alpha with latest version
- [ ] Verify health check passes on port 8083
- [ ] Test rollback with invalid version

🤖 Generated with [Claude Code](https://claude.com/claude-code)