### PR TITLE
feat(ci): add beta as deployable instance

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ on:
         type: choice
         options:
           - alpha
+          - beta
           - farmacia
           - bodega
       version:
@@ -19,7 +20,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment: ${{ inputs.instance == 'bodega' && 'production' || inputs.instance == 'farmacia' && 'beta' || 'alpha' }}
+    environment: ${{ inputs.instance == 'bodega' && 'production' || (inputs.instance == 'farmacia' || inputs.instance == 'beta') && 'beta' || 'alpha' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -47,8 +48,8 @@ jobs:
                 -H "Accept: application/vnd.github.v3+json" \
                 "https://api.github.com/repos/${{ github.repository }}/releases/latest" \
                 | jq -r '.tag_name')
-            elif [[ "${INSTANCE}" == "farmacia" ]]; then
-              # Beta: latest prerelease with -beta
+            elif [[ "${INSTANCE}" == "farmacia" || "${INSTANCE}" == "beta" ]]; then
+              # Beta channel: latest prerelease with -beta
               TAG=$(curl -fsSL \
                 -H "Authorization: token ${GH_TOKEN}" \
                 -H "Accept: application/vnd.github.v3+json" \


### PR DESCRIPTION
## Summary
Adds `beta` to the `deploy.yml` instance options. Beta shares the `-beta` release channel with `farmacia` (both consume the same beta releases) but targets:
- Host: `172.25.1.200`
- Path: `/opt/frc-backend-central/beta/`
- Systemd unit: `frc-beta.service`
- Port: `8084`

## Why
The pilot beta server (`172.25.1.200:8084`) was set up to validate the full CI/CD beta channel end-to-end before migrating real farmacia production. Without this change, deploys cannot target the beta host via GitHub Actions — the only options were alpha/farmacia/bodega.

## Changes
- Added `- beta` to the instance choice list (line 12)
- Updated environment mapping: `beta` → `beta` environment (same approval rules as farmacia)
- Updated version resolver: `beta` instance also resolves to latest `-beta` prerelease (same logic as farmacia)

`deploy.sh` requires no changes — it's fully parametrized by `INSTANCE`.

## Test plan
- [ ] After merge to develop → wait for alpha release to publish (sanity check workflows still pass)
- [ ] PR develop → release/beta → triggers new beta release
- [ ] Test the new beta release: `Actions → Deploy → workflow_dispatch with instance=beta`
- [ ] Verify deploy lands on 172.25.1.200, restarts `frc-beta.service`, health check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)