### PR TITLE
fix(compras): exclude RECHAZADO items from physical reception flow

### DIFF
--- a/src/main/java/com/franco/dev/graphql/operaciones/RecepcionMercaderiaItemGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/RecepcionMercaderiaItemGraphQL.java
@@ -23,6 +23,7 @@ import com.franco.dev.domain.operaciones.Pedido;
 import com.franco.dev.domain.operaciones.ProcesoEtapa;
 import com.franco.dev.domain.operaciones.RecepcionMercaderiaNota;
 import com.franco.dev.domain.operaciones.enums.NotaRecepcionEstado;
+import com.franco.dev.domain.operaciones.enums.NotaRecepcionItemEstado;
 import com.franco.dev.domain.operaciones.enums.RecepcionMercaderiaEstado;
 import com.franco.dev.domain.operaciones.enums.ProcesoEtapaTipo;
 import com.franco.dev.domain.operaciones.enums.ProcesoEtapaEstado;
@@ -290,6 +291,12 @@ public class RecepcionMercaderiaItemGraphQL implements GraphQLQueryResolver, Gra
         NotaRecepcionItem notaItem = notaRecepcionItemService.findById(input.getNotaRecepcionItemId())
                 .orElseThrow(() -> new GraphQLException(
                         "NotaRecepcionItem no encontrado con ID: " + input.getNotaRecepcionItemId()));
+
+        // 3.1 Rechazar operación si el ítem fue rechazado documentalmente
+        if (notaItem.getEstado() == NotaRecepcionItemEstado.RECHAZADO) {
+            throw new GraphQLException(
+                    "No se puede recepcionar un ítem rechazado documentalmente (ID: " + notaItem.getId() + ")");
+        }
 
         // 4. Obtener o crear RecepcionMercaderia automáticamente
         RecepcionMercaderia recepcion = crearRecepcionAutomatica(input);
@@ -930,9 +937,11 @@ public class RecepcionMercaderiaItemGraphQL implements GraphQLQueryResolver, Gra
                     .orElseThrow(() -> new GraphQLException("Nota de recepción no encontrada: " + notaId));
 
             // 2. Obtener todas las distribuciones de la nota para las sucursales dadas
+            // Excluir items documentalmente rechazados (estado RECHAZADO en nota_recepcion_item)
             List<NotaRecepcionItemDistribucion> distribuciones = notaRecepcionItemDistribucionService
                     .findByNotaRecepcionId(notaId);
             List<NotaRecepcionItemDistribucion> distribucionesFiltradas = distribuciones.stream()
+                    .filter(dist -> dist.getNotaRecepcionItem().getEstado() != NotaRecepcionItemEstado.RECHAZADO)
                     .filter(dist -> sucursalesIds.contains(dist.getSucursalEntrega().getId()))
                     .filter(dist -> itemIds == null || itemIds.contains(dist.getNotaRecepcionItem().getId()))
                     .collect(Collectors.toList());
@@ -1025,9 +1034,11 @@ public class RecepcionMercaderiaItemGraphQL implements GraphQLQueryResolver, Gra
                     .orElseThrow(() -> new GraphQLException("Nota de recepción no encontrada: " + notaId));
 
             // Obtener distribuciones de la nota para las sucursales dadas (y filtrar itemIds si corresponde)
+            // Excluir items documentalmente rechazados
             List<NotaRecepcionItemDistribucion> distribuciones = notaRecepcionItemDistribucionService
                     .findByNotaRecepcionId(notaId);
             List<NotaRecepcionItemDistribucion> distribucionesFiltradas = distribuciones.stream()
+                    .filter(dist -> dist.getNotaRecepcionItem().getEstado() != NotaRecepcionItemEstado.RECHAZADO)
                     .filter(dist -> sucursalesIds.contains(dist.getSucursalEntrega().getId()))
                     .filter(dist -> itemIds == null || itemIds.contains(dist.getNotaRecepcionItem().getId()))
                     .collect(Collectors.toList());
@@ -1111,9 +1122,12 @@ public class RecepcionMercaderiaItemGraphQL implements GraphQLQueryResolver, Gra
             for (NotaRecepcion nota : notasPedido) {
                 System.out.println("Procesando nota: " + nota.getNumero());
 
-                // 2. Obtener todos los ítems de la nota
-                List<NotaRecepcionItem> itemsNota = notaRecepcionItemService.findByNotaRecepcionId(nota.getId());
-                System.out.println("Ítems de nota encontrados: " + itemsNota.size());
+                // 2. Obtener todos los ítems de la nota (excluyendo rechazados documentalmente)
+                List<NotaRecepcionItem> itemsNota = notaRecepcionItemService.findByNotaRecepcionId(nota.getId())
+                        .stream()
+                        .filter(item -> item.getEstado() != NotaRecepcionItemEstado.RECHAZADO)
+                        .collect(Collectors.toList());
+                System.out.println("Ítems de nota encontrados (sin rechazados): " + itemsNota.size());
 
                 for (NotaRecepcionItem item : itemsNota) {
                     // 3. Verificar si el ítem tiene distribuciones en las sucursales seleccionadas


### PR DESCRIPTION
## Summary
Items rejected during documental reception (`nota_recepcion_item.estado = RECHAZADO`) were leaking into the physical reception phase, causing:
- **"Verificar Todos"** created `RecepcionMercaderiaItem` + stock movements for rejected items
- **Finalization validation** counted rejected items as pending, blocking completion with "2 items faltan ser verificados"
- **Individual save** had no guard against creating reception for rejected items

### Fix
Add `NotaRecepcionItemEstado.RECHAZADO` filter in 4 places:
1. `recepcionarTodoPorNota` — skip distributions of rejected items
2. `validarFinalizacionRecepcionPorPedido` — exclude from pending count
3. `deshacerVerificacionTodoPorNota` — consistency
4. `crearRecepcionMercaderiaItem` — guard against individual saves

### Tested scenarios
- [x] Verificar Todos with mixed CONCILIADO/RECHAZADO items → only CONCILIADO items receive stock
- [x] Recepción Rápida (individual) → rejected items skipped
- [x] Rejected item assigned to separate rejection nota → main nota finalizes cleanly
- [x] Stock movements only created for CONCILIADO items
- [x] Finalization not blocked by rejected items

🤖 Generated with [Claude Code](https://claude.com/claude-code)