### PR TITLE
feat(ventas): generar reporte de venta

### DIFF
--- a/src/main/java/com/franco/dev/domain/operaciones/dto/ReporteVentaItemDto.java
+++ b/src/main/java/com/franco/dev/domain/operaciones/dto/ReporteVentaItemDto.java
@@ -1,0 +1,22 @@
+package com.franco.dev.domain.operaciones.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO para cada fila del reporte de ventas (JasperReports datasource).
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReporteVentaItemDto {
+    private Long ventaId;
+    private String sucursal;
+    private String cliente;
+    private String fecha;
+    private String formaPago;
+    private String moneda;
+    private String estado;
+    private Double totalGs;
+}

--- a/src/main/java/com/franco/dev/graphql/operaciones/VentaGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/VentaGraphQL.java
@@ -4,10 +4,15 @@ import com.franco.dev.config.multitenant.MultiTenantService;
 import com.franco.dev.domain.EmbebedPrimaryKey;
 import com.franco.dev.domain.empresarial.Sucursal;
 import com.franco.dev.domain.financiero.FacturaLegal;
+import com.franco.dev.domain.financiero.FormaPago;
+import com.franco.dev.domain.financiero.Moneda;
 import com.franco.dev.domain.operaciones.Cobro;
 import com.franco.dev.domain.operaciones.Venta;
 import com.franco.dev.domain.operaciones.VentaItem;
+
 import com.franco.dev.domain.operaciones.enums.VentaEstado;
+import com.franco.dev.domain.personas.Cliente;
+import com.franco.dev.domain.personas.Usuario;
 import com.franco.dev.graphql.financiero.FacturaLegalGraphQL;
 import com.franco.dev.graphql.financiero.VentaCreditoGraphQL;
 import com.franco.dev.graphql.operaciones.input.CobroDetalleInput;
@@ -16,13 +21,18 @@ import com.franco.dev.graphql.operaciones.input.VentaInput;
 import com.franco.dev.graphql.operaciones.input.VentaItemInput;
 import com.franco.dev.service.empresarial.SucursalService;
 import com.franco.dev.service.financiero.FormaPagoService;
+import com.franco.dev.service.financiero.MonedaService;
 import com.franco.dev.service.financiero.MovimientoCajaService;
 import com.franco.dev.service.financiero.PdvCajaService;
 import com.franco.dev.service.operaciones.DeliveryService;
 import com.franco.dev.service.operaciones.VentaItemService;
 import com.franco.dev.service.operaciones.VentaObservacionService;
+import com.franco.dev.service.impresion.ImpresionService;
 import com.franco.dev.service.operaciones.VentaService;
+import com.franco.dev.domain.operaciones.CobroDetalle;
+import com.franco.dev.domain.operaciones.dto.ReporteVentaItemDto;
 import com.franco.dev.domain.operaciones.VentaObservacion;
+import com.franco.dev.service.operaciones.CobroDetalleService;
 import com.franco.dev.service.personas.ClienteService;
 import com.franco.dev.service.personas.UsuarioService;
 import com.franco.dev.service.productos.CostosPorProductoService;
@@ -105,6 +115,15 @@ public class VentaGraphQL implements GraphQLQueryResolver, GraphQLMutationResolv
 
     @Autowired
     private MultiTenantService multiTenantService;
+
+    @Autowired
+    private ImpresionService impresionService;
+
+    @Autowired
+    private CobroDetalleService cobroDetalleService;
+
+    @Autowired
+    private MonedaService monedaService;
 
     private Sucursal sucursal;
 
@@ -418,5 +437,156 @@ public class VentaGraphQL implements GraphQLQueryResolver, GraphQLMutationResolv
           clienteId, 
           fechaInicio, fechaFin
         );
+    }
+
+    public String reporteGenericVentas(
+            Long idVenta,
+            Long idCaja,
+            Long sucId,
+            Long formaPago,
+            VentaEstado estado,
+            Boolean isDelivery,
+            Long monedaId,
+            Boolean conDescuento,
+            Boolean conAumento,
+            Boolean conObservacion,
+            Long clienteId,
+            String fechaInicio,
+            String fechaFin,
+            Long usuarioId) {
+
+        // Cargar todas las ventas sin límite de paginación
+        Pageable allPages = PageRequest.of(0, Integer.MAX_VALUE);
+        Page<Venta> ventaPage = service.onGenericSearch(
+                idVenta, idCaja, allPages, false,
+                sucId, formaPago, estado, isDelivery, monedaId,
+                conDescuento, conAumento, conObservacion, clienteId,
+                fechaInicio, fechaFin);
+
+        List<Venta> ventas = ventaPage.getContent();
+
+        // Acumuladores de totales por forma de pago (en Gs.)
+        double totalGeneral       = 0.0;
+        double totalEfectivo      = 0.0;
+        double totalTarjeta       = 0.0;
+        double totalConvenio      = 0.0;
+        double totalTransferencia = 0.0;
+        double totalOtros         = 0.0;
+
+        List<ReporteVentaItemDto> itemList = new ArrayList<>();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
+
+        for (Venta v : ventas) {
+            double ventaTotalGs = v.getTotalGs() != null ? v.getTotalGs() : 0.0;
+            totalGeneral += ventaTotalGs;
+
+            // Resolver forma de pago y moneda usando la lógica del VentaResolver:
+            // si la venta no tiene formaPago directo, buscar en el cobro
+            FormaPago fp = v.getFormaPago();
+            Moneda moneda = null;
+            if (v.getCobro() != null) {
+                List<CobroDetalle> detalles = cobroDetalleService.findByCobroId(
+                        v.getCobro().getId(), v.getSucursalId());
+                if (detalles != null && !detalles.isEmpty()) {
+                    CobroDetalle primerDetalle = detalles.get(0);
+                    if (fp == null) {
+                        fp = primerDetalle.getFormaPago();
+                    }
+                    moneda = primerDetalle.getMoneda();
+                }
+            }
+
+            String fpDesc = fp != null && fp.getDescripcion() != null
+                    ? fp.getDescripcion().toUpperCase() : "";
+
+            if (fpDesc.contains("EFECTIVO")) {
+                totalEfectivo += ventaTotalGs;
+            } else if (fpDesc.contains("TARJETA")) {
+                totalTarjeta += ventaTotalGs;
+            } else if (fpDesc.contains("CONVENIO")) {
+                totalConvenio += ventaTotalGs;
+            } else if (fpDesc.contains("TRANSFERENCIA")) {
+                totalTransferencia += ventaTotalGs;
+            } else {
+                totalOtros += ventaTotalGs;
+            }
+
+            // Construir fila para el reporte
+            ReporteVentaItemDto dto = new ReporteVentaItemDto();
+            dto.setVentaId(v.getId());
+            dto.setSucursal(v.getSucursal() != null ? v.getSucursal().getNombre() : "");
+            dto.setCliente(v.getCliente() != null && v.getCliente().getPersona() != null
+                    ? v.getCliente().getPersona().getNombre() : "");
+            dto.setFecha(v.getCreadoEn() != null ? v.getCreadoEn().format(formatter) : "");
+            dto.setFormaPago(fp != null && fp.getDescripcion() != null ? fp.getDescripcion() : "");
+            dto.setMoneda(moneda != null && moneda.getDenominacion() != null ? moneda.getDenominacion() : "");
+            dto.setEstado(v.getEstado() != null ? v.getEstado().toString() : "");
+            dto.setTotalGs(ventaTotalGs);
+            itemList.add(dto);
+        }
+
+        // Resolver nombres reales de los filtros
+        Usuario usuario = usuarioId != null
+                ? usuarioService.findById(usuarioId).orElse(null) : null;
+
+        String filtroSucursalStr;
+        if (sucId != null) {
+            Sucursal suc = sucursalService.findById(sucId).orElse(null);
+            filtroSucursalStr = suc != null ? suc.getNombre() : "Sucursal " + sucId;
+        } else {
+            filtroSucursalStr = "Todas";
+        }
+
+        String filtroFpStr;
+        if (formaPago != null) {
+            FormaPago fp = formaPagoService.findById(formaPago).orElse(null);
+            filtroFpStr = fp != null ? fp.getDescripcion() : "FormaPago " + formaPago;
+        } else {
+            filtroFpStr = "Todas";
+        }
+
+        String filtroMonedaStr;
+        if (monedaId != null) {
+            Moneda m = monedaService.findById(monedaId).orElse(null);
+            filtroMonedaStr = m != null ? m.getDenominacion() : "Moneda " + monedaId;
+        } else {
+            filtroMonedaStr = "Todas";
+        }
+
+        String filtroEstadoStr  = estado    != null ? estado.toString() : "Todos";
+        String filtroClienteStr;
+        if (clienteId != null) {
+            Cliente c = clienteService.findById(clienteId).orElse(null);
+            filtroClienteStr = (c != null && c.getPersona() != null) ? c.getPersona().getNombre() : "ID: " + clienteId;
+        } else {
+            filtroClienteStr = "Todos";
+        }
+
+        String filtroModoStr;
+        if (isDelivery == null) {
+            filtroModoStr = "Todos";
+        } else if (isDelivery) {
+            filtroModoStr = "Delivery";
+        } else {
+            filtroModoStr = "Local";
+        }
+
+        String filtroConObsStr   = conObservacion != null && conObservacion ? "Sí" : "Todos";
+        String filtroConDescStr  = conDescuento   != null && conDescuento   ? "Sí" : "Todos";
+        String filtroConAumStr   = conAumento     != null && conAumento     ? "Sí" : "Todos";
+        
+        String filtroIdVentaStr  = idVenta        != null ? idVenta.toString() : "Todos";
+
+        return impresionService.imprimirReporteGenericVentas(
+                itemList,
+                filtroIdVentaStr,
+                fechaInicio != null ? fechaInicio : "-",
+                fechaFin    != null ? fechaFin    : "-",
+                filtroSucursalStr, filtroFpStr, filtroMonedaStr,
+                filtroEstadoStr, filtroClienteStr,
+                filtroModoStr, filtroConObsStr, filtroConDescStr, filtroConAumStr,
+                totalGeneral, totalEfectivo, totalTarjeta,
+                totalConvenio, totalTransferencia, totalOtros,
+                usuario);
     }
 }

--- a/src/main/java/com/franco/dev/service/impresion/ImpresionService.java
+++ b/src/main/java/com/franco/dev/service/impresion/ImpresionService.java
@@ -9,6 +9,7 @@ import com.franco.dev.domain.operaciones.Transferencia;
 import com.franco.dev.domain.operaciones.TransferenciaItem;
 import com.franco.dev.domain.operaciones.SolicitudPago;
 import com.franco.dev.domain.operaciones.dto.LucroPorProductosDto;
+import com.franco.dev.domain.operaciones.dto.ReporteVentaItemDto;
 import com.franco.dev.domain.personas.Cliente;
 import com.franco.dev.domain.personas.Usuario;
 import com.franco.dev.domain.productos.Codigo;
@@ -1391,6 +1392,68 @@ public class ImpresionService {
         private String nominal;
         private String diferido;
         private Boolean esCheque;
+    }
+
+    public String imprimirReporteGenericVentas(
+            List<ReporteVentaItemDto> itemList,
+            String filtroIdVenta,
+            String filtroFechaInicio,
+            String filtroFechaFin,
+            String filtroSucursal,
+            String filtroFormaPago,
+            String filtroMoneda,
+            String filtroEstado,
+            String filtroCliente,
+            String filtroModo,
+            String filtroConObservacion,
+            String filtroConDescuento,
+            String filtroConAumento,
+            Double totalGeneral,
+            Double totalEfectivo,
+            Double totalTarjeta,
+            Double totalConvenio,
+            Double totalTransferencia,
+            Double totalOtros,
+            Usuario usuario) {
+        try {
+            ClassPathResource resource = new ClassPathResource("reports/reporte-ventas.jrxml");
+            InputStream inputStream = resource.getInputStream();
+            JasperReport jasperReport = JasperCompileManager.compileReport(inputStream);
+            JRBeanCollectionDataSource dataSource = new JRBeanCollectionDataSource(
+                    itemList != null ? itemList : new ArrayList<>());
+            Map<String, Object> parameters = new HashMap<>();
+            parameters.put("fechaReporte", DateUtils.toString(LocalDateTime.now()));
+            parameters.put("usuario", usuario != null ? usuario.getNickname() : "");
+            parameters.put("logo", imageService.getImagePath() + File.separator + "logo.png");
+            parameters.put("filtroIdVenta", filtroIdVenta != null ? filtroIdVenta : "");
+            parameters.put("filtroFechaInicio", filtroFechaInicio != null ? filtroFechaInicio : "");
+            parameters.put("filtroFechaFin", filtroFechaFin != null ? filtroFechaFin : "");
+            parameters.put("filtroSucursal", filtroSucursal != null ? filtroSucursal : "");
+            parameters.put("filtroFormaPago", filtroFormaPago != null ? filtroFormaPago : "");
+            parameters.put("filtroMoneda", filtroMoneda != null ? filtroMoneda : "");
+            parameters.put("filtroEstado", filtroEstado != null ? filtroEstado : "");
+            parameters.put("filtroCliente", filtroCliente != null ? filtroCliente : "");
+            parameters.put("filtroModo", filtroModo != null ? filtroModo : "");
+            parameters.put("filtroConObservacion", filtroConObservacion != null ? filtroConObservacion : "");
+            parameters.put("filtroConDescuento", filtroConDescuento != null ? filtroConDescuento : "");
+            parameters.put("filtroConAumento", filtroConAumento != null ? filtroConAumento : "");
+            parameters.put("totalGeneral", totalGeneral != null ? totalGeneral : 0.0);
+            parameters.put("totalEfectivo", totalEfectivo != null ? totalEfectivo : 0.0);
+            parameters.put("totalTarjeta", totalTarjeta != null ? totalTarjeta : 0.0);
+            parameters.put("totalConvenio", totalConvenio != null ? totalConvenio : 0.0);
+            parameters.put("totalTransferencia", totalTransferencia != null ? totalTransferencia : 0.0);
+            parameters.put("totalOtros", totalOtros != null ? totalOtros : 0.0);
+            parameters.put("cantidadVentas", itemList != null ? (long) itemList.size() : 0L);
+            JasperPrint jasperPrint = JasperFillManager.fillReport(jasperReport, parameters, dataSource);
+            byte[] pdfBytes = JasperExportManager.exportReportToPdf(jasperPrint);
+            return Base64.getEncoder().encodeToString(pdfBytes);
+        } catch (JRException e) {
+            e.printStackTrace();
+            return null;
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
     }
 
     private String formatMinutes(Long minutes) {

--- a/src/main/resources/graphql/operaciones/venta.graphqls
+++ b/src/main/resources/graphql/operaciones/venta.graphqls
@@ -83,6 +83,22 @@ extend type Query {
         fechaInicio: String,
         fechaFin: String
     ):VentaPage
+    reporteGenericVentas(
+        idVenta: ID
+        idCaja: ID
+        sucId: ID
+        formaPago: ID
+        estado: VentaEstado
+        isDelivery: Boolean
+        monedaId: Int
+        conDescuento: Boolean
+        conAumento: Boolean
+        conObservacion: Boolean
+        clienteId: ID
+        fechaInicio: String
+        fechaFin: String
+        usuarioId: ID
+    ): String
 #    ventaPorPeriodo(inicio:String, fin:String, sucId: ID): [VentaPorPeriodo]
 #    ventaPorSucursal(inicio:String, fin:String): [VentaPorSucursal]
 }

--- a/src/main/resources/reports/reporte-ventas.jrxml
+++ b/src/main/resources/reports/reporte-ventas.jrxml
@@ -1,0 +1,631 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 6.21.5.final using JasperReports Library version 6.21.5-74d586df47b25dbd05bd0957999819196e59934a  -->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="reporte-ventas" pageWidth="842" pageHeight="595" orientation="Landscape" whenNoDataType="AllSectionsNoDetail" columnWidth="802" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isFloatColumnFooter="true" uuid="a1b2c3d4-e5f6-7890-abcd-ef1234567890">
+	<parameter name="fechaReporte" class="java.lang.String"/>
+	<parameter name="usuario" class="java.lang.String"/>
+	<parameter name="logo" class="java.lang.String"/>
+	<parameter name="filtroFechaInicio" class="java.lang.String"/>
+	<parameter name="filtroFechaFin" class="java.lang.String"/>
+	<parameter name="filtroSucursal" class="java.lang.String"/>
+	<parameter name="filtroFormaPago" class="java.lang.String"/>
+	<parameter name="filtroMoneda" class="java.lang.String"/>
+	<parameter name="filtroEstado" class="java.lang.String"/>
+	<parameter name="filtroCliente" class="java.lang.String"/>
+	<parameter name="filtroModo" class="java.lang.String"/>
+	<parameter name="filtroConObservacion" class="java.lang.String"/>
+	<parameter name="filtroConDescuento" class="java.lang.String"/>
+	<parameter name="filtroConAumento" class="java.lang.String"/>
+	<parameter name="totalGeneral" class="java.lang.Double"/>
+	<parameter name="totalEfectivo" class="java.lang.Double"/>
+	<parameter name="totalTarjeta" class="java.lang.Double"/>
+	<parameter name="totalConvenio" class="java.lang.Double"/>
+	<parameter name="totalTransferencia" class="java.lang.Double"/>
+	<parameter name="totalOtros" class="java.lang.Double"/>
+	<parameter name="cantidadVentas" class="java.lang.Long"/>
+	<parameter name="filtroIdVenta" class="java.lang.String"/>
+	<queryString>
+		<![CDATA[]]>
+	</queryString>
+	<field name="ventaId" class="java.lang.Long"/>
+	<field name="sucursal" class="java.lang.String"/>
+	<field name="cliente" class="java.lang.String"/>
+	<field name="fecha" class="java.lang.String"/>
+	<field name="formaPago" class="java.lang.String"/>
+	<field name="moneda" class="java.lang.String"/>
+	<field name="estado" class="java.lang.String"/>
+	<field name="totalGs" class="java.lang.Double"/>
+	<title>
+		<band height="148" splitType="Stretch">
+			<image hAlign="Center">
+				<reportElement x="10" y="51" width="100" height="76" uuid="11111111-1111-1111-1111-111111111101"/>
+				<imageExpression><![CDATA[$P{logo}]]></imageExpression>
+			</image>
+			<staticText>
+				<reportElement x="0" y="0" width="802" height="20" uuid="11111111-1111-1111-1111-111111111102"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="14" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Reporte de Ventas]]></text>
+			</staticText>
+			<rectangle>
+				<reportElement x="120" y="32" width="449" height="100" uuid="11111111-1111-1111-1111-111111111107">
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<graphicElement>
+					<pen lineColor="#808080"/>
+				</graphicElement>
+			</rectangle>
+			<staticText>
+				<reportElement x="130" y="53" width="58" height="12" uuid="11111111-1111-1111-1111-111111111109">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement>
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Fecha inicio:]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="188" y="53" width="120" height="12" uuid="11111111-1111-1111-1111-111111111110">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement>
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroFechaInicio}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="130" y="65" width="48" height="12" uuid="11111111-1111-1111-1111-111111111111">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement>
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Fecha fin:]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="188" y="65" width="120" height="12" uuid="11111111-1111-1111-1111-111111111112">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement>
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroFechaFin}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="130" y="77" width="48" height="12" uuid="11111111-1111-1111-1111-111111111113">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement>
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Sucursal:]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="188" y="77" width="202" height="12" uuid="11111111-1111-1111-1111-111111111114">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement>
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroSucursal}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="390" y="41" width="75" height="12" uuid="11111111-1111-1111-1111-111111111115">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Forma de pago:]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="475" y="41" width="84" height="12" uuid="11111111-1111-1111-1111-111111111116">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroFormaPago}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="426" y="53" width="39" height="12" uuid="11111111-1111-1111-1111-111111111133">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Moneda:]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="475" y="53" width="84" height="12" uuid="11111111-1111-1111-1111-111111111134">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroMoneda}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="426" y="65" width="39" height="12" uuid="11111111-1111-1111-1111-111111111117">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Estado:]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="475" y="65" width="84" height="12" uuid="11111111-1111-1111-1111-111111111118">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroEstado}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="130" y="89" width="48" height="12" uuid="11111111-1111-1111-1111-111111111119">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement>
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Cliente:]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="188" y="89" width="212" height="12" uuid="11111111-1111-1111-1111-111111111120">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement>
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroCliente}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="130" y="101" width="48" height="12" uuid="11111111-1111-1111-1111-111111111135">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Left">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Modo:]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="188" y="101" width="38" height="12" uuid="11111111-1111-1111-1111-111111111136">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement>
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroModo}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="380" y="101" width="85" height="12" uuid="11111111-1111-1111-1111-111111111137">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Con observación:]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="475" y="101" width="84" height="12" uuid="11111111-1111-1111-1111-111111111138">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroConObservacion}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="391" y="77" width="74" height="12" uuid="11111111-1111-1111-1111-111111111139">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Con descuento:]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="475" y="77" width="84" height="12" uuid="11111111-1111-1111-1111-111111111140">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroConDescuento}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="400" y="89" width="65" height="12" uuid="11111111-1111-1111-1111-111111111141">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Con aumento:]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="475" y="89" width="84" height="12" uuid="11111111-1111-1111-1111-111111111142">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroConAumento}]]></textFieldExpression>
+			</textField>
+			<rectangle>
+				<reportElement x="580" y="32" width="222" height="100" uuid="11111111-1111-1111-1111-111111111121"/>
+				<graphicElement>
+					<pen lineColor="#808080"/>
+				</graphicElement>
+			</rectangle>
+			<staticText>
+				<reportElement mode="Opaque" x="640" y="25" width="100" height="13" uuid="11111111-1111-1111-1111-111111111122">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Resumen General]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="590" y="41" width="110" height="12" uuid="11111111-1111-1111-1111-111111111123">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement>
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Cant. ventas:]]></text>
+			</staticText>
+			<textField pattern="#,##0">
+				<reportElement x="704" y="41" width="86" height="12" uuid="11111111-1111-1111-1111-111111111124">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{cantidadVentas}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="590" y="53" width="110" height="12" uuid="11111111-1111-1111-1111-111111111125">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement>
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Efectivo (Gs.):]]></text>
+			</staticText>
+			<textField pattern="#,###">
+				<reportElement x="704" y="53" width="86" height="12" uuid="11111111-1111-1111-1111-111111111126">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{totalEfectivo}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="590" y="65" width="110" height="12" uuid="11111111-1111-1111-1111-111111111127">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement>
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Tarjeta (Gs.):]]></text>
+			</staticText>
+			<textField pattern="#,###">
+				<reportElement x="704" y="65" width="86" height="12" uuid="11111111-1111-1111-1111-111111111128">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{totalTarjeta}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="590" y="77" width="110" height="12" uuid="11111111-1111-1111-1111-111111111129">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement>
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Convenio (Gs.):]]></text>
+			</staticText>
+			<textField pattern="#,###">
+				<reportElement x="704" y="77" width="86" height="12" uuid="11111111-1111-1111-1111-111111111130">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{totalConvenio}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="590" y="89" width="110" height="12" uuid="11111111-1111-1111-1111-111111111131">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement>
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Transferencia (Gs.):]]></text>
+			</staticText>
+			<textField pattern="#,###">
+				<reportElement x="704" y="89" width="86" height="12" uuid="11111111-1111-1111-1111-111111111132">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{totalTransferencia}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="590" y="113" width="110" height="12" uuid="11111111-1111-1111-1111-111111111143">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement>
+					<font fontName="Verdana" size="9" isBold="true"/>
+				</textElement>
+				<text><![CDATA[TOTAL (Gs.):]]></text>
+			</staticText>
+			<textField pattern="#,###">
+				<reportElement x="704" y="113" width="86" height="12" uuid="11111111-1111-1111-1111-111111111144">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{totalGeneral}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="130" y="113" width="58" height="12" uuid="11111111-1111-1111-1111-111111111103">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Left" verticalAlignment="Top">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Creado en:]]></text>
+			</staticText>
+			<textField>
+				<reportElement x="188" y="113" width="77" height="12" uuid="11111111-1111-1111-1111-111111111104">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{fechaReporte}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="265" y="113" width="27" height="12" uuid="11111111-1111-1111-1111-111111111105">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[por:]]></text>
+			</staticText>
+			<textField>
+				<reportElement x="292" y="113" width="146" height="12" uuid="11111111-1111-1111-1111-111111111106">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{usuario}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement mode="Opaque" x="291" y="25" width="100" height="13" backcolor="#FFFFFF" uuid="11111111-1111-1111-1111-111111111108">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="10" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Filtros aplicados]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="130" y="41" width="48" height="12" uuid="d2efc4a7-d380-4522-bb04-242ad853d7e3">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement>
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[ID:]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="188" y="41" width="120" height="12" uuid="11111111-1111-1111-1111-111111111145">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement>
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroIdVenta}]]></textFieldExpression>
+			</textField>
+		</band>
+	</title>
+	<columnHeader>
+		<band height="14">
+			<rectangle>
+				<reportElement x="0" y="-8" width="802" height="12" forecolor="#D4D4D4" backcolor="#EDEDED" uuid="22222222-2222-2222-2222-222222222201"/>
+				<graphicElement>
+					<pen lineColor="#A3A3A3"/>
+				</graphicElement>
+			</rectangle>
+			<staticText>
+				<reportElement x="0" y="-8" width="35" height="12" uuid="22222222-2222-2222-2222-222222222202"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8" isBold="true"/>
+				</textElement>
+				<text><![CDATA[ID]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="35" y="-8" width="180" height="12" uuid="22222222-2222-2222-2222-222222222203"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Sucursal]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="215" y="-8" width="185" height="12" uuid="22222222-2222-2222-2222-222222222204"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Cliente]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="400" y="-8" width="90" height="12" uuid="22222222-2222-2222-2222-222222222205"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Fecha]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="490" y="-8" width="90" height="12" uuid="22222222-2222-2222-2222-222222222206"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Forma de Pago]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="580" y="-8" width="70" height="12" uuid="22222222-2222-2222-2222-222222222209"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Moneda]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="650" y="-8" width="60" height="12" uuid="22222222-2222-2222-2222-222222222207"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Estado]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="710" y="-8" width="92" height="12" uuid="22222222-2222-2222-2222-222222222208"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Total (Gs.)]]></text>
+			</staticText>
+		</band>
+	</columnHeader>
+	<detail>
+		<band height="13">
+			<textField>
+				<reportElement x="0" y="-6" width="35" height="12" uuid="33333333-3333-3333-3333-333333333301"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{ventaId}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="35" y="-6" width="180" height="12" uuid="33333333-3333-3333-3333-333333333302"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{sucursal}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="215" y="-6" width="185" height="12" uuid="33333333-3333-3333-3333-333333333303"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{cliente}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="400" y="-6" width="90" height="12" uuid="33333333-3333-3333-3333-333333333304"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{fecha}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="490" y="-6" width="90" height="12" uuid="33333333-3333-3333-3333-333333333305"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{formaPago}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="580" y="-6" width="70" height="12" uuid="33333333-3333-3333-3333-333333333308"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{moneda}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="650" y="-6" width="60" height="12" uuid="33333333-3333-3333-3333-333333333306"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{estado}]]></textFieldExpression>
+			</textField>
+			<textField pattern="#,###" isBlankWhenNull="true">
+				<reportElement x="710" y="-6" width="92" height="12" uuid="33333333-3333-3333-3333-333333333307"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{totalGs}]]></textFieldExpression>
+			</textField>
+		</band>
+	</detail>
+	<columnFooter>
+		<band height="26">
+			<line>
+				<reportElement x="0" y="-7" width="802" height="1" uuid="44444444-4444-4444-4444-444444444401"/>
+				<graphicElement>
+					<pen lineWidth="1.0" lineColor="#000000"/>
+				</graphicElement>
+			</line>
+			<staticText>
+				<reportElement x="559" y="0" width="151" height="11" uuid="44444444-4444-4444-4444-444444444402"/>
+				<textElement textAlignment="Right" verticalAlignment="Middle">
+					<font fontName="Verdana" size="9" isBold="true"/>
+				</textElement>
+				<text><![CDATA[TOTAL GENERAL (Gs.):]]></text>
+			</staticText>
+			<textField pattern="#,###">
+				<reportElement x="710" y="0" width="92" height="11" uuid="44444444-4444-4444-4444-444444444403"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="9" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{totalGeneral}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="0" y="0" width="40" height="10" uuid="44444444-4444-4444-4444-444444444406"/>
+				<textElement>
+					<font fontName="Verdana" size="7"/>
+				</textElement>
+				<text><![CDATA[Página:]]></text>
+			</staticText>
+			<textField>
+				<reportElement x="42" y="0" width="30" height="10" uuid="44444444-4444-4444-4444-444444444407"/>
+				<textElement>
+					<font fontName="Verdana" size="7"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$V{PAGE_NUMBER}]]></textFieldExpression>
+			</textField>
+		</band>
+	</columnFooter>
+</jasperReport>


### PR DESCRIPTION
### ¿Qué resuelve?
Este PR completa la funcionalidad para generar Reportes de Ventas en formato PDF desde la pantalla del buscador (GenericListVentaComponent). Resuelve la necesidad de obtener un consolidado visual de las ventas según los filtros aplicados en la tabla.

**Cambios principales**

- Se ampliaron los parámetros recibidos por el VentaGraphQL y ImpresionService para incluir e inyectar al reporte los filtros de: ID de Venta, Moneda, Modo (Delivery/Local), Con Observación, Con Descuento y Con Aumento.
- Se implementó resolución de datos (por ejemplo, obtener el nombre real del cliente a través de ClienteService).
- Se rediseñó el template de JasperReports (reporte-ventas.jrxml) ampliando la cabecera, ajustando sus coordenadas (band height) e incluyendo una nueva columna para visualizar la moneda, así como los nuevos parámetros en la caja de Filtros Aplicados.

### ¿Cómo probarlo?

- Aplicar una combinación de filtros (ej. Cliente específico, una moneda en particular, estado y sucursal).
- Hacer clic en "Generar Reporte".
- Revisar el archivo PDF descargado y comprobar lo siguiente:
- El cuadro de filtros muestra correctamente el nombre del cliente.
- Los valores de Modo, Con Observación, Con Aumento y Con Descuento se muestran según lo seleccionado.
- La columna extra de Moneda figura en el detalle.
- Los totales y sumatorias calculadas en la parte final coinciden con la información filtrada.

### Impacto DB
- Ninguno. No se realizaron migraciones ni alteraciones estructurales en la base de datos. Solo se ejecutan consultas de lectura preexistentes (selects) a través de GraphQL para resolver entidades como Cliente o Moneda.

### Riesgo
- Bajo: Los ajustes se aíslan a la generación y compilación del archivo JasperReports (exportación a PDF) y la recolección de los strings de los filtros, por lo que no compromete la lógica financiera ni la estabilidad de las operaciones principales.