### PR TITLE
chore(release): promote release/beta to master for stable v4.1.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ on:
         type: choice
         options:
           - alpha
+          - beta
           - farmacia
           - bodega
       version:
@@ -19,7 +20,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment: ${{ inputs.instance == 'bodega' && 'production' || inputs.instance == 'farmacia' && 'beta' || 'alpha' }}
+    environment: ${{ inputs.instance == 'bodega' && 'production' || (inputs.instance == 'farmacia' || inputs.instance == 'beta') && 'beta' || 'alpha' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -47,8 +48,8 @@ jobs:
                 -H "Accept: application/vnd.github.v3+json" \
                 "https://api.github.com/repos/${{ github.repository }}/releases/latest" \
                 | jq -r '.tag_name')
-            elif [[ "${INSTANCE}" == "farmacia" ]]; then
-              # Beta: latest prerelease with -beta
+            elif [[ "${INSTANCE}" == "farmacia" || "${INSTANCE}" == "beta" ]]; then
+              # Beta channel: latest prerelease with -beta
               TAG=$(curl -fsSL \
                 -H "Authorization: token ${GH_TOKEN}" \
                 -H "Accept: application/vnd.github.v3+json" \

--- a/CICD-WORKFLOW.md
+++ b/CICD-WORKFLOW.md
@@ -5,7 +5,7 @@
 ## Flujo General
 
 ```
-feature/* --PR--> develop (alpha) --merge--> release/next (beta) --merge--> master (stable)
+feature/* --PR--> develop (alpha) --merge--> release/beta (beta) --merge--> master (stable)
                      |                           |                             |
                semantic-release            semantic-release              semantic-release
                v3.2.0-alpha.1             v3.2.0-beta.1                   v3.2.0
@@ -31,9 +31,9 @@ feature/* --PR--> develop (alpha) --merge--> release/next (beta) --merge--> mast
 
 ## 2. Promocion a Beta
 
-1. Mergear `develop` en `release/next`:
+1. Mergear `develop` en `release/beta`:
    ```
-   git checkout release/next && git pull
+   git checkout release/beta && git pull
    git merge develop
    git push
    ```
@@ -43,12 +43,12 @@ feature/* --PR--> develop (alpha) --merge--> release/next (beta) --merge--> mast
 
 > **IMPORTANTE: Usar MERGE COMMIT, NO squash.**
 >
-> Si se hace squash con mensaje `chore: merge release/next into master`, semantic-release
+> Si se hace squash con mensaje `chore: merge release/beta into master`, semantic-release
 > solo ve un commit `chore:` y hace un patch bump (o ninguno). Se debe usar **merge commit**
 > para que semantic-release vea los commits originales `feat:` y `fix:` y calcule
 > correctamente el bump de version.
 
-1. Crear PR de `release/next` hacia `master`.
+1. Crear PR de `release/beta` hacia `master`.
 2. Mergear con **"Create a merge commit"** (NO "Squash and merge").
 3. `semantic-release` genera la release estable (ej: `v3.2.0`).
 
@@ -75,12 +75,12 @@ El workflow descarga el JAR desde GitHub Releases, lo sube al servidor via SSH/S
 
 Si hay un bug critico en beta:
 
-1. Crear rama desde `release/next`:
+1. Crear rama desde `release/beta`:
    ```
-   git checkout release/next && git pull
+   git checkout release/beta && git pull
    git checkout -b fix/corregir-timeout-conexion
    ```
-2. Crear PR hacia `release/next` con prefijo `fix:`.
+2. Crear PR hacia `release/beta` con prefijo `fix:`.
 3. Al mergear, se genera nueva release beta.
 
 ## Prefijos de Commits

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,21 +1,205 @@
-# FRC Central Server
+# CLAUDE.md -- frc-comercial/central
 
-## Stack
-- Java / Spring Boot
-- Maven
-- PostgreSQL
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+`franco-dev-systems` (artifactId), server principal del producto **Franco Systems**. Corre en HQ y es el origen de la replicacion logica de PostgreSQL hacia las filiales (`frc-comercial/filial`). Repo git independiente: `GabFrank/franco-system-backend-servidor`.
+
+Stack: **Spring Boot 2.1.15 / Java 8 / PostgreSQL** + **GraphQL** (`graphql-java-kickstart`). Package root `com.franco.dev`. JAR final: `frc-central-server.jar` (configurado via `<jar.finalName>`) -- **no cambiar** este nombre, los servicios systemd y los scripts de deploy lo esperan literal.
 
 ## Build & Run
-- Build: `./mvnw clean package`
-- Run: `./mvnw spring-boot:run`
-- Test: `./mvnw test`
+
+```bash
+./mvnw spring-boot:run                    # Run con profile activo
+./mvnw clean package                      # Build
+./mvnw test                               # Tests
+./mvnw clean verify -B -DskipFlyway=true  # CI build (sin Flyway)
+```
+
+Maven Wrapper: 3.6.3. CI usa JDK 11 (Temurin). El pom.xml declara Java 1.8 como source/target.
 
 ## Project Structure
-- `src/main/java/` - Application source code
-- `src/main/resources/` - Configuration and resources
-- `src/test/` - Tests
 
-## Conventions
-- Follow existing code patterns and naming conventions
-- Use Spanish for business domain terms as established in the codebase
-- Write clear commit messages in English
+```
+src/main/java/com/franco/dev/
+  domain/          -- 256 entidades JPA (19 modulos de dominio)
+  service/         -- 192 servicios (25 subdirectorios)
+  repository/      -- 166 repositorios Spring Data JPA
+  graphql/         -- 390 clases GraphQL (71 resolvers)
+  security/        -- 19 clases JWT/auth
+  config/          -- Configuracion general + multitenant (20 clases)
+  fmc/             -- Firebase Cloud Messaging
+  service/sifen/   -- Integracion factura electronica (SIFEN)
+  scheduler/       -- Tareas programadas (@Scheduled)
+
+src/main/resources/
+  graphql/         -- 152 archivos .graphqls (schema por dominio)
+  db/migration/    -- 166 migraciones Flyway (V0..V118)
+  application.properties
+  application-dev.properties
+  application-ci.properties
+  application-user-dev.properties  (ignorado por git, overrides locales)
+
+.github/
+  workflows/       -- ci.yml, release.yml, deploy.yml
+  scripts/         -- deploy.sh (deploy + rollback automatico)
+  settings.xml     -- Maven settings para GitHub Packages
+
+docs/              -- Manuales, changelogs, utilitarios
+```
+
+### Modulos de dominio (bajo `domain/`)
+
+`administrativo`, `configuracion`, `empresarial`, `financiero`, `general`, `login`, `operaciones`, `pdv`, `personas`, `productos`, `reportes`, `transferencias` y otros.
+
+## API: GraphQL (NO REST)
+
+- **Schema root:** `src/main/resources/graphql/schema.graphqls`
+- **152 archivos .graphqls** organizados por dominio (`financiero/`, `personas/`, `productos/`, `operaciones/`, `general/`, `configuracion/`, `administrativo/`, `empresarial/`, `replication/`, `print/`)
+- **71 resolvers** en `com.franco.dev.graphql.*`
+- GraphiQL habilitado en desarrollo
+- Endpoints nuevos van en `graphql/` (resolvers + schema), **no en `controller/`**
+- Existe una carpeta `controller 2/` paralela a `controller/` -- no es typo, no borrar sin investigar
+
+## Database: PostgreSQL + Flyway
+
+- **Flyway 5.2.3**, 166 migraciones (V0..V118)
+- Config: `baseline-on-migrate=true`, `out-of-order=true`, `ignore-missing-migrations=true`
+- DDL: `hibernate.ddl-auto=none` (solo migraciones, nunca auto-DDL)
+- Multi-tenancy basada en schemas (20 clases en `config/multitenant/`)
+- Puerto default local: 5551
+
+### Reglas criticas de migraciones Flyway
+
+Una migracion mal hecha puede dejar el sistema inoperativo. **El rollback automatico NO la revierte** (Flyway no hace down migrations; rollback de JAR no rollback de DB).
+
+| Permitido | Prohibido |
+|---|---|
+| `CREATE TABLE` | `DROP TABLE` |
+| `ALTER TABLE ADD COLUMN` (nullable o con default) | `ALTER TABLE DROP COLUMN` |
+| `CREATE INDEX` | `ALTER TABLE RENAME COLUMN` |
+| `ALTER TABLE ALTER COLUMN SET DEFAULT` | `ALTER TABLE ALTER COLUMN TYPE` (cambio de tipo) |
+| `INSERT INTO` (datos de referencia) | `DELETE FROM` / `TRUNCATE` |
+
+**Eliminar o renombrar columnas:** estrategia de 2 versiones. Version N: crear columna nueva, codigo deja de usar la vieja. Version N+1 (solo cuando N esta estable en produccion): eliminar la vieja.
+
+**Naming:** `V{numero}__{descripcion_con_underscores}.sql`. Numeracion secuencial y unica. **Nunca modificar una migracion ya aplicada** (Flyway compara checksums). Si falla una migracion, corregirla directamente en el mismo archivo VXX (no crear una nueva para arreglar la anterior).
+
+## Overrides locales: NO tocar `application-dev.properties`
+
+La clase `com.franco.dev.config.UserDevPropertiesEnvironmentPostProcessor` (registrada en `META-INF/spring.factories`) carga `application-user-dev.properties` con prioridad maxima cuando el profile `dev` esta activo. Este archivo esta ignorado por git.
+
+**Siempre usar `application-user-dev.properties` para cambios locales** (paths, credenciales DB, IPs). Pushear cambios a `application-dev.properties` rompe el dev de otros y genera release tags con paths basura.
+
+## Security
+
+- JWT-based stateless authentication
+- `SecurityConfig.java` configura HttpSecurity, JWT filter, CORS
+- `SecurityGraphQLAspect` para seguridad declarativa en resolvers (`@AdminSecured`, `@Unsecured`)
+- Endpoints protegidos: `/graphql/**`, `/subscriptions/**`
+- Endpoints publicos: `/public/**`, `/login`
+- CSRF deshabilitado, CORS habilitado
+
+> **Vulnerabilidades conocidas:** Plaintext passwords en `security/TokenController.java`, password dentro de claims JWT en `security/jwt/JwtGenerator.java`. Ver `../../REPORTE_VULNERABILIDADES.md` antes de tocar `security/`.
+
+## Features especiales
+
+- **Multi-tenancy:** Schema-based via Hibernate (`config/multitenant/`)
+- **SIFEN:** Factura electronica (jsifenlib 0.2.4-frc.13, fork custom en GitHub Packages)
+- **Firebase:** Push notifications (Firebase Admin SDK 9.1.1)
+- **Google Drive:** Upload/storage de imagenes
+- **Reportes:** JasperReports 6.20.0, iTextPDF, Apache POI, ZXing (QR/barcode)
+- **Async:** `@EnableAsync` + `@EnableScheduling`
+
+## CI/CD
+
+### Branches
+
+- Tres branches long-lived: `develop` (alpha) -> `release/beta` (beta) -> `master` (stable)
+- **Este repo usa `master`, no `main`**, y **`release/beta` long-lived**. Ambas protegidas con `enforce_admins=true` -- siempre PR, no push directo.
+- Branch naming: `feature/modulo-descripcion`, `fix/modulo-descripcion`, `refactor/modulo-descripcion`, `chore/descripcion`, `hotfix/descripcion`. Minusculas, guiones, sin acentos ni espacios.
+- `feature/*`, `fix/*`, etc. salen siempre de `develop`. **`hotfix/*` sale de `master`.**
+
+### Releases automaticos
+
+- `semantic-release` lee commits convencionales: `feat:` -> minor, `fix:` -> patch, `feat!:` o `BREAKING CHANGE:` -> major. `chore:`/`refactor:`/`ci:`/`docs:`/`test:`/`perf:` no liberan.
+- **Promocion `release/beta -> master`: merge commit, NO squash.** El squash colapsa los `feat:`/`fix:` originales y semantic-release calcula mal el bump.
+- Push a cualquiera de las 3 branches dispara release. **Nunca pushear sin confirmacion explicita del usuario.**
+- Workflow Release tiene concurrency group (serializa runs) y fetch de git notes antes de semantic-release.
+
+### Deploys
+
+- Deploys son **manuales** via GitHub Actions `workflow_dispatch` (`Deploy` workflow), parametrizados por `version` e `instance`.
+- Tres targets: `alpha` (172.25.1.200:8083), `farmacia` (beta, :8082), `bodega` (production, :8081)
+- Production (`bodega`) requiere aprobacion en GitHub Environments.
+- Health check post-deploy: `GET /actuator/health` (timeout 120s, interval 5s). Si falla: **rollback automatico** a version anterior.
+- SSH key: `~/.ssh/frc-deploy`, user: `deploy`
+
+### Hotfix flow (urgencia en produccion)
+
+1. `git checkout master && git pull` -> branch desde **master** (no develop)
+2. `git checkout -b hotfix/descripcion`
+3. Fix + commit `fix(modulo): ...` + push
+4. PR `hotfix/* -> master`, CI verde, merge -> semantic-release genera version de produccion
+5. Deploy manual a produccion
+6. **Inmediatamente despues: PR `master -> develop`** para que `develop` tenga el fix. **Nunca dejar un hotfix solo en `master`.**
+
+## Pull Requests
+
+- **Tamano**: idealmente menos de 400 lineas de cambio neto. Una responsabilidad por PR.
+- **Descripcion del PR debe incluir**: que resuelve, como probarlo, impacto en DB (si aplica), impacto en rollback (si aplica), riesgo (bajo/medio/alto).
+- **Sin commits "WIP"** al mergear.
+- Revisar **impacto cross-proyecto**: si cambias un endpoint GraphQL que el desktop/mobile usan, verificar que no se rompen.
+
+### Checklist para PR con cambio de DB
+
+- [ ] Migracion versionada (`V{n}__...sql`) con numero unico
+- [ ] Probada localmente con `./mvnw clean verify`
+- [ ] Es **retrocompatible** con la version anterior del backend
+- [ ] No hace `DROP`/`RENAME`/cambio de tipo sin la estrategia de 2 versiones
+- [ ] La descripcion del PR documenta el impacto en DB y el plan de rollback
+
+## Lo que NUNCA hacer
+
+1. Push directo a `master`, `release/beta` o `develop` -- siempre via PR
+2. `git push --force` a ramas compartidas
+3. Modificar migraciones de Flyway ya aplicadas
+4. `DROP TABLE/COLUMN` sin la estrategia de 2 versiones
+5. Commitear secretos (`.env`, keystores, tokens, passwords, certificados `.pfx`)
+6. Squash merge en PRs -- usar **merge commit**
+7. Deploy a produccion sin aprobacion
+8. Deploy los viernes (durante el periodo de adopcion)
+9. Saltear el CI con `--no-verify` -- si falla, corregir, no buscar bypass
+10. Cambiar nombre de artefactos (`frc-central-server.jar`) sin coordinar con el equipo y actualizar los scripts de deploy / servicios systemd primero
+
+## Otros cambios con riesgo de rollback
+
+### Variables de entorno nuevas
+
+Si tu codigo necesita una variable nueva, **avisar al lider tecnico ANTES de crear el PR**. Tiene que crearla en los servidores antes de que el codigo se despliegue, sino la aplicacion falla al arrancar.
+
+### Carpetas locales en el server
+
+Si tu codigo espera que exista una carpeta en disco, crearla programaticamente con `Files.createDirectories()` o `File.mkdirs()`. **No asumir** que el servidor la tiene.
+
+### Cambios en la API GraphQL
+
+1. **No eliminar campos existentes de golpe.** Agregar el campo nuevo, mantener el viejo.
+2. Recien cuando todos los clientes (desktop + mobile) esten actualizados, eliminar el campo viejo.
+3. Si es inevitable, marcarlo como breaking change: `feat!: cambiar respuesta de /productos`. Esto sube MAJOR e implica que filiales + desktop + mobile tienen que actualizarse coordinadamente.
+
+## Convenciones
+
+- **GraphQL, no REST.** Endpoints nuevos van en `graphql/` (resolvers + schema), no `controller/`.
+- **Idioma de dominio:** espanol (`razon_social`, `numero_factura`). Identificadores genericos en ingles.
+- **Package root:** `com.franco.dev` (compartido con `filial`). No mezclar con `com.frcefact` (otro proyecto independiente, `frc-efact`).
+- **JAR finalName:** `frc-central-server.jar` -- no renombrar.
+
+## Referencias relacionadas
+
+- [CICD-WORKFLOW.md](CICD-WORKFLOW.md) -- Flujo CI/CD detallado con ejemplos de comandos
+- [../../REPORTE_VULNERABILIDADES.md](../../REPORTE_VULNERABILIDADES.md) -- Auditoria de seguridad
+- [../../CLAUDE.md](../../CLAUDE.md) -- Mapa cross-project del workspace
+- [../filial/CLAUDE.md](../filial/CLAUDE.md) -- Server filial, mismo mecanismo de overrides, replica desde este central
+- [../../cicd-implementation/guia-desarrollo-cicd.md](../../cicd-implementation/guia-desarrollo-cicd.md) -- Guia consolidada de CI/CD

--- a/src/main/java/com/franco/dev/graphql/replication/LogicalReplicationGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/replication/LogicalReplicationGraphQL.java
@@ -232,6 +232,15 @@ public class LogicalReplicationGraphQL implements GraphQLQueryResolver, GraphQLM
         return status;
     }
     
+    public ReplicationStatus removeFullReplication(String sucursalId) {
+        LogicalReplicationService.SetupFullReplicationResult result =
+            replicationService.removeFullReplication(Long.parseLong(sucursalId));
+        ReplicationStatus status = new ReplicationStatus();
+        status.setSuccess(result.isSuccess());
+        status.setMessage(result.getMessage());
+        return status;
+    }
+
     public ReplicationStatus removeReplication(String sucursalId) {
         ReplicationStatus status = new ReplicationStatus();
         

--- a/src/main/java/com/franco/dev/graphql/replication/LogicalReplicationGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/replication/LogicalReplicationGraphQL.java
@@ -188,26 +188,8 @@ public class LogicalReplicationGraphQL implements GraphQLQueryResolver, GraphQLM
         return lr;
     }
     
-    // Helper method to extract sucursal ID from name
     private Long extractSucursalIdFromName(String name) {
-        try {
-            if (name.startsWith("filial") && name.contains("_")) {
-                // Format: filial<id>_pub or filial<id>_sub
-                String idPart = name.substring(6, name.indexOf("_"));
-                return Long.parseLong(idPart);
-            } else if (name.startsWith("central_filial") && name.contains("_pub")) {
-                // Format: central_filial<id>_pub
-                String idPart = name.substring(14, name.indexOf("_pub"));
-                return Long.parseLong(idPart);
-            } else if (name.startsWith("central_filial") && name.contains("_sub")) {
-                // Format: central_filial<id>_sub
-                String idPart = name.substring(14, name.indexOf("_sub"));
-                return Long.parseLong(idPart);
-            }
-        } catch (NumberFormatException | IndexOutOfBoundsException e) {
-            // Handle parsing error
-        }
-        return null;
+        return replicationService.extractSucursalIdFromName(name);
     }
     
     // Mutation resolvers
@@ -307,7 +289,7 @@ public class LogicalReplicationGraphQL implements GraphQLQueryResolver, GraphQLM
             
             if (isSubscription) {
                 // Toggle subscription
-                String subscriptionName = "filial" + sucursalId + "_sub";
+                String subscriptionName = replicationService.generateBranchSubscriptionName(Long.parseLong(sucursalId));
                 success = replicationService.alterSubscription(subscriptionName, enabled);
                 
                 if (success) {
@@ -331,7 +313,7 @@ public class LogicalReplicationGraphQL implements GraphQLQueryResolver, GraphQLM
                     }
                 } else {
                     // Disable publication (drop it)
-                    String publicationName = "central_filial" + sucursalId + "_pub";
+                    String publicationName = replicationService.generateCentralToBranchPublicationName(Long.parseLong(sucursalId));
                     success = replicationService.dropPublication(publicationName);
                     
                     if (success) {

--- a/src/main/java/com/franco/dev/graphql/replication/ReplicationResolver.java
+++ b/src/main/java/com/franco/dev/graphql/replication/ReplicationResolver.java
@@ -2,6 +2,7 @@ package com.franco.dev.graphql.replication;
 
 import com.franco.dev.domain.empresarial.Sucursal;
 import com.franco.dev.graphql.replication.types.LogicalReplication;
+import com.franco.dev.service.empresarial.LogicalReplicationService;
 import com.franco.dev.service.empresarial.SucursalService;
 import graphql.kickstart.tools.GraphQLResolver;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,48 +13,23 @@ public class ReplicationResolver implements GraphQLResolver<LogicalReplication> 
 
     @Autowired
     private SucursalService sucursalService;
-    
-    /**
-     * Resolve sucursal field if it's null but name provides enough information
-     */
+
+    @Autowired
+    private LogicalReplicationService replicationService;
+
     public Sucursal sucursal(LogicalReplication replication) {
         if (replication.getSucursal() != null) {
             return replication.getSucursal();
         }
-        
-        // If sucursal is null but we can extract ID from name, resolve it
+
         String name = replication.getName();
         if (name != null) {
-            Long sucursalId = extractSucursalIdFromName(name);
+            Long sucursalId = replicationService.extractSucursalIdFromName(name);
             if (sucursalId != null) {
                 return sucursalService.findById(sucursalId).orElse(null);
             }
         }
-        
-        return null;
-    }
-    
-    /**
-     * Extract sucursal ID from replication name
-     */
-    private Long extractSucursalIdFromName(String name) {
-        try {
-            if (name.startsWith("filial") && name.contains("_")) {
-                // Format: filial<id>_pub or filial<id>_sub
-                String idPart = name.substring(6, name.indexOf("_"));
-                return Long.parseLong(idPart);
-            } else if (name.startsWith("central_filial") && name.contains("_pub")) {
-                // Format: central_filial<id>_pub
-                String idPart = name.substring(14, name.indexOf("_pub"));
-                return Long.parseLong(idPart);
-            } else if (name.startsWith("central_filial") && name.contains("_sub")) {
-                // Format: central_filial<id>_sub
-                String idPart = name.substring(14, name.indexOf("_sub"));
-                return Long.parseLong(idPart);
-            }
-        } catch (NumberFormatException | IndexOutOfBoundsException e) {
-            // Handle parsing error
-        }
+
         return null;
     }
 } 

--- a/src/main/java/com/franco/dev/service/empresarial/LogicalReplicationService.java
+++ b/src/main/java/com/franco/dev/service/empresarial/LogicalReplicationService.java
@@ -579,8 +579,16 @@ public class LogicalReplicationService {
         boolean subCentralCreated = false;
         boolean subFilialBidiCreated = false;
         boolean subFilialCentralCreated = false;
-        
+
         try {
+            logger.info("[setupFullReplication] Iniciando setup completo para sucursalId={}", sucursalId);
+
+            // 0. Remove any existing replication objects (idempotent: ensures clean slate)
+            logger.info("[setupFullReplication] Paso 0: limpiando objetos previos para sucursalId={}", sucursalId);
+            SetupFullReplicationResult removeResult = removeFullReplication(sucursalId);
+            log("Paso 0 (limpieza previa): " + removeResult.getMessage().replace("\n", " | "), log);
+            logger.info("[setupFullReplication] Paso 0 completado: {}", removeResult.getMessage().replace("\n", " | "));
+
             // 1. Validate sucursal
             Sucursal sucursal = sucursalService.findById(sucursalId)
                 .orElseThrow(() -> new RuntimeException("Sucursal con ID " + sucursalId + " no encontrada"));
@@ -591,74 +599,98 @@ public class LogicalReplicationService {
                 throw new RuntimeException("Sucursal sin IP o puerto configurado");
             }
             log("Paso 1: Sucursal validada (activa, IP/puerto).", log);
-            
+            logger.info("[setupFullReplication] Paso 1: sucursal validada id={} ip={} puerto={}", sucursalId, sucursal.getIp(), sucursal.getPuerto());
+
             // 2. Verify central connection
             verifyConnectionCentral(log);
             log("Paso 2: Conexión a base central OK.", log);
-            
+            logger.info("[setupFullReplication] Paso 2: conexión central OK");
+
             // 3. Verify filial connection
             verifyConnectionFilial(sucursalId, log);
             log("Paso 3: Conexión a base filial OK.", log);
-            
+            logger.info("[setupFullReplication] Paso 3: conexión filial OK ip={} puerto={}", sucursal.getIp(), sucursal.getPuerto());
+
             // 4. Create publication central_filial{id}_pub
+            String centralPubName = generateCentralToBranchPublicationName(sucursalId);
+            logger.info("[setupFullReplication] Paso 4: creando publicación {} en central", centralPubName);
             if (!createCentralToBranchPublication(sucursalId)) {
-                throw new RuntimeException("No se pudo crear la publicación " + generateCentralToBranchPublicationName(sucursalId));
+                throw new RuntimeException("No se pudo crear la publicación " + centralPubName);
             }
             pubCentralCreated = true;
-            log("Paso 4: Publicación " + generateCentralToBranchPublicationName(sucursalId) + " creada en central.", log);
-            
+            log("Paso 4: Publicación " + centralPubName + " creada en central.", log);
+            logger.info("[setupFullReplication] Paso 4: publicación {} creada en central", centralPubName);
+
             // 4b. Ensure replication_test table exists on filial (it's in BRANCH_TO_MAIN; filial may not have run V115 yet)
+            logger.info("[setupFullReplication] Paso 4b: verificando tabla replication_test en filial");
             ensureReplicationTestTableRemote(sucursalId);
-            
+
             // 5. Create publication filial{id}_pub on branch (remote) — use DB-backed list so it's always up to date
+            String branchPubName = generateBranchPublicationName(sucursalId);
             List<String> branchTables = replicationTableService.getBranchToMainTableNames();
             if (branchTables == null || branchTables.isEmpty()) {
                 throw new RuntimeException("No hay tablas BRANCH_TO_MAIN configuradas en replication_table (enabled = true)");
             }
-            if (!createRemotePublication(sucursalId, generateBranchPublicationName(sucursalId), branchTables)) {
-                throw new RuntimeException("No se pudo crear la publicación " + generateBranchPublicationName(sucursalId) + " en filial");
+            logger.info("[setupFullReplication] Paso 5: creando publicación {} en filial ({} tablas)", branchPubName, branchTables.size());
+            if (!createRemotePublication(sucursalId, branchPubName, branchTables)) {
+                throw new RuntimeException("No se pudo crear la publicación " + branchPubName + " en filial");
             }
             pubFilialCreated = true;
-            log("Paso 5: Publicación " + generateBranchPublicationName(sucursalId) + " creada en filial.", log);
-            
+            log("Paso 5: Publicación " + branchPubName + " creada en filial.", log);
+            logger.info("[setupFullReplication] Paso 5: publicación {} creada en filial", branchPubName);
+
             // 6. Create subscription filial{id}_sub on central (subscribes to filial's pub)
+            String centralSubName = generateBranchSubscriptionName(sucursalId);
             String branchDbName = getBranchDbName();
+            logger.info("[setupFullReplication] Paso 6: creando suscripción {} en central -> filial {}:{}/{}", centralSubName, sucursal.getIp(), sucursal.getPuerto(), branchDbName);
             if (!createCentralToBranchSubscription(sucursalId, sucursal.getIp(), sucursal.getPuerto(), branchDbName)) {
-                throw new RuntimeException("No se pudo crear la suscripción " + generateBranchSubscriptionName(sucursalId) + " en central");
+                throw new RuntimeException("No se pudo crear la suscripción " + centralSubName + " en central");
             }
             subCentralCreated = true;
-            log("Paso 6: Suscripción " + generateBranchSubscriptionName(sucursalId) + " creada en central.", log);
-            
+            log("Paso 6: Suscripción " + centralSubName + " creada en central.", log);
+            logger.info("[setupFullReplication] Paso 6: suscripción {} creada en central", centralSubName);
+
             // 7. Create subscription central_filial{id}_sub on branch (to central_filial{id}_pub on central)
             String centralConnStr = createCentralConnectionString();
-            if (!createRemoteSubscription(sucursalId, generateCentralToBranchSubscriptionName(sucursalId), centralConnStr, generateCentralToBranchPublicationName(sucursalId))) {
-                throw new RuntimeException("No se pudo crear la suscripción " + generateCentralToBranchSubscriptionName(sucursalId) + " en filial");
+            String filialBidiSubName = generateCentralToBranchSubscriptionName(sucursalId);
+            logger.info("[setupFullReplication] Paso 7: creando suscripción {} en filial -> pub {}", filialBidiSubName, centralPubName);
+            if (!createRemoteSubscription(sucursalId, filialBidiSubName, centralConnStr, centralPubName)) {
+                throw new RuntimeException("No se pudo crear la suscripción " + filialBidiSubName + " en filial");
             }
             subFilialBidiCreated = true;
-            log("Paso 7: Suscripción " + generateCentralToBranchSubscriptionName(sucursalId) + " creada en filial.", log);
-            
+            log("Paso 7: Suscripción " + filialBidiSubName + " creada en filial.", log);
+            logger.info("[setupFullReplication] Paso 7: suscripción {} creada en filial", filialBidiSubName);
+
             // 8. Create subscription filial{id}_central_sub on branch (to central_pub)
-            if (!createRemoteSubscription(sucursalId, generateBranchToCentralSubscriptionName(sucursalId), centralConnStr, "central_pub")) {
-                throw new RuntimeException("No se pudo crear la suscripción " + generateBranchToCentralSubscriptionName(sucursalId) + " en filial");
+            String filialCentralSubName = generateBranchToCentralSubscriptionName(sucursalId);
+            logger.info("[setupFullReplication] Paso 8: creando suscripción {} en filial -> pub central_pub", filialCentralSubName);
+            if (!createRemoteSubscription(sucursalId, filialCentralSubName, centralConnStr, "central_pub")) {
+                throw new RuntimeException("No se pudo crear la suscripción " + filialCentralSubName + " en filial");
             }
             subFilialCentralCreated = true;
-            log("Paso 8: Suscripción " + generateBranchToCentralSubscriptionName(sucursalId) + " creada en filial.", log);
-            
+            log("Paso 8: Suscripción " + filialCentralSubName + " creada en filial.", log);
+            logger.info("[setupFullReplication] Paso 8: suscripción {} creada en filial", filialCentralSubName);
+
             // 9. Wait and verify workers
+            logger.info("[setupFullReplication] Paso 9: esperando workers de replicación (3s)...");
             Thread.sleep(3000);
             String verifyMsg = verifyReplicationWorkers(sucursalId, log);
             log("Paso 9: " + verifyMsg, log);
-            
+            logger.info("[setupFullReplication] Paso 9: {}", verifyMsg);
+
             // 10. E2E test
+            logger.info("[setupFullReplication] Paso 10: ejecutando test E2E bidireccional");
             String e2eMsg = testReplicationE2E(sucursalId, log);
             log("Paso 10: " + e2eMsg, log);
-            
+            logger.info("[setupFullReplication] Paso 10: {}", e2eMsg);
+
             log.append("\nSetup de replicación completado correctamente.");
+            logger.info("[setupFullReplication] Setup completo exitoso para sucursalId={}", sucursalId);
             return new SetupFullReplicationResult(true, log.toString());
-            
+
         } catch (Exception e) {
             log.append("\nERROR: ").append(e.getMessage());
-            logger.error("setupFullReplication failed: {}", e.getMessage(), e);
+            logger.error("[setupFullReplication] Falló para sucursalId={}: {}", sucursalId, e.getMessage(), e);
             // Rollback in reverse order
             if (subFilialCentralCreated) {
                 try {
@@ -1081,7 +1113,7 @@ public class LogicalReplicationService {
      * @return JdbcTemplate for the remote connection
      */
     private JdbcTemplate createRemoteJdbcTemplate(String host, int port, String dbName, String username, String password) {
-        logger.info("Replicación: creando conexión JDBC remota host={} port={} dbName={}", host, port, dbName);
+        logger.debug("Replicación: conexión JDBC remota host={} port={} dbName={}", host, port, dbName);
         String url = String.format("jdbc:postgresql://%s:%d/%s", host, port, dbName);
         
         DriverManagerDataSource dataSource = new DriverManagerDataSource();
@@ -1305,31 +1337,31 @@ public class LogicalReplicationService {
             try {
                 String checkQuery = "SELECT COUNT(*) FROM pg_publication WHERE pubname = ?";
                 int count = remoteJdbcTemplate.queryForObject(checkQuery, Integer.class, publicationName);
-                
+
                 if (count > 0) {
-                    // Publication already exists
-                    logger.info("Publication " + publicationName + " already exists on remote branch " + branchId);
+                    logger.info("[Replicación] Publicación {} ya existe en filial {} (OK, omitiendo)", publicationName, branchId);
                     return true;
                 }
             } catch (Exception e) {
-                logger.error("Error checking for existing remote publication: " + e.getMessage());
+                logger.error("[Replicación] Error verificando publicación existente en filial {}: {}", branchId, e.getMessage());
             }
-            
+
             // Build the CREATE PUBLICATION command
             StringBuilder sql = new StringBuilder("CREATE PUBLICATION ")
                 .append(publicationName)
                 .append(" FOR TABLE ");
-            
+
             for (int i = 0; i < tables.size(); i++) {
                 if (i > 0) {
                     sql.append(", ");
                 }
                 sql.append(tables.get(i));
             }
-            
+
+            logger.info("[Replicación] Creando publicación {} en filial {} ({} tablas)", publicationName, branchId, tables.size());
             // Execute the command
             remoteJdbcTemplate.execute(sql.toString());
-            logger.info("Successfully created remote publication " + publicationName + " on branch " + branchId);
+            logger.info("[Replicación] Publicación {} creada en filial {}", publicationName, branchId);
             
             return true;
         } catch (Exception e) {
@@ -1368,25 +1400,25 @@ public class LogicalReplicationService {
             try {
                 String checkQuery = "SELECT COUNT(*) FROM pg_subscription WHERE subname = ?";
                 int count = remoteJdbcTemplate.queryForObject(checkQuery, Integer.class, subscriptionName);
-                
+
                 if (count > 0) {
-                    // Subscription already exists
-                    logger.info("Subscription " + subscriptionName + " already exists on remote branch " + branchId);
+                    logger.info("[Replicación] Suscripción {} ya existe en filial {} (OK, omitiendo)", subscriptionName, branchId);
                     return true;
                 }
             } catch (Exception e) {
-                logger.error("Error checking for existing remote subscription: " + e.getMessage());
+                logger.error("[Replicación] Error verificando suscripción existente en filial {}: {}", branchId, e.getMessage());
             }
-            
+
             // Build the CREATE SUBSCRIPTION command
-            String sql = "CREATE SUBSCRIPTION " + subscriptionName + 
+            String sql = "CREATE SUBSCRIPTION " + subscriptionName +
                     " CONNECTION '" + connectionString + "' " +
-                    " PUBLICATION " + publicationName + 
+                    " PUBLICATION " + publicationName +
                     " WITH (copy_data = false, origin = 'none')";
-            
+
+            logger.info("[Replicación] Creando suscripción {} en filial {} -> publicación {}", subscriptionName, branchId, publicationName);
             // Execute the command
             remoteJdbcTemplate.execute(sql);
-            logger.info("Successfully created remote subscription " + subscriptionName + " on branch " + branchId);
+            logger.info("[Replicación] Suscripción {} creada en filial {}", subscriptionName, branchId);
             
             return true;
         } catch (Exception e) {
@@ -1914,5 +1946,211 @@ public class LogicalReplicationService {
 
     private List<String> getPublicationTableNamesLocal(String pubname) {
         return getPublicationTableNames(jdbcTemplate, pubname);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // removeFullReplication — limpieza completa de una sucursal
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Elimina completamente todos los objetos de replicación (publicaciones, suscripciones y slots
+     * huérfanos) de central y filial para la sucursal indicada. Operación best-effort: cada paso
+     * registra un warning en el log si falla pero continúa con los demás. Idempotente: seguro de
+     * llamar aunque los objetos no existan.
+     * <p>
+     * Llamado automáticamente al inicio de {@link #setupFullReplication(Long)} para garantizar
+     * un estado limpio antes de recrear todo.
+     *
+     * @param sucursalId ID de la sucursal
+     * @return resultado con log detallado de lo que se eliminó
+     */
+    public SetupFullReplicationResult removeFullReplication(Long sucursalId) {
+        StringBuilder log = new StringBuilder();
+        logger.info("[removeFullReplication] Iniciando limpieza para sucursalId={}", sucursalId);
+        log("Limpieza de replicación para sucursal " + sucursalId + ":", log);
+
+        // ── 1. Suscripción en central (beta_filialX_sub) ───────────────────────
+        //    Su slot vive en la filial (publisher). SET slot_name=NONE para que el
+        //    DROP no necesite conectarse a la filial y luego limpiamos el slot allá.
+        safeDropLocalSubscription(generateBranchSubscriptionName(sucursalId), log);
+
+        // ── 2. Suscripciones en filial ────────────────────────────────────────
+        //    Sus slots viven en central (publisher de central_pub y central_filialX_pub).
+        try {
+            safeDropRemoteSubscription(sucursalId, generateCentralToBranchSubscriptionName(sucursalId), log);
+            safeDropRemoteSubscription(sucursalId, generateBranchToCentralSubscriptionName(sucursalId), log);
+        } catch (Exception e) {
+            log("  Warning: filial no accesible para limpiar suscripciones remotas: " + e.getMessage(), log);
+            logger.warn("[removeFullReplication] Filial {} no accesible para limpiar subs: {}", sucursalId, e.getMessage());
+        }
+
+        // ── 3. Publicaciones ──────────────────────────────────────────────────
+        safeDropLocalPublication(generateCentralToBranchPublicationName(sucursalId), log);
+        try {
+            safeDropRemotePublication(sucursalId, generateBranchPublicationName(sucursalId), log);
+        } catch (Exception e) {
+            log("  Warning: no se pudo eliminar publicación remota: " + e.getMessage(), log);
+            logger.warn("[removeFullReplication] Error eliminando pub remota en filial {}: {}", sucursalId, e.getMessage());
+        }
+
+        // ── 4. Slots huérfanos en central ────────────────────────────────────
+        dropOrphanSlotsLocal(sucursalId, log);
+
+        // ── 5. Slots huérfanos en filial ──────────────────────────────────────
+        try {
+            dropOrphanSlotsRemote(sucursalId, log);
+        } catch (Exception e) {
+            log("  Warning: no se pudieron verificar slots en filial: " + e.getMessage(), log);
+            logger.warn("[removeFullReplication] Error verificando slots en filial {}: {}", sucursalId, e.getMessage());
+        }
+
+        log("Limpieza finalizada.", log);
+        logger.info("[removeFullReplication] Limpieza completada para sucursalId={}", sucursalId);
+        return new SetupFullReplicationResult(true, log.toString());
+    }
+
+    /**
+     * Desactiva y elimina una suscripción local (en central) de forma segura.
+     * Usa SET slot_name=NONE antes del DROP para no necesitar conectarse al publisher remoto.
+     */
+    private void safeDropLocalSubscription(String subName, StringBuilder log) {
+        try {
+            Integer exists = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM pg_subscription WHERE subname = ?", Integer.class, subName);
+            if (exists == null || exists == 0) {
+                log("  " + subName + " no existe en central (OK).", log);
+                return;
+            }
+            try { jdbcTemplate.execute("ALTER SUBSCRIPTION " + subName + " DISABLE"); } catch (Exception ignored) {}
+            try { jdbcTemplate.execute("ALTER SUBSCRIPTION " + subName + " SET (slot_name = NONE)"); } catch (Exception ignored) {}
+            jdbcTemplate.execute("DROP SUBSCRIPTION IF EXISTS " + subName);
+            log("  Suscripción " + subName + " eliminada en central.", log);
+            logger.info("[removeFullReplication] Suscripción {} eliminada en central", subName);
+        } catch (Exception e) {
+            log("  Warning: error eliminando suscripción " + subName + " en central: " + e.getMessage(), log);
+            logger.warn("[removeFullReplication] Error eliminando sub {} en central: {}", subName, e.getMessage());
+        }
+    }
+
+    /**
+     * Desactiva y elimina una suscripción remota (en filial) de forma segura.
+     * Usa SET slot_name=NONE antes del DROP para no necesitar conectarse al publisher remoto (central).
+     */
+    private void safeDropRemoteSubscription(Long sucursalId, String subName, StringBuilder log) {
+        try {
+            Sucursal sucursal = sucursalService.findById(sucursalId).orElse(null);
+            if (sucursal == null || sucursal.getIp() == null || sucursal.getPuerto() == null) {
+                log("  Warning: sucursal " + sucursalId + " sin IP/puerto, no se puede limpiar sub remota " + subName, log);
+                return;
+            }
+            JdbcTemplate remote = createRemoteJdbcTemplate(
+                sucursal.getIp(), sucursal.getPuerto(), getBranchDbName(), dbUsername, dbPassword);
+            Integer exists = remote.queryForObject(
+                "SELECT COUNT(*) FROM pg_subscription WHERE subname = ?", Integer.class, subName);
+            if (exists == null || exists == 0) {
+                log("  " + subName + " no existe en filial (OK).", log);
+                return;
+            }
+            try { remote.execute("ALTER SUBSCRIPTION " + subName + " DISABLE"); } catch (Exception ignored) {}
+            try { remote.execute("ALTER SUBSCRIPTION " + subName + " SET (slot_name = NONE)"); } catch (Exception ignored) {}
+            remote.execute("DROP SUBSCRIPTION IF EXISTS " + subName);
+            log("  Suscripción " + subName + " eliminada en filial.", log);
+            logger.info("[removeFullReplication] Suscripción {} eliminada en filial {}", subName, sucursalId);
+        } catch (Exception e) {
+            log("  Warning: error eliminando suscripción " + subName + " en filial: " + e.getMessage(), log);
+            logger.warn("[removeFullReplication] Error eliminando sub {} en filial {}: {}", subName, sucursalId, e.getMessage());
+        }
+    }
+
+    /** Elimina una publicación local (en central) de forma segura; no falla si no existe. */
+    private void safeDropLocalPublication(String pubName, StringBuilder log) {
+        try {
+            jdbcTemplate.execute("DROP PUBLICATION IF EXISTS " + pubName);
+            log("  Publicación " + pubName + " eliminada en central (o no existía).", log);
+            logger.info("[removeFullReplication] Publicación {} eliminada en central", pubName);
+        } catch (Exception e) {
+            log("  Warning: error eliminando publicación " + pubName + " en central: " + e.getMessage(), log);
+            logger.warn("[removeFullReplication] Error eliminando pub {} en central: {}", pubName, e.getMessage());
+        }
+    }
+
+    /** Elimina una publicación remota (en filial) de forma segura; no falla si no existe. */
+    private void safeDropRemotePublication(Long sucursalId, String pubName, StringBuilder log) {
+        try {
+            Sucursal sucursal = sucursalService.findById(sucursalId).orElse(null);
+            if (sucursal == null || sucursal.getIp() == null || sucursal.getPuerto() == null) return;
+            JdbcTemplate remote = createRemoteJdbcTemplate(
+                sucursal.getIp(), sucursal.getPuerto(), getBranchDbName(), dbUsername, dbPassword);
+            remote.execute("DROP PUBLICATION IF EXISTS " + pubName);
+            log("  Publicación " + pubName + " eliminada en filial (o no existía).", log);
+            logger.info("[removeFullReplication] Publicación {} eliminada en filial {}", pubName, sucursalId);
+        } catch (Exception e) {
+            log("  Warning: error eliminando publicación " + pubName + " en filial: " + e.getMessage(), log);
+            logger.warn("[removeFullReplication] Error eliminando pub {} en filial {}: {}", pubName, sucursalId, e.getMessage());
+        }
+    }
+
+    /**
+     * Elimina slots de replicación inactivos (huérfanos) en central cuyo nombre contiene "filialX".
+     * Solo elimina slots con active = false para no interrumpir replicación en curso.
+     */
+    private void dropOrphanSlotsLocal(Long sucursalId, StringBuilder log) {
+        try {
+            String pattern = "%filial" + sucursalId + "%";
+            List<Map<String, Object>> slots = jdbcTemplate.queryForList(
+                "SELECT slot_name FROM pg_replication_slots WHERE slot_name LIKE ? AND active = false", pattern);
+            if (slots.isEmpty()) {
+                log("  Sin slots huérfanos en central.", log);
+                return;
+            }
+            for (Map<String, Object> slot : slots) {
+                String slotName = (String) slot.get("slot_name");
+                try {
+                    jdbcTemplate.execute("SELECT pg_drop_replication_slot('" + slotName.replace("'", "''") + "')");
+                    log("  Slot huérfano " + slotName + " eliminado en central.", log);
+                    logger.info("[removeFullReplication] Slot huérfano {} eliminado en central", slotName);
+                } catch (Exception e) {
+                    log("  Warning: no se pudo eliminar slot " + slotName + " en central: " + e.getMessage(), log);
+                    logger.warn("[removeFullReplication] Error eliminando slot {} en central: {}", slotName, e.getMessage());
+                }
+            }
+        } catch (Exception e) {
+            log("  Warning: error verificando slots en central: " + e.getMessage(), log);
+            logger.warn("[removeFullReplication] Error verificando slots en central: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Elimina slots de replicación inactivos (huérfanos) en la filial cuyo nombre contiene "filialX".
+     * Solo elimina slots con active = false.
+     */
+    private void dropOrphanSlotsRemote(Long sucursalId, StringBuilder log) {
+        Sucursal sucursal = sucursalService.findById(sucursalId).orElse(null);
+        if (sucursal == null || sucursal.getIp() == null || sucursal.getPuerto() == null) return;
+        try {
+            JdbcTemplate remote = createRemoteJdbcTemplate(
+                sucursal.getIp(), sucursal.getPuerto(), getBranchDbName(), dbUsername, dbPassword);
+            String pattern = "%filial" + sucursalId + "%";
+            List<Map<String, Object>> slots = remote.queryForList(
+                "SELECT slot_name FROM pg_replication_slots WHERE slot_name LIKE ? AND active = false", pattern);
+            if (slots.isEmpty()) {
+                log("  Sin slots huérfanos en filial.", log);
+                return;
+            }
+            for (Map<String, Object> slot : slots) {
+                String slotName = (String) slot.get("slot_name");
+                try {
+                    remote.execute("SELECT pg_drop_replication_slot('" + slotName.replace("'", "''") + "')");
+                    log("  Slot huérfano " + slotName + " eliminado en filial.", log);
+                    logger.info("[removeFullReplication] Slot huérfano {} eliminado en filial {}", slotName, sucursalId);
+                } catch (Exception e) {
+                    log("  Warning: no se pudo eliminar slot " + slotName + " en filial: " + e.getMessage(), log);
+                    logger.warn("[removeFullReplication] Error eliminando slot {} en filial {}: {}", slotName, sucursalId, e.getMessage());
+                }
+            }
+        } catch (Exception e) {
+            log("  Warning: error verificando slots en filial: " + e.getMessage(), log);
+            logger.warn("[removeFullReplication] Error verificando slots en filial {}: {}", sucursalId, e.getMessage());
+        }
     }
 } 

--- a/src/main/java/com/franco/dev/service/empresarial/LogicalReplicationService.java
+++ b/src/main/java/com/franco/dev/service/empresarial/LogicalReplicationService.java
@@ -1553,7 +1553,25 @@ public class LogicalReplicationService {
     public String generateBranchToCentralSubscriptionName(Long sucursalId) {
         return getCentralDbName() + "_filial" + sucursalId + "_central_sub";
     }
-    
+
+    /**
+     * Extract sucursal ID from a publication or subscription name.
+     * Handles dynamic DB-prefixed names like: beta_filial2_pub, central_beta_filial2_sub, etc.
+     */
+    public Long extractSucursalIdFromName(String name) {
+        if (name == null) return null;
+        try {
+            // Pattern: ...filial<id>_pub, ...filial<id>_sub, ...filial<id>_central_sub
+            java.util.regex.Matcher m = java.util.regex.Pattern.compile("filial(\\d+)_").matcher(name);
+            if (m.find()) {
+                return Long.parseLong(m.group(1));
+            }
+        } catch (NumberFormatException e) {
+            // ignore
+        }
+        return null;
+    }
+
     /**
      * Refresh a specific subscription to sync with its publication
      * @param subscriptionName Name of the subscription to refresh
@@ -1742,12 +1760,13 @@ public class LogicalReplicationService {
             }
 
             // 2. central_filialX_pub: for each existing publication, add missing tables with WHERE (sucursal_id = X)
+            String centralPubPrefix = "central_" + getCentralDbName() + "_filial";
             List<Map<String, Object>> pubs = jdbcTemplate.queryForList(
-                "SELECT pubname FROM pg_publication WHERE pubname LIKE 'central_filial%_pub' ORDER BY pubname");
+                "SELECT pubname FROM pg_publication WHERE pubname LIKE '" + centralPubPrefix + "%_pub' ORDER BY pubname");
             for (Map<String, Object> row : pubs) {
                 String pubname = (String) row.get("pubname");
                 if (pubname == null) continue;
-                String suffix = pubname.replace("central_filial", "").replace("_pub", "");
+                String suffix = pubname.replace(centralPubPrefix, "").replace("_pub", "");
                 Long sucursalId = null;
                 try {
                     sucursalId = Long.parseLong(suffix);
@@ -1784,7 +1803,7 @@ public class LogicalReplicationService {
                 for (Sucursal sucursal : sucursales) {
                     Long sid = sucursal.getId();
                     if (sid == null || sid == 0) continue;
-                    String filialPubName = "filial" + sid + "_pub";
+                    String filialPubName = generateBranchPublicationName(sid);
                     try {
                         JdbcTemplate remoteJdbc = createRemoteJdbcTemplate(
                             sucursal.getIp(),
@@ -1822,14 +1841,17 @@ public class LogicalReplicationService {
                 Long sid = sucursal.getId();
                 if (sid == null || sid == 0) continue;
                 try {
-                    if (refreshRemoteSubscription(sid, "filial" + sid + "_central_sub")) {
-                        log.append("  Filial ").append(sid).append(": filial").append(sid).append("_central_sub refrescada.\n");
+                    String branchToCentralSubName = generateBranchToCentralSubscriptionName(sid);
+                    if (refreshRemoteSubscription(sid, branchToCentralSubName)) {
+                        log.append("  Filial ").append(sid).append(": ").append(branchToCentralSubName).append(" refrescada.\n");
                     }
-                    if (refreshRemoteSubscription(sid, "central_filial" + sid + "_sub")) {
-                        log.append("  Filial ").append(sid).append(": central_filial").append(sid).append("_sub refrescada.\n");
+                    String centralToBranchSubName = generateCentralToBranchSubscriptionName(sid);
+                    if (refreshRemoteSubscription(sid, centralToBranchSubName)) {
+                        log.append("  Filial ").append(sid).append(": ").append(centralToBranchSubName).append(" refrescada.\n");
                     }
-                    if (refreshSubscription("filial" + sid + "_sub")) {
-                        log.append("  Central: filial").append(sid).append("_sub refrescada.\n");
+                    String branchSubName = generateBranchSubscriptionName(sid);
+                    if (refreshSubscription(branchSubName)) {
+                        log.append("  Central: ").append(branchSubName).append(" refrescada.\n");
                     }
                 } catch (Exception e) {
                     log.append("  Refresco sucursal ").append(sid).append(": ").append(e.getMessage()).append("\n");

--- a/src/main/resources/db/migration/V119__add_replication_test_to_publications.sql
+++ b/src/main/resources/db/migration/V119__add_replication_test_to_publications.sql
@@ -1,0 +1,44 @@
+-- Add replication_test to central_pub (MAIN_TO_ALL direction) and to all central_*_filialX_pub publications.
+-- Publication names are dynamic (prefixed with DB name), so we discover them.
+
+-- 1. Add to central_pub if it exists
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_publication WHERE pubname = 'central_pub') THEN
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_publication_tables
+            WHERE pubname = 'central_pub' AND tablename = 'replication_test'
+        ) THEN
+            EXECUTE 'ALTER PUBLICATION central_pub ADD TABLE configuraciones.replication_test';
+            RAISE NOTICE 'Added configuraciones.replication_test to central_pub';
+        END IF;
+    END IF;
+END $$;
+
+-- 2. Add to all central_*_filialX_pub publications (with sucursal_id WHERE clause)
+DO $$
+DECLARE
+    pub RECORD;
+    suc_id TEXT;
+BEGIN
+    FOR pub IN
+        SELECT pubname FROM pg_publication
+        WHERE pubname LIKE 'central_%_filial%_pub'
+        ORDER BY pubname
+    LOOP
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_publication_tables
+            WHERE pubname = pub.pubname AND tablename = 'replication_test'
+        ) THEN
+            -- Extract sucursal_id: pattern is central_{dbname}_filial{id}_pub
+            suc_id := regexp_replace(pub.pubname, '^central_.*_filial(\d+)_pub$', '\1');
+            IF suc_id ~ '^\d+$' THEN
+                EXECUTE format(
+                    'ALTER PUBLICATION %I ADD TABLE configuraciones.replication_test WHERE (sucursal_id = %s)',
+                    pub.pubname, suc_id
+                );
+                RAISE NOTICE 'Added configuraciones.replication_test to % (sucursal_id=%)', pub.pubname, suc_id;
+            END IF;
+        END IF;
+    END LOOP;
+END $$;

--- a/src/main/resources/graphql/replication/replication.graphqls
+++ b/src/main/resources/graphql/replication/replication.graphqls
@@ -101,6 +101,9 @@ extend type Mutation {
     # Setup branch-side replication (to be called on branch server)
     setupBranchReplication(sucursalId: ID!): ReplicationStatus!
     
+    # Remove all replication objects for a branch (pubs, subs, orphan slots on central and filial). Idempotent, best-effort.
+    removeFullReplication(sucursalId: ID!): ReplicationStatus!
+
     # Remove central server replication for a branch
     removeReplication(sucursalId: ID!): ReplicationStatus!
     


### PR DESCRIPTION
## Contexto

Promoción de `release/beta` a `master` para generar un nuevo tag stable (`v4.1.0`) vía semantic-release. Requerido para la migración de central bodega al canal stable programada para la próxima ventana operacional.

## Por qué ahora

Master tiene solo `v4.0.0` como último stable (2026-04-13). Los 9 commits en `release/beta` que no están en master incluyen el fix crítico para la migración bodega:

- **`3cd26d08 fix(replication): use dynamic publication/subscription names instead of hardcoded`** — hace que `setupFullReplication(sucursalId)` genere naming `bodega_filial${N}_pub` basado en el nombre de la DB (vs. hardcoded a `farmacia_*` o legacy `filial${N}_pub`). Sin este fix, el rename de pubs/subs y la estrategia del split de cluster bodega no funcionan correctamente.
- `27253dba feat(ci): add beta as deployable instance` + `a1ab6ea5 docs: update CLAUDE.md and CICD-WORKFLOW.md for release/beta branch` — documentación y targets de deploy ya vivos en beta.

## Merge strategy

**IMPORTANTE: merge commit, NO squash.** Squash colapsa los `feat:`/`fix:` y semantic-release calcula mal el bump. El proceso correcto:

    gh pr merge <N> --merge

## Qué genera este merge

1. `master` avanza 9 commits.
2. CI corre (job `build`).
3. `semantic-release` en master detecta commits y crea:
   - Tag nuevo `v4.1.0` (minor bump por el `feat:` de beta deploy target).
   - GitHub Release con asset `frc-central-server.jar`.
4. El canal `stable` del manifest apunta a `v4.1.0`.

## Impacto en clientes

- **Bodega (canal stable):** todavía no consume. El deploy a bodega es manual vía `workflow_dispatch` con `instance=bodega`. Este PR solo hace que la versión esté disponible; el despliegue se ejecuta en la ventana planificada.
- **Farmacia (canal beta):** sin cambio. Farmacia sigue consumiendo `v4.1.0-beta.3`.
- **Alpha (canal alpha):** sin cambio.

## Test plan

- [ ] CI `build` verde en el PR.
- [ ] Post-merge: verificar que semantic-release publicó tag `v4.1.0` con asset JAR.
- [ ] Post-merge: `gh release view v4.1.0 --repo GabFrank/franco-system-backend-servidor` muestra prerelease=false.
- [ ] Deploy a bodega se dispara manualmente en la ventana de migración planificada (no en este PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)