### PR TITLE
fix(config): zona horaria America/Asuncion (JVM, Jackson y hora-servidor)

### DIFF
--- a/src/main/java/com/franco/dev/config/ConfigController.java
+++ b/src/main/java/com/franco/dev/config/ConfigController.java
@@ -9,6 +9,7 @@ import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.RestTemplate;
@@ -18,7 +19,10 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
-import java.time.LocalDateTime;
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
@@ -38,6 +42,9 @@ public class ConfigController {
     @Autowired
     private ImageService imageService;
 
+    @Value("${app.timezone:America/Asuncion}")
+    private String appTimezone;
+
     @PostMapping
     @RequestMapping(value = "/verificar")
     @ResponseBody
@@ -51,9 +58,21 @@ public class ConfigController {
     @ResponseBody
     public ResponseEntity<java.util.Map<String, Object>> horaServidor() {
         java.util.Map<String, Object> response = new java.util.HashMap<>();
-        LocalDateTime ahora = LocalDateTime.now();
-        response.put("horaServidor", ahora.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
-        response.put("timestamp", System.currentTimeMillis());
+        ZoneId zone;
+        try {
+            zone = ZoneId.of(appTimezone.trim());
+        } catch (DateTimeException e) {
+            log.warn("app.timezone inválido '{}', usando America/Asuncion", appTimezone);
+            zone = ZoneId.of("America/Asuncion");
+        }
+        long epochMillis = System.currentTimeMillis();
+        ZonedDateTime zdt = Instant.ofEpochMilli(epochMillis).atZone(zone);
+        String isoConOffset = zdt.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        response.put("epochMillis", epochMillis);
+        response.put("timestamp", epochMillis);
+        response.put("zoneId", zone.getId());
+        response.put("fechaHoraServidor", isoConOffset);
+        response.put("horaServidor", isoConOffset);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/franco/dev/config/TimeZoneConfig.java
+++ b/src/main/java/com/franco/dev/config/TimeZoneConfig.java
@@ -1,0 +1,29 @@
+package com.franco.dev.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+
+import javax.annotation.PostConstruct;
+import java.util.TimeZone;
+
+/**
+ * Alinea la zona por defecto de la JVM con {@code app.timezone} para que
+ * {@code LocalDateTime.now()} y el endpoint {@code /config/hora-servidor} reflejen la hora civil esperada.
+ * El instante {@code System.currentTimeMillis()} sigue siendo el del reloj del sistema operativo.
+ */
+@Configuration
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class TimeZoneConfig {
+
+    @Value("${app.timezone:America/Asuncion}")
+    private String timezoneId;
+
+    @PostConstruct
+    public void applyDefaultTimeZone() {
+        TimeZone tz = TimeZone.getTimeZone(timezoneId.trim());
+        TimeZone.setDefault(tz);
+        System.setProperty("user.timezone", tz.getID());
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,6 +26,10 @@ spring.datasource.hikari.connection-timeout=60000
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=false
 spring.jpa.properties.hibernate.default_batch_fetch_size=10
+# Zona horaria del negocio (JVM default, Jackson, Hibernate). Cambiar aquí o en el perfil activo.
+app.timezone=America/Asuncion
+spring.jackson.time-zone=${app.timezone}
+spring.jpa.properties.hibernate.jdbc.time_zone=${app.timezone}
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.show_sql=false


### PR DESCRIPTION
## Qué resuelve
- Define `app.timezone=America/Asuncion` y propaga a Jackson y Hibernate (`jdbc.time_zone`).
- `TimeZoneConfig` alinea la zona por defecto de la JVM.
- `/config/hora-servidor` devuelve fecha/hora en ISO con offset, `zoneId`, `epochMillis` y compatibilidad con el campo `horaServidor`.

## Cómo probarlo
- Arrancar el backend y llamar `GET /config/hora-servidor`; verificar que la hora corresponde a America/Asuncion y el offset es correcto.

## Impacto en DB
- Ninguno.

## Riesgo
- Bajo: clientes que parseaban solo `horaServidor` como `LocalDateTime` sin offset pueden necesitar ajuste (ahora es offset datetime).

Made with [Cursor](https://cursor.com)