### PR TITLE
feat!: bump major version to v4.0.0 + fix release branch config

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -2,7 +2,7 @@
   "branches": [
     { "name": "master" },
     { "name": "develop", "prerelease": "alpha" },
-    { "name": "release/*", "prerelease": "beta" }
+    { "name": "release/beta", "prerelease": "beta" }
   ],
   "plugins": [
     "@semantic-release/commit-analyzer",


### PR DESCRIPTION
BREAKING CHANGE: Major version bump to reset release numbering.

- Changes `release/*` pattern to exact `release/beta` name (avoids EPRERELEASEBRANCHES from legacy release/next tags)
- Bumps to v4.0.0 to avoid collision with existing v3.1.0-beta.1 tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)