### PR TITLE
fix: remove evento_inutilizacion tables from central_pub

### DIFF
--- a/src/main/resources/db/migration/V118__remove_inutilizacion_from_central_pub.sql
+++ b/src/main/resources/db/migration/V118__remove_inutilizacion_from_central_pub.sql
@@ -1,0 +1,4 @@
+-- Remove evento_inutilizacion tables from central_pub
+-- These tables are central-only and should not be replicated to filiales
+ALTER PUBLICATION central_pub DROP TABLE IF EXISTS financiero.evento_inutilizacion_de;
+ALTER PUBLICATION central_pub DROP TABLE IF EXISTS financiero.evento_inutilizacion_de_documento_electronico;


### PR DESCRIPTION
## Summary
- Remove `financiero.evento_inutilizacion_de` and `financiero.evento_inutilizacion_de_documento_electronico` from `central_pub`
- These tables are central-only and don't exist in filiales, causing subscription creation to fail

## Test plan
- [x] Already applied manually on production central DB
- [ ] CI passes