### PR TITLE
fix: correct PdvCajaRepository ID type

### DIFF
--- a/src/main/java/com/franco/dev/repository/financiero/PdvCajaRepository.java
+++ b/src/main/java/com/franco/dev/repository/financiero/PdvCajaRepository.java
@@ -16,7 +16,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-public interface PdvCajaRepository extends HelperRepository<PdvCaja, Long>, JpaSpecificationExecutor<PdvCaja> {
+public interface PdvCajaRepository extends HelperRepository<PdvCaja, EmbebedPrimaryKey>, JpaSpecificationExecutor<PdvCaja> {
 
     default Class<PdvCaja> getEntityClass() {
         return PdvCaja.class;


### PR DESCRIPTION
## Summary
- Fix ID type mismatch: `Long` → `EmbebedPrimaryKey` in PdvCajaRepository
- PdvCaja uses `@IdClass(EmbebedPrimaryKey.class)`, repository now matches

## Test plan
- [x] Verified no other code calls `findById(Long)` on this repository
- [x] PdvCajaService already uses `EmbebedPrimaryKey` — consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)