### PR TITLE
fix(ci): sort releases by published_at in deploy resolver

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,19 +49,19 @@ jobs:
                 "https://api.github.com/repos/${{ github.repository }}/releases/latest" \
                 | jq -r '.tag_name')
             elif [[ "${INSTANCE}" == "farmacia" || "${INSTANCE}" == "beta" ]]; then
-              # Beta channel: latest prerelease with -beta
+              # Beta channel: latest prerelease with -beta (sorted by published_at desc)
               TAG=$(curl -fsSL \
                 -H "Authorization: token ${GH_TOKEN}" \
                 -H "Accept: application/vnd.github.v3+json" \
                 "https://api.github.com/repos/${{ github.repository }}/releases" \
-                | jq -r '[.[] | select(.prerelease == true and (.tag_name | contains("beta")))][0].tag_name')
+                | jq -r '[.[] | select(.prerelease == true and (.tag_name | contains("beta")))] | sort_by(.published_at) | reverse | .[0].tag_name')
             else
-              # Alpha: latest prerelease with -alpha
+              # Alpha: latest prerelease with -alpha (sorted by published_at desc)
               TAG=$(curl -fsSL \
                 -H "Authorization: token ${GH_TOKEN}" \
                 -H "Accept: application/vnd.github.v3+json" \
                 "https://api.github.com/repos/${{ github.repository }}/releases" \
-                | jq -r '[.[] | select(.prerelease == true and (.tag_name | contains("alpha")))][0].tag_name')
+                | jq -r '[.[] | select(.prerelease == true and (.tag_name | contains("alpha")))] | sort_by(.published_at) | reverse | .[0].tag_name')
             fi
             VERSION="${TAG#v}"
             echo "Resolved version: ${VERSION}"


### PR DESCRIPTION
## Summary
- Deploy workflow picked stale versions (e.g. alpha.9 instead of alpha.11) because GitHub API `/releases` order is not guaranteed chronological
- Add `sort_by(.published_at) | reverse` before `.[0]` for alpha and beta channel resolution
- Stable/bodega channel unaffected (uses `/releases/latest`)

## Test plan
- [ ] Trigger Deploy workflow with instance=alpha, no version override → should resolve latest alpha release

🤖 Generated with [Claude Code](https://claude.com/claude-code)