### PR TITLE
chore: add master to CI workflow triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [develop, release/*, main]
+    branches: [develop, release/*, main, master]
 
 jobs:
   build:


### PR DESCRIPTION
CI was not running on PRs targeting master because the branch list only had main.