### PR TITLE
fix(ci): prevent git notes race condition in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [develop, release/*, main, master]
 
+concurrency:
+  group: release-${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -32,6 +36,9 @@ jobs:
 
       - name: Install semantic-release plugins
         run: npm install -g semantic-release @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/exec @semantic-release/github
+
+      - name: Fetch semantic-release git notes
+        run: git fetch origin 'refs/notes/*:refs/notes/*' || true
 
       - name: Run semantic-release
         run: npx semantic-release


### PR DESCRIPTION
Add concurrency group to serialize Release runs and fetch existing semantic-release git notes before running, preventing failures when multiple branches push simultaneously.

Discovered while validating the alpha→beta→stable release flow on the mobile repo: parallel runs on master and release/beta race on git notes push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)