### PR TITLE
release: v4.0.0 stable

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -2,7 +2,7 @@
   "branches": [
     { "name": "master" },
     { "name": "develop", "prerelease": "alpha" },
-    { "name": "release/*", "prerelease": "beta" }
+    { "name": "release/beta", "prerelease": "beta" }
   ],
   "plugins": [
     "@semantic-release/commit-analyzer",


### PR DESCRIPTION
Promote release/beta to master to trigger stable v4.0.0 release.

Validates the full release flow: alpha (develop) → beta (release/beta) → stable (master).

**Note:** This is Backend Central — production deploy requires manual approval via Deploy workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)