### PR TITLE
chore: add master to Release workflow triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [develop, release/*, main]
+    branches: [develop, release/*, main, master]
 
 jobs:
   release:


### PR DESCRIPTION
Release workflow was not triggering on push to master because the branch list only had main.