### PR TITLE
feat(impresion): imprimir pedido de compra PDF y ticket

### DIFF
--- a/src/main/java/com/franco/dev/graphql/operaciones/PedidoGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/PedidoGraphQL.java
@@ -82,6 +82,9 @@ public class PedidoGraphQL implements GraphQLQueryResolver, GraphQLMutationResol
     @Autowired
     private RecepcionMercaderiaService recepcionMercaderiaService;
 
+    @Autowired
+    private com.franco.dev.service.impresion.ImpresionService impresionService;
+
     // ===== BASIC CRUD OPERATIONS =====
 
     public Optional<Pedido> pedido(Long id) {
@@ -595,5 +598,22 @@ public class PedidoGraphQL implements GraphQLQueryResolver, GraphQLMutationResol
             e.printStackTrace();
             throw new GraphQLException("Error al obtener pedidos con filtros: " + e.getMessage());
         }
+    }
+
+    // ===== IMPRESION DE PEDIDO =====
+
+    public String imprimirPedidoPDF(Long pedidoId) {
+        Pedido pedido = service.findById(pedidoId)
+                .orElseThrow(() -> new GraphQLException("Pedido no encontrado: " + pedidoId));
+        List<PedidoItem> items = pedidoItemService.findByPedidoId(pedidoId);
+        return impresionService.imprimirPedido(pedido, items, false, null);
+    }
+
+    public Boolean imprimirPedidoTicket(Long pedidoId, String printerName) {
+        Pedido pedido = service.findById(pedidoId)
+                .orElseThrow(() -> new GraphQLException("Pedido no encontrado: " + pedidoId));
+        List<PedidoItem> items = pedidoItemService.findByPedidoId(pedidoId);
+        impresionService.imprimirPedido(pedido, items, true, printerName);
+        return true;
     }
 }

--- a/src/main/java/com/franco/dev/service/impresion/ImpresionService.java
+++ b/src/main/java/com/franco/dev/service/impresion/ImpresionService.java
@@ -5,6 +5,8 @@ import com.franco.dev.domain.administrativo.Jornada;
 import com.franco.dev.domain.administrativo.Marcacion;
 import com.franco.dev.domain.empresarial.Sucursal;
 import com.franco.dev.domain.financiero.VentaCredito;
+import com.franco.dev.domain.operaciones.Pedido;
+import com.franco.dev.domain.operaciones.PedidoItem;
 import com.franco.dev.domain.operaciones.Transferencia;
 import com.franco.dev.domain.operaciones.TransferenciaItem;
 import com.franco.dev.domain.operaciones.SolicitudPago;
@@ -1465,5 +1467,222 @@ public class ImpresionService {
         long hours = minutes / 60;
         long remainingMinutes = minutes % 60;
         return String.format("%02d:%02d", hours, remainingMinutes);
+    }
+
+    // ==================== PEDIDO DE COMPRA ====================
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class PedidoItemDto {
+        private Integer numero;
+        private String descripcion;
+        private String presentacion;
+        private Double cantidadUnidades;
+        private Double precioUnitario;
+        private Double subtotal;
+        private String vencimiento;
+    }
+
+    public String imprimirPedido(Pedido pedido, List<PedidoItem> items, Boolean ticket, String printerName) {
+        if (ticket != null && ticket) {
+            // ===== ESC/POS TICKET =====
+            try {
+                selectedPrintService = printingService.getPrintService(printerName);
+                if (selectedPrintService != null) {
+                    printerOutputStream = new PrinterOutputStream(selectedPrintService);
+                    Style center = new Style().setJustification(EscPosConst.Justification.Center);
+                    QRCode qrCode = new QRCode();
+
+                    BufferedImage imageBufferedImage = ImageIO
+                            .read(new File(imageService.getImagePath() + "logo.png"));
+                    imageBufferedImage = resize(imageBufferedImage, 200, 100);
+                    BitImageWrapper imageWrapper = new BitImageWrapper();
+                    EscPos escpos = new EscPos(printerOutputStream);
+                    Bitonal algorithm = new BitonalThreshold();
+                    EscPosImage escposImage = new EscPosImage(new CoffeeImageImpl(imageBufferedImage), algorithm);
+                    imageWrapper.setJustification(EscPosConst.Justification.Center);
+                    escpos.writeLF("--------------------------------");
+                    escpos.write(imageWrapper, escposImage);
+                    escpos.writeLF(center.setBold(true), "PEDIDO DE COMPRA");
+                    escpos.writeLF("--------------------------------");
+                    escpos.writeLF("Pedido Nro: " + pedido.getId());
+                    escpos.writeLF("Fecha: " + (pedido.getCreadoEn() != null
+                            ? pedido.getCreadoEn().format(formatter)
+                            : ""));
+                    String provNombre = pedido.getProveedor() != null
+                            && pedido.getProveedor().getPersona() != null
+                                    ? pedido.getProveedor().getPersona().getNombre()
+                                    : "";
+                    if (provNombre.length() > 28) {
+                        provNombre = provNombre.substring(0, 28);
+                    }
+                    escpos.writeLF("Prov: " + provNombre);
+                    String monedaStr = pedido.getMoneda() != null
+                            && pedido.getMoneda().getDenominacion() != null
+                                    ? pedido.getMoneda().getDenominacion()
+                                    : "";
+                    escpos.writeLF("Moneda: " + monedaStr);
+                    escpos.writeLF("--------------------------------");
+
+                    double totalPedido = 0;
+                    for (int i = 0; i < items.size(); i++) {
+                        PedidoItem item = items.get(i);
+                        String desc = item.getProducto() != null ? item.getProducto().getDescripcion() : "";
+                        if (desc.length() > 32) {
+                            desc = desc.substring(0, 32);
+                        }
+                        escpos.writeLF((i + 1) + ". " + desc);
+
+                        Double cant = item.getCantidadSolicitada() != null ? item.getCantidadSolicitada() : 0.0;
+                        Double precio = item.getPrecioUnitarioSolicitado() != null
+                                ? item.getPrecioUnitarioSolicitado()
+                                : 0.0;
+                        double sub = cant * precio;
+                        totalPedido += sub;
+
+                        String cantStr = String.format("%.0f", cant);
+                        String precioStr = NumberFormat.getNumberInstance(Locale.GERMAN)
+                                .format((long) Math.round(precio));
+                        String subStr = NumberFormat.getNumberInstance(Locale.GERMAN)
+                                .format((long) Math.round(sub));
+                        escpos.writeLF("  " + cantStr + " x " + precioStr + " = " + subStr);
+
+                        if (Boolean.TRUE.equals(item.getEsBonificacion())) {
+                            escpos.writeLF("  ** BONIFICACION **");
+                        }
+                    }
+
+                    escpos.writeLF("--------------------------------");
+                    String totalStr = NumberFormat.getNumberInstance(Locale.GERMAN)
+                            .format((long) Math.round(totalPedido));
+                    escpos.writeLF(center.setBold(true), "TOTAL: " + totalStr);
+                    escpos.writeLF("--------------------------------");
+
+                    String qrData = "frc-0-PEDIDO-" + pedido.getId() + "-" + pedido.getId()
+                            + "-GestionComprasComponent-null-null";
+                    escpos.write(qrCode.setSize(7).setJustification(EscPosConst.Justification.Center), qrData);
+
+                    escpos.feed(4);
+                    escpos.writeLF(center, ".......................");
+                    escpos.writeLF(center, "Comprador");
+                    escpos.feed(5);
+                    escpos.close();
+                    printerOutputStream.close();
+                }
+            } catch (IOException e) {
+                log.error("Error al imprimir ticket de pedido: {}", e.getMessage(), e);
+            }
+            return null;
+        } else {
+            // ===== JASPER PDF =====
+            try {
+                List<PedidoItemDto> dtoList = new ArrayList<>();
+                double montoTotal = 0;
+                for (int i = 0; i < items.size(); i++) {
+                    PedidoItem item = items.get(i);
+                    PedidoItemDto dto = new PedidoItemDto();
+                    dto.setNumero(i + 1);
+
+                    // Descripción + código de barras: "PRODUCTO (codBarra)"
+                    String desc = item.getProducto() != null ? item.getProducto().getDescripcion() : "";
+                    String codBarra = "";
+                    if (item.getPresentacionCreacion() != null) {
+                        Codigo codigo = codigoService
+                                .findPrincipalByPresentacionId(item.getPresentacionCreacion().getId());
+                        if (codigo != null && codigo.getCodigo() != null && !codigo.getCodigo().isEmpty()) {
+                            codBarra = codigo.getCodigo();
+                        }
+                    }
+                    if (!codBarra.isEmpty()) {
+                        desc = desc + " (" + codBarra + ")";
+                    }
+                    dto.setDescripcion(desc);
+
+                    // Presentación: "1 unid." o "Caja x N unid."
+                    String pres = "";
+                    if (item.getPresentacionCreacion() != null
+                            && item.getPresentacionCreacion().getCantidad() != null) {
+                        int cant = item.getPresentacionCreacion().getCantidad().intValue();
+                        if (cant <= 1) {
+                            pres = "1 unid.";
+                        } else {
+                            pres = "Caja x " + cant + " unid.";
+                        }
+                    }
+                    dto.setPresentacion(pres);
+
+                    Double cant = item.getCantidadSolicitada() != null ? item.getCantidadSolicitada() : 0.0;
+                    Double precio = item.getPrecioUnitarioSolicitado() != null
+                            ? item.getPrecioUnitarioSolicitado()
+                            : 0.0;
+                    double sub = cant * precio;
+                    montoTotal += sub;
+
+                    dto.setCantidadUnidades(cant);
+                    dto.setPrecioUnitario(precio);
+                    dto.setSubtotal(sub);
+                    dto.setVencimiento(item.getVencimientoEsperado() != null
+                            ? DateUtils.toStringOnlyDate(item.getVencimientoEsperado())
+                            : "");
+                    dtoList.add(dto);
+                }
+
+                JasperReport jasperReport = compileReportFromClasspath("reports/pedido-compra.jrxml");
+                JRBeanCollectionDataSource dataSource = new JRBeanCollectionDataSource(dtoList);
+                Map<String, Object> parameters = new HashMap<>();
+                parameters.put("pedidoId", pedido.getId());
+                parameters.put("proveedor", pedido.getProveedor() != null
+                        && pedido.getProveedor().getPersona() != null
+                                ? pedido.getProveedor().getPersona().getNombre()
+                                : "");
+                parameters.put("vendedor", pedido.getVendedor() != null
+                        && pedido.getVendedor().getPersona() != null
+                                ? pedido.getVendedor().getPersona().getNombre()
+                                : "");
+                parameters.put("moneda", pedido.getMoneda() != null
+                        && pedido.getMoneda().getDenominacion() != null
+                                ? pedido.getMoneda().getDenominacion()
+                                : "");
+                parameters.put("monedaSimbolo", pedido.getMoneda() != null
+                        && pedido.getMoneda().getSimbolo() != null
+                                ? pedido.getMoneda().getSimbolo()
+                                : "");
+                parameters.put("formaPago", pedido.getFormaPago() != null
+                        && pedido.getFormaPago().getDescripcion() != null
+                                ? pedido.getFormaPago().getDescripcion()
+                                : "");
+                parameters.put("plazoCredito", pedido.getPlazoCredito());
+                parameters.put("observacion", pedido.getObservacionFormaPago() != null
+                        ? pedido.getObservacionFormaPago()
+                        : "");
+                parameters.put("fechaCreacion", pedido.getCreadoEn() != null
+                        ? DateUtils.toString(pedido.getCreadoEn())
+                        : "");
+                String usuario = "";
+                if (pedido.getUsuario() != null) {
+                    if (pedido.getUsuario().getPersona() != null
+                            && pedido.getUsuario().getPersona().getNombre() != null) {
+                        usuario = pedido.getUsuario().getPersona().getNombre();
+                    } else if (pedido.getUsuario().getNickname() != null) {
+                        usuario = pedido.getUsuario().getNickname();
+                    }
+                }
+                parameters.put("usuario", usuario);
+                parameters.put("logo", imageService.getImagePath() + File.separator + "logo.png");
+                parameters.put("fechaReporte", DateUtils.toString(LocalDateTime.now()));
+                parameters.put("montoTotal", montoTotal);
+                parameters.put("qrText", "frc-0-PEDIDO-" + pedido.getId() + "-" + pedido.getId()
+                        + "-GestionComprasComponent-null-null");
+
+                JasperPrint jasperPrint = JasperFillManager.fillReport(jasperReport, parameters, dataSource);
+                byte[] pdfBytes = JasperExportManager.exportReportToPdf(jasperPrint);
+                return Base64.getEncoder().encodeToString(pdfBytes);
+
+            } catch (JRException e) {
+                log.error("Error al generar PDF de pedido: {}", e.getMessage(), e);
+                throw new RuntimeException("Error al generar PDF del pedido: " + e.getMessage(), e);
+            }
+        }
     }
 }

--- a/src/main/resources/graphql/operaciones/pedido.graphqls
+++ b/src/main/resources/graphql/operaciones/pedido.graphqls
@@ -92,6 +92,8 @@ extend type Mutation {
     deletePedido(id: ID!): Boolean!
     finalizarCreacionPedido(pedidoId: ID!): Pedido!
     finalizarRecepcionNotas(pedidoId: ID!): Pedido!
+    imprimirPedidoPDF(pedidoId: ID!): String!
+    imprimirPedidoTicket(pedidoId: ID!, printerName: String): Boolean!
 }
 
 

--- a/src/main/resources/reports/pedido-compra.jrxml
+++ b/src/main/resources/reports/pedido-compra.jrxml
@@ -1,0 +1,379 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 6.17.0.final using JasperReports Library version 6.17.0-6d93193241dd8cc42629e188b94f9e0bc5722efd  -->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="pedido-compra" pageWidth="595" pageHeight="842" whenNoDataType="AllSectionsNoDetail" columnWidth="555" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isFloatColumnFooter="true" uuid="a1b2c3d4-e5f6-7890-abcd-ef1234567890">
+	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="One Empty Record"/>
+	<parameter name="pedidoId" class="java.lang.Long"/>
+	<parameter name="qrText" class="java.lang.String"/>
+	<parameter name="proveedor" class="java.lang.String"/>
+	<parameter name="vendedor" class="java.lang.String"/>
+	<parameter name="moneda" class="java.lang.String"/>
+	<parameter name="monedaSimbolo" class="java.lang.String"/>
+	<parameter name="formaPago" class="java.lang.String"/>
+	<parameter name="plazoCredito" class="java.lang.Integer"/>
+	<parameter name="observacion" class="java.lang.String"/>
+	<parameter name="fechaCreacion" class="java.lang.String"/>
+	<parameter name="usuario" class="java.lang.String"/>
+	<parameter name="logo" class="java.lang.String"/>
+	<parameter name="fechaReporte" class="java.lang.String"/>
+	<parameter name="montoTotal" class="java.lang.Double"/>
+	<field name="numero" class="java.lang.Integer"/>
+	<field name="descripcion" class="java.lang.String"/>
+	<field name="presentacion" class="java.lang.String"/>
+	<field name="cantidadUnidades" class="java.lang.Double"/>
+	<field name="precioUnitario" class="java.lang.Double"/>
+	<field name="subtotal" class="java.lang.Double"/>
+	<field name="vencimiento" class="java.lang.String"/>
+	<variable name="totalGeneral" class="java.lang.Double" calculation="Sum">
+		<variableExpression><![CDATA[$F{subtotal}]]></variableExpression>
+	</variable>
+	<title>
+		<band height="100" splitType="Stretch">
+			<image hAlign="Center">
+				<reportElement x="0" y="0" width="120" height="60" uuid="11111111-1111-1111-1111-111111111111"/>
+				<imageExpression><![CDATA[$P{logo}]]></imageExpression>
+			</image>
+			<staticText>
+				<reportElement x="130" y="0" width="280" height="18" uuid="22222222-2222-2222-2222-222222222222"/>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Verdana" size="12" isBold="true"/>
+				</textElement>
+				<text><![CDATA[PEDIDO DE COMPRA]]></text>
+			</staticText>
+			<componentElement>
+				<reportElement x="460" y="0" width="93" height="99" uuid="33333333-3333-3333-3333-333333333333"/>
+				<jr:QRCode xmlns:jr="http://jasperreports.sourceforge.net/jasperreports/components" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports/components http://jasperreports.sourceforge.net/xsd/components.xsd" evaluationTime="Report">
+					<jr:codeExpression><![CDATA[$P{qrText}]]></jr:codeExpression>
+				</jr:QRCode>
+			</componentElement>
+			<staticText>
+				<reportElement x="130" y="20" width="80" height="10" uuid="44444444-0001-0000-0000-000000000001"/>
+				<box rightPadding="4"/>
+				<textElement>
+					<font fontName="Verdana" size="7" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Pedido Nro:]]></text>
+			</staticText>
+			<textField>
+				<reportElement x="210" y="20" width="100" height="10" uuid="44444444-0002-0000-0000-000000000001"/>
+				<textElement>
+					<font fontName="Verdana" size="7"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{pedidoId}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="320" y="20" width="50" height="10" uuid="44444444-0003-0000-0000-000000000001"/>
+				<box rightPadding="4"/>
+				<textElement>
+					<font fontName="Verdana" size="7" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Fecha:]]></text>
+			</staticText>
+			<textField>
+				<reportElement x="370" y="20" width="70" height="10" uuid="44444444-0004-0000-0000-000000000001"/>
+				<textElement>
+					<font fontName="Verdana" size="7"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{fechaCreacion}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="130" y="32" width="80" height="10" uuid="44444444-0005-0000-0000-000000000001"/>
+				<box rightPadding="4"/>
+				<textElement>
+					<font fontName="Verdana" size="7" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Proveedor:]]></text>
+			</staticText>
+			<textField textAdjust="StretchHeight">
+				<reportElement x="210" y="32" width="230" height="10" uuid="44444444-0006-0000-0000-000000000001"/>
+				<textElement>
+					<font fontName="Verdana" size="7"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{proveedor}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="130" y="44" width="80" height="10" uuid="44444444-0007-0000-0000-000000000001"/>
+				<box rightPadding="4"/>
+				<textElement>
+					<font fontName="Verdana" size="7" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Vendedor:]]></text>
+			</staticText>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement x="210" y="44" width="230" height="10" uuid="44444444-0008-0000-0000-000000000001"/>
+				<textElement>
+					<font fontName="Verdana" size="7"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{vendedor}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="0" y="65" width="70" height="10" uuid="44444444-0009-0000-0000-000000000001"/>
+				<box rightPadding="4"/>
+				<textElement>
+					<font fontName="Verdana" size="7" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Moneda:]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="70" y="65" width="100" height="10" uuid="44444444-0010-0000-0000-000000000001"/>
+				<textElement>
+					<font fontName="Verdana" size="7"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{moneda}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="180" y="65" width="70" height="10" uuid="44444444-0011-0000-0000-000000000001"/>
+				<box rightPadding="4"/>
+				<textElement>
+					<font fontName="Verdana" size="7" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Forma Pago:]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="250" y="65" width="100" height="10" uuid="44444444-0012-0000-0000-000000000001"/>
+				<textElement>
+					<font fontName="Verdana" size="7"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{formaPago}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="360" y="65" width="70" height="10" uuid="44444444-0013-0000-0000-000000000001"/>
+				<box rightPadding="4"/>
+				<textElement>
+					<font fontName="Verdana" size="7" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Plazo Crédito:]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="430" y="65" width="30" height="10" uuid="44444444-0014-0000-0000-000000000001"/>
+				<textElement>
+					<font fontName="Verdana" size="7"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{plazoCredito} != null ? $P{plazoCredito} + " días" : ""]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="0" y="77" width="70" height="10" uuid="44444444-0015-0000-0000-000000000001"/>
+				<box rightPadding="4"/>
+				<textElement>
+					<font fontName="Verdana" size="7" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Observación:]]></text>
+			</staticText>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement x="70" y="77" width="390" height="10" uuid="44444444-0016-0000-0000-000000000001"/>
+				<textElement>
+					<font fontName="Verdana" size="7"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{observacion}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="0" y="90" width="70" height="9" uuid="44444444-0017-0000-0000-000000000001"/>
+				<box rightPadding="4"/>
+				<textElement>
+					<font fontName="Verdana" size="6"/>
+				</textElement>
+				<text><![CDATA[Creado por:]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="70" y="90" width="150" height="9" uuid="44444444-0018-0000-0000-000000000001"/>
+				<textElement>
+					<font fontName="Verdana" size="6"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{usuario}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="250" y="90" width="80" height="9" uuid="44444444-0019-0000-0000-000000000001"/>
+				<textElement>
+					<font fontName="Verdana" size="6"/>
+				</textElement>
+				<text><![CDATA[Reporte generado:]]></text>
+			</staticText>
+			<textField>
+				<reportElement x="330" y="90" width="130" height="9" uuid="44444444-0020-0000-0000-000000000001"/>
+				<textElement>
+					<font fontName="Verdana" size="6"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{fechaReporte}]]></textFieldExpression>
+			</textField>
+		</band>
+	</title>
+	<columnHeader>
+		<band height="16">
+			<rectangle>
+				<reportElement x="0" y="0" width="555" height="14" forecolor="#9E9E9E" backcolor="#E0E0E0" uuid="66666666-0001-0000-0000-000000000001"/>
+			</rectangle>
+			<staticText>
+				<reportElement x="2" y="0" width="20" height="14" uuid="66666666-0002-0000-0000-000000000001"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="7" isBold="true"/>
+				</textElement>
+				<text><![CDATA[#]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="22" y="0" width="215" height="14" uuid="66666666-0003-0000-0000-000000000001"/>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Verdana" size="7" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Producto]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="237" y="0" width="60" height="14" uuid="66666666-0010-0000-0000-000000000001"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="7" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Venc.]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="297" y="0" width="75" height="14" uuid="66666666-0005-0000-0000-000000000001"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="7" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Presentación]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="372" y="0" width="38" height="14" uuid="66666666-0006-0000-0000-000000000001"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="7" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Cant.]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="410" y="0" width="65" height="14" uuid="66666666-0007-0000-0000-000000000001"/>
+				<textElement textAlignment="Right" verticalAlignment="Middle">
+					<font fontName="Verdana" size="7" isBold="true"/>
+				</textElement>
+				<text><![CDATA[P. Unit.]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="475" y="0" width="78" height="14" uuid="66666666-0008-0000-0000-000000000001"/>
+				<textElement textAlignment="Right" verticalAlignment="Middle">
+					<font fontName="Verdana" size="7" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Subtotal]]></text>
+			</staticText>
+		</band>
+	</columnHeader>
+	<detail>
+		<band height="13" splitType="Stretch">
+			<textField>
+				<reportElement x="2" y="0" width="20" height="11" uuid="77777777-0001-0000-0000-000000000001"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="7"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{numero}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight">
+				<reportElement x="22" y="0" width="215" height="11" uuid="77777777-0002-0000-0000-000000000001"/>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Verdana" size="7"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{descripcion}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="237" y="0" width="60" height="11" uuid="77777777-0009-0000-0000-000000000001">
+					<printWhenExpression><![CDATA[$F{vencimiento} != null]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="7"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{vencimiento}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="297" y="0" width="75" height="11" uuid="77777777-0004-0000-0000-000000000001"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="7"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{presentacion}]]></textFieldExpression>
+			</textField>
+			<textField pattern="#,##0.##">
+				<reportElement x="372" y="0" width="38" height="11" uuid="77777777-0005-0000-0000-000000000001"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="7"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{cantidadUnidades}]]></textFieldExpression>
+			</textField>
+			<textField pattern="#,##0">
+				<reportElement x="410" y="0" width="65" height="11" uuid="77777777-0006-0000-0000-000000000001"/>
+				<textElement textAlignment="Right" verticalAlignment="Middle">
+					<font fontName="Verdana" size="7"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{precioUnitario}]]></textFieldExpression>
+			</textField>
+			<textField pattern="#,##0">
+				<reportElement x="475" y="0" width="78" height="11" uuid="77777777-0007-0000-0000-000000000001"/>
+				<textElement textAlignment="Right" verticalAlignment="Middle">
+					<font fontName="Verdana" size="7"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{subtotal}]]></textFieldExpression>
+			</textField>
+			<line>
+				<reportElement x="0" y="11" width="555" height="1" forecolor="#BDBDBD" uuid="77777777-0010-0000-0000-000000000001">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+			</line>
+		</band>
+	</detail>
+	<pageFooter>
+		<band height="16">
+			<textField>
+				<reportElement x="420" y="2" width="80" height="12" uuid="aaa00001-0000-0000-0000-000000000001"/>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="6"/>
+				</textElement>
+				<textFieldExpression><![CDATA["Página " + $V{PAGE_NUMBER} + " de"]]></textFieldExpression>
+			</textField>
+			<textField evaluationTime="Report">
+				<reportElement x="500" y="2" width="55" height="12" uuid="aaa00002-0000-0000-0000-000000000001"/>
+				<textElement textAlignment="Left">
+					<font fontName="Verdana" size="6"/>
+				</textElement>
+				<textFieldExpression><![CDATA[" " + $V{PAGE_NUMBER}]]></textFieldExpression>
+			</textField>
+		</band>
+	</pageFooter>
+	<lastPageFooter>
+		<band height="16">
+			<staticText>
+				<reportElement x="210" y="2" width="140" height="12" uuid="99999999-0001-0000-0000-000000000001"/>
+				<textElement textAlignment="Center">
+					<font fontName="Verdana" size="7" isItalic="true"/>
+				</textElement>
+				<text><![CDATA[— Fin del documento —]]></text>
+			</staticText>
+			<textField>
+				<reportElement x="420" y="2" width="80" height="12" uuid="aaa00003-0000-0000-0000-000000000001"/>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="6"/>
+				</textElement>
+				<textFieldExpression><![CDATA["Página " + $V{PAGE_NUMBER} + " de"]]></textFieldExpression>
+			</textField>
+			<textField evaluationTime="Report">
+				<reportElement x="500" y="2" width="55" height="12" uuid="aaa00004-0000-0000-0000-000000000001"/>
+				<textElement textAlignment="Left">
+					<font fontName="Verdana" size="6"/>
+				</textElement>
+				<textFieldExpression><![CDATA[" " + $V{PAGE_NUMBER}]]></textFieldExpression>
+			</textField>
+		</band>
+	</lastPageFooter>
+	<summary>
+		<band height="18">
+			<rectangle>
+				<reportElement x="0" y="0" width="555" height="16" forecolor="#9E9E9E" backcolor="#E0E0E0" uuid="88888888-0010-0000-0000-000000000001"/>
+			</rectangle>
+			<staticText>
+				<reportElement x="350" y="0" width="125" height="16" uuid="88888888-0002-0000-0000-000000000001"/>
+				<textElement textAlignment="Right" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8" isBold="true"/>
+				</textElement>
+				<text><![CDATA[TOTAL:]]></text>
+			</staticText>
+			<textField pattern="#,##0">
+				<reportElement x="475" y="0" width="78" height="16" uuid="88888888-0003-0000-0000-000000000001"/>
+				<textElement textAlignment="Right" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$V{totalGeneral}]]></textFieldExpression>
+			</textField>
+		</band>
+	</summary>
+</jasperReport>


### PR DESCRIPTION
## Summary
- Agrega funcionalidad para imprimir pedidos de compra en PDF (Jasper) y ticket 58mm (ESC/POS)
- Nuevo template `pedido-compra.jrxml`: reporte A4 con logo, QR, metadata del pedido, tabla de items (Producto+cód barra, Venc., Presentación, Cant., P.Unit., Subtotal), total como footer de tabla, paginación
- Presentación formateada: `1 unid.` o `Caja x N unid.`
- Mutations GraphQL: `imprimirPedidoPDF(pedidoId)` → base64 String, `imprimirPedidoTicket(pedidoId, printerName)` → Boolean

## Archivos modificados
- `ImpresionService.java` — `PedidoItemDto` + método `imprimirPedido()`
- `PedidoGraphQL.java` — 2 resolver mutations
- `pedido.graphqls` — schema mutations
- `pedido-compra.jrxml` — template Jasper (nuevo)

## Test plan
- [ ] Abrir pedido existente → imprimir PDF → verificar layout correcto
- [ ] Imprimir en ticket → verificar envío a impresora térmica
- [ ] Verificar que productos con código de barras muestren `PRODUCTO (codBarra)`
- [ ] Verificar presentación: unidad muestra `1 unid.`, caja muestra `Caja x N unid.`
- [ ] Pedido con muchos items → verificar paginación y "Página X de Y"

🤖 Generated with [Claude Code](https://claude.com/claude-code)