### PR TITLE
fix(replication): use dynamic pub/sub names + add replication_test to publications

### DIFF
--- a/src/main/java/com/franco/dev/graphql/replication/LogicalReplicationGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/replication/LogicalReplicationGraphQL.java
@@ -188,26 +188,8 @@ public class LogicalReplicationGraphQL implements GraphQLQueryResolver, GraphQLM
         return lr;
     }
     
-    // Helper method to extract sucursal ID from name
     private Long extractSucursalIdFromName(String name) {
-        try {
-            if (name.startsWith("filial") && name.contains("_")) {
-                // Format: filial<id>_pub or filial<id>_sub
-                String idPart = name.substring(6, name.indexOf("_"));
-                return Long.parseLong(idPart);
-            } else if (name.startsWith("central_filial") && name.contains("_pub")) {
-                // Format: central_filial<id>_pub
-                String idPart = name.substring(14, name.indexOf("_pub"));
-                return Long.parseLong(idPart);
-            } else if (name.startsWith("central_filial") && name.contains("_sub")) {
-                // Format: central_filial<id>_sub
-                String idPart = name.substring(14, name.indexOf("_sub"));
-                return Long.parseLong(idPart);
-            }
-        } catch (NumberFormatException | IndexOutOfBoundsException e) {
-            // Handle parsing error
-        }
-        return null;
+        return replicationService.extractSucursalIdFromName(name);
     }
     
     // Mutation resolvers
@@ -307,7 +289,7 @@ public class LogicalReplicationGraphQL implements GraphQLQueryResolver, GraphQLM
             
             if (isSubscription) {
                 // Toggle subscription
-                String subscriptionName = "filial" + sucursalId + "_sub";
+                String subscriptionName = replicationService.generateBranchSubscriptionName(Long.parseLong(sucursalId));
                 success = replicationService.alterSubscription(subscriptionName, enabled);
                 
                 if (success) {
@@ -331,7 +313,7 @@ public class LogicalReplicationGraphQL implements GraphQLQueryResolver, GraphQLM
                     }
                 } else {
                     // Disable publication (drop it)
-                    String publicationName = "central_filial" + sucursalId + "_pub";
+                    String publicationName = replicationService.generateCentralToBranchPublicationName(Long.parseLong(sucursalId));
                     success = replicationService.dropPublication(publicationName);
                     
                     if (success) {

--- a/src/main/java/com/franco/dev/graphql/replication/ReplicationResolver.java
+++ b/src/main/java/com/franco/dev/graphql/replication/ReplicationResolver.java
@@ -2,6 +2,7 @@ package com.franco.dev.graphql.replication;
 
 import com.franco.dev.domain.empresarial.Sucursal;
 import com.franco.dev.graphql.replication.types.LogicalReplication;
+import com.franco.dev.service.empresarial.LogicalReplicationService;
 import com.franco.dev.service.empresarial.SucursalService;
 import graphql.kickstart.tools.GraphQLResolver;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,48 +13,23 @@ public class ReplicationResolver implements GraphQLResolver<LogicalReplication> 
 
     @Autowired
     private SucursalService sucursalService;
-    
-    /**
-     * Resolve sucursal field if it's null but name provides enough information
-     */
+
+    @Autowired
+    private LogicalReplicationService replicationService;
+
     public Sucursal sucursal(LogicalReplication replication) {
         if (replication.getSucursal() != null) {
             return replication.getSucursal();
         }
-        
-        // If sucursal is null but we can extract ID from name, resolve it
+
         String name = replication.getName();
         if (name != null) {
-            Long sucursalId = extractSucursalIdFromName(name);
+            Long sucursalId = replicationService.extractSucursalIdFromName(name);
             if (sucursalId != null) {
                 return sucursalService.findById(sucursalId).orElse(null);
             }
         }
-        
-        return null;
-    }
-    
-    /**
-     * Extract sucursal ID from replication name
-     */
-    private Long extractSucursalIdFromName(String name) {
-        try {
-            if (name.startsWith("filial") && name.contains("_")) {
-                // Format: filial<id>_pub or filial<id>_sub
-                String idPart = name.substring(6, name.indexOf("_"));
-                return Long.parseLong(idPart);
-            } else if (name.startsWith("central_filial") && name.contains("_pub")) {
-                // Format: central_filial<id>_pub
-                String idPart = name.substring(14, name.indexOf("_pub"));
-                return Long.parseLong(idPart);
-            } else if (name.startsWith("central_filial") && name.contains("_sub")) {
-                // Format: central_filial<id>_sub
-                String idPart = name.substring(14, name.indexOf("_sub"));
-                return Long.parseLong(idPart);
-            }
-        } catch (NumberFormatException | IndexOutOfBoundsException e) {
-            // Handle parsing error
-        }
+
         return null;
     }
 } 

--- a/src/main/java/com/franco/dev/service/empresarial/LogicalReplicationService.java
+++ b/src/main/java/com/franco/dev/service/empresarial/LogicalReplicationService.java
@@ -1553,7 +1553,25 @@ public class LogicalReplicationService {
     public String generateBranchToCentralSubscriptionName(Long sucursalId) {
         return getCentralDbName() + "_filial" + sucursalId + "_central_sub";
     }
-    
+
+    /**
+     * Extract sucursal ID from a publication or subscription name.
+     * Handles dynamic DB-prefixed names like: beta_filial2_pub, central_beta_filial2_sub, etc.
+     */
+    public Long extractSucursalIdFromName(String name) {
+        if (name == null) return null;
+        try {
+            // Pattern: ...filial<id>_pub, ...filial<id>_sub, ...filial<id>_central_sub
+            java.util.regex.Matcher m = java.util.regex.Pattern.compile("filial(\\d+)_").matcher(name);
+            if (m.find()) {
+                return Long.parseLong(m.group(1));
+            }
+        } catch (NumberFormatException e) {
+            // ignore
+        }
+        return null;
+    }
+
     /**
      * Refresh a specific subscription to sync with its publication
      * @param subscriptionName Name of the subscription to refresh
@@ -1742,12 +1760,13 @@ public class LogicalReplicationService {
             }
 
             // 2. central_filialX_pub: for each existing publication, add missing tables with WHERE (sucursal_id = X)
+            String centralPubPrefix = "central_" + getCentralDbName() + "_filial";
             List<Map<String, Object>> pubs = jdbcTemplate.queryForList(
-                "SELECT pubname FROM pg_publication WHERE pubname LIKE 'central_filial%_pub' ORDER BY pubname");
+                "SELECT pubname FROM pg_publication WHERE pubname LIKE '" + centralPubPrefix + "%_pub' ORDER BY pubname");
             for (Map<String, Object> row : pubs) {
                 String pubname = (String) row.get("pubname");
                 if (pubname == null) continue;
-                String suffix = pubname.replace("central_filial", "").replace("_pub", "");
+                String suffix = pubname.replace(centralPubPrefix, "").replace("_pub", "");
                 Long sucursalId = null;
                 try {
                     sucursalId = Long.parseLong(suffix);
@@ -1784,7 +1803,7 @@ public class LogicalReplicationService {
                 for (Sucursal sucursal : sucursales) {
                     Long sid = sucursal.getId();
                     if (sid == null || sid == 0) continue;
-                    String filialPubName = "filial" + sid + "_pub";
+                    String filialPubName = generateBranchPublicationName(sid);
                     try {
                         JdbcTemplate remoteJdbc = createRemoteJdbcTemplate(
                             sucursal.getIp(),
@@ -1822,14 +1841,17 @@ public class LogicalReplicationService {
                 Long sid = sucursal.getId();
                 if (sid == null || sid == 0) continue;
                 try {
-                    if (refreshRemoteSubscription(sid, "filial" + sid + "_central_sub")) {
-                        log.append("  Filial ").append(sid).append(": filial").append(sid).append("_central_sub refrescada.\n");
+                    String branchToCentralSubName = generateBranchToCentralSubscriptionName(sid);
+                    if (refreshRemoteSubscription(sid, branchToCentralSubName)) {
+                        log.append("  Filial ").append(sid).append(": ").append(branchToCentralSubName).append(" refrescada.\n");
                     }
-                    if (refreshRemoteSubscription(sid, "central_filial" + sid + "_sub")) {
-                        log.append("  Filial ").append(sid).append(": central_filial").append(sid).append("_sub refrescada.\n");
+                    String centralToBranchSubName = generateCentralToBranchSubscriptionName(sid);
+                    if (refreshRemoteSubscription(sid, centralToBranchSubName)) {
+                        log.append("  Filial ").append(sid).append(": ").append(centralToBranchSubName).append(" refrescada.\n");
                     }
-                    if (refreshSubscription("filial" + sid + "_sub")) {
-                        log.append("  Central: filial").append(sid).append("_sub refrescada.\n");
+                    String branchSubName = generateBranchSubscriptionName(sid);
+                    if (refreshSubscription(branchSubName)) {
+                        log.append("  Central: ").append(branchSubName).append(" refrescada.\n");
                     }
                 } catch (Exception e) {
                     log.append("  Refresco sucursal ").append(sid).append(": ").append(e.getMessage()).append("\n");

--- a/src/main/resources/db/migration/V119__add_replication_test_to_publications.sql
+++ b/src/main/resources/db/migration/V119__add_replication_test_to_publications.sql
@@ -1,0 +1,44 @@
+-- Add replication_test to central_pub (MAIN_TO_ALL direction) and to all central_*_filialX_pub publications.
+-- Publication names are dynamic (prefixed with DB name), so we discover them.
+
+-- 1. Add to central_pub if it exists
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_publication WHERE pubname = 'central_pub') THEN
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_publication_tables
+            WHERE pubname = 'central_pub' AND tablename = 'replication_test'
+        ) THEN
+            EXECUTE 'ALTER PUBLICATION central_pub ADD TABLE configuraciones.replication_test';
+            RAISE NOTICE 'Added configuraciones.replication_test to central_pub';
+        END IF;
+    END IF;
+END $$;
+
+-- 2. Add to all central_*_filialX_pub publications (with sucursal_id WHERE clause)
+DO $$
+DECLARE
+    pub RECORD;
+    suc_id TEXT;
+BEGIN
+    FOR pub IN
+        SELECT pubname FROM pg_publication
+        WHERE pubname LIKE 'central_%_filial%_pub'
+        ORDER BY pubname
+    LOOP
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_publication_tables
+            WHERE pubname = pub.pubname AND tablename = 'replication_test'
+        ) THEN
+            -- Extract sucursal_id: pattern is central_{dbname}_filial{id}_pub
+            suc_id := regexp_replace(pub.pubname, '^central_.*_filial(\d+)_pub$', '\1');
+            IF suc_id ~ '^\d+$' THEN
+                EXECUTE format(
+                    'ALTER PUBLICATION %I ADD TABLE configuraciones.replication_test WHERE (sucursal_id = %s)',
+                    pub.pubname, suc_id
+                );
+                RAISE NOTICE 'Added configuraciones.replication_test to % (sucursal_id=%)', pub.pubname, suc_id;
+            END IF;
+        END IF;
+    END LOOP;
+END $$;


### PR DESCRIPTION
## Summary
- Replace hardcoded publication/subscription names in `syncPublicationsWithReplicationTable()` with generator methods — fixes "publication does not exist" errors in environments where names include DB prefix (e.g. `beta_filial2_pub` instead of `filial2_pub`)
- Fix `toggleReplication()` in `LogicalReplicationGraphQL` (lines 310, 334)
- Centralize `extractSucursalIdFromName()` using regex in `LogicalReplicationService`, removing broken duplicate parsers from `LogicalReplicationGraphQL` and `ReplicationResolver`
- Fix LIKE query for `central_*_filialX_pub` to use dynamic prefix
- Add V119 Flyway migration to include `configuraciones.replication_test` in `central_pub` and all `central_*_filialX_pub` publications

## Test plan
- [ ] Verify `syncPublicationsWithReplicationTable()` no longer produces "publication does not exist" errors on beta central
- [ ] Verify `replication_test` appears in `pg_publication_tables` for both `central_pub` and `central_beta_filial2_pub` after migration
- [ ] Verify `toggleReplication` GraphQL mutation works with correct names
- [ ] Verify `extractSucursalIdFromName` resolves correct sucursal for names like `beta_filial2_pub`

🤖 Generated with [Claude Code](https://claude.com/claude-code)