### PR TITLE
fix: correct V118 migration syntax for ALTER PUBLICATION

### DIFF
--- a/src/main/resources/db/migration/V118__remove_inutilizacion_from_central_pub.sql
+++ b/src/main/resources/db/migration/V118__remove_inutilizacion_from_central_pub.sql
@@ -1,4 +1,23 @@
 -- Remove evento_inutilizacion tables from central_pub
 -- These tables are central-only and should not be replicated to filiales
-ALTER PUBLICATION central_pub DROP TABLE IF EXISTS financiero.evento_inutilizacion_de;
-ALTER PUBLICATION central_pub DROP TABLE IF EXISTS financiero.evento_inutilizacion_de_documento_electronico;
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_publication_tables
+    WHERE pubname = 'central_pub'
+      AND schemaname = 'financiero'
+      AND tablename = 'evento_inutilizacion_de'
+  ) THEN
+    ALTER PUBLICATION central_pub DROP TABLE financiero.evento_inutilizacion_de;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_publication_tables
+    WHERE pubname = 'central_pub'
+      AND schemaname = 'financiero'
+      AND tablename = 'evento_inutilizacion_de_documento_electronico'
+  ) THEN
+    ALTER PUBLICATION central_pub DROP TABLE financiero.evento_inutilizacion_de_documento_electronico;
+  END IF;
+END
+$$;


### PR DESCRIPTION
ALTER PUBLICATION DROP TABLE does not support IF EXISTS. Use DO block with pg_publication_tables check instead.