### PR TITLE
feat(productos): agregar columna de costo total en reporte

### DIFF
--- a/src/main/java/com/franco/dev/service/productos/ProductoService.java
+++ b/src/main/java/com/franco/dev/service/productos/ProductoService.java
@@ -343,50 +343,19 @@ public class ProductoService extends CrudService<Producto, ProductoRepository, L
         StringBuilder filtroBusqueda = new StringBuilder();
         if (texto != null && !texto.trim().isEmpty()) {
             String textoBusqueda = texto.length() > 60 ? texto.substring(0, 57) + "..." : texto;
-            filtroBusqueda.append("Búsqueda: '").append(textoBusqueda).append("'");
+            filtroBusqueda.append("BÚSQUEDA: '").append(textoBusqueda.toUpperCase()).append("'");
         } else {
-            filtroBusqueda.append("Búsqueda: todos");
+            filtroBusqueda.append("BÚSQUEDA: TODOS");
         }
 
-        // Columna 1: Estado y Pesable
-        StringBuilder filtroColumna1 = new StringBuilder();
-        if (activo != null) {
-            filtroColumna1.append("Estado: ").append(activo ? "activos" : "inactivos");
-        } else {
-            filtroColumna1.append("Estado: todos");
-        }
-        filtroColumna1.append("\n");
-        if (balanza != null) {
-            filtroColumna1.append("Pesable: ").append(balanza ? "sí" : "no");
-        } else {
-            filtroColumna1.append("Pesable: todos");
-        }
+        // Nuevos parámetros individuales
+        String filtroEstado = "ESTADO: " + (activo != null ? (activo ? "ACTIVOS" : "INACTIVOS") : "TODOS");
+        String filtroPesable = "PESABLE: " + (balanza != null ? (balanza ? "SÍ" : "NO") : "TODOS");
+        String filtroMovStock = "MOV. STOCK: " + (stock != null ? (stock ? "SÍ" : "NO") : "TODOS");
+        String filtroCostoCero = "COSTO CERO: " + (costoCero != null ? (costoCero ? "SÍ" : "NO") : "TODOS");
+        String filtroVencimiento = "VENCIMIENTO: " + (vencimiento != null ? (vencimiento ? "SÍ" : "NO") : "TODOS");
 
-        // Columna 2: Movimiento stock y Costo cero
-        StringBuilder filtroColumna2 = new StringBuilder();
-        if (stock != null) {
-            filtroColumna2.append("Mov. stock: ").append(stock ? "sí" : "no");
-        } else {
-            filtroColumna2.append("Mov. stock: todos");
-        }
-        filtroColumna2.append("\n");
-        if (costoCero != null) {
-            filtroColumna2.append("Costo cero: ").append(costoCero ? "sí" : "no");
-        } else {
-            filtroColumna2.append("Costo cero: todos");
-        }
-
-        // Columna 3: Solo Vencimiento
-        StringBuilder filtroColumna3 = new StringBuilder();
-        if (vencimiento != null) {
-            filtroColumna3.append("Vencimiento: ").append(vencimiento ? "sí" : "no");
-        } else {
-            filtroColumna3.append("Vencimiento: todos");
-        }
-
-        // Columna 4: Subfamilia (debajo de vencimiento en la misma columna 3 del
-        // template)
-        StringBuilder filtroColumna4 = new StringBuilder();
+        String filtroSubfamiliaStr = "SUBFAMILIA: TODOS";
         if (subfamiliaId != null) {
             try {
                 Subfamilia subfamilia = subFamiliaService.findById(subfamiliaId).orElse(null);
@@ -394,21 +363,19 @@ public class ProductoService extends CrudService<Producto, ProductoRepository, L
                     String nombreCorto = subfamilia.getNombre().length() > 35
                             ? subfamilia.getNombre().substring(0, 32) + "..."
                             : subfamilia.getNombre();
-                    filtroColumna4.append("Subfamilia: ").append(nombreCorto);
+                    filtroSubfamiliaStr = "SUBFAMILIA: " + nombreCorto.toUpperCase();
                 } else {
-                    filtroColumna4.append("Subfamilia ID: ").append(subfamiliaId);
+                    filtroSubfamiliaStr = "SUBFAMILIA ID: " + subfamiliaId;
                 }
             } catch (Exception e) {
-                filtroColumna4.append("Subfamilia ID: ").append(subfamiliaId);
+                filtroSubfamiliaStr = "SUBFAMILIA ID: " + subfamiliaId;
             }
-        } else {
-            filtroColumna4.append("Subfamilia: todos");
         }
 
         // Filtro de Stock (columna 4 del template - separado)
         StringBuilder filtroStock = new StringBuilder();
         if (stockFiltro != null && !stockFiltro.equals("todos")) {
-            filtroStock.append("Stock: ").append(stockFiltro);
+            filtroStock.append("STOCK: ").append(stockFiltro.toUpperCase());
             if (sucursalId != null) {
                 try {
                     Sucursal sucursal = sucursalService.findById(sucursalId).orElse(null);
@@ -417,7 +384,7 @@ public class ProductoService extends CrudService<Producto, ProductoRepository, L
                         String nombreSucursal = sucursal.getNombre().length() > 35
                                 ? sucursal.getNombre().substring(0, 32) + "..."
                                 : sucursal.getNombre();
-                        filtroStock.append(" (").append(nombreSucursal).append(")");
+                        filtroStock.append(" (").append(nombreSucursal.toUpperCase()).append(")");
                     } else {
                         filtroStock.append(" (ID: ").append(sucursalId).append(")");
                     }
@@ -426,7 +393,7 @@ public class ProductoService extends CrudService<Producto, ProductoRepository, L
                 }
             }
         } else {
-            filtroStock.append("Stock: todos");
+            filtroStock.append("STOCK: TODOS");
         }
 
         // Crear la lista de DTOs para el reporte
@@ -509,12 +476,14 @@ public class ProductoService extends CrudService<Producto, ProductoRepository, L
             // Usuario actual - usar el parámetro recibido
             parameters.put("usuario", usuario != null ? usuario : "Usuario del Sistema");
 
-            // Filtro de búsqueda y filtros en columnas
+            // Filtro de búsqueda y filtros individuales
             parameters.put("filtroBusqueda", filtroBusqueda.toString());
-            parameters.put("filtroColumna1", filtroColumna1.toString());
-            parameters.put("filtroColumna2", filtroColumna2.toString());
-            parameters.put("filtroColumna3", filtroColumna3.toString());
-            parameters.put("filtroColumna4", filtroColumna4.toString());
+            parameters.put("filtroEstado", filtroEstado);
+            parameters.put("filtroPesable", filtroPesable);
+            parameters.put("filtroMovStock", filtroMovStock);
+            parameters.put("filtroCostoCero", filtroCostoCero);
+            parameters.put("filtroVencimiento", filtroVencimiento);
+            parameters.put("filtroSubfamilia", filtroSubfamiliaStr);
             parameters.put("filtroStock", filtroStock.toString());
 
             // Total de productos encontrados

--- a/src/main/resources/reports/productos.jrxml
+++ b/src/main/resources/reports/productos.jrxml
@@ -1,267 +1,267 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.17.0.final using JasperReports Library version 6.17.0-6d93193241dd8cc42629e188b94f9e0bc5722efd  -->
+<!-- Created with Jaspersoft Studio version 6.21.5.final using JasperReports Library version 6.21.5-74d586df47b25dbd05bd0957999819196e59934a  -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="productos" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="4eedbb89-b4f6-4469-9ab6-f642a1688cf7">
-    <property name="com.jaspersoft.studio.data.defaultdataadapter" value="One Empty Record"/>
-    
-    <!-- Parámetros del reporte -->
-    <parameter name="logo" class="java.lang.String"/>
-    <parameter name="fechaReporte" class="java.lang.String"/>
-    <parameter name="usuario" class="java.lang.String"/>
-    <parameter name="filtroBusqueda" class="java.lang.String"/>
-    <parameter name="filtroColumna1" class="java.lang.String"/>
-    <parameter name="filtroColumna2" class="java.lang.String"/>
-    <parameter name="filtroColumna3" class="java.lang.String"/>
-    <parameter name="filtroColumna4" class="java.lang.String"/>
-    <parameter name="filtroStock" class="java.lang.String"/>
-    <parameter name="totalProductos" class="java.lang.Integer"/>
-    
-    <!-- Campos de datos -->
-    <field name="id" class="java.lang.Long"/>
-    <field name="descripcion" class="java.lang.String"/>
-    <field name="cantidad" class="java.lang.Double"/>
-    <field name="codigoPrincipal" class="java.lang.String"/>
-    <field name="precioCosto" class="java.lang.Double"/>
-    <field name="precioVenta" class="java.lang.Double"/>
-    
-    <title>
-        <band height="76" splitType="Stretch">
-            <!-- Logo de la empresa -->
-            <image hAlign="Center">
-                <reportElement x="0" y="0" width="120" height="69" uuid="94883631-a913-43e2-b182-ab8d77d0181e"/>
-                <imageExpression><![CDATA[$P{logo}]]></imageExpression>
-            </image>
-            
-            <!-- Título del reporte -->
-            <staticText>
-                <reportElement x="150" y="2" width="300" height="18" uuid="c0c9f5b8-f0b7-4503-9428-2d7be98aa4e6"/>
-                <textElement textAlignment="Center">
-                    <font fontName="SansSerif" size="14" isBold="true"/>
-                </textElement>
-                <text><![CDATA[Reporte de Productos]]></text>
-            </staticText>
-            
-            <!-- Filtro de búsqueda - Línea superior completa -->
-            <textField isStretchWithOverflow="true">
-                <reportElement x="130" y="27" width="415" height="10" uuid="f2a3b4c5-d6e7-8901-2345-678901bcdef2"/>
-                <textElement>
-                    <font fontName="SansSerif" size="10" isBold="true"/>
-                </textElement>
-                <textFieldExpression><![CDATA[$P{filtroBusqueda}]]></textFieldExpression>
-            </textField>
-            
-            <!-- Filtros en 4 columnas - Segunda fila -->
-            <textField isStretchWithOverflow="true">
-                <reportElement x="130" y="42" width="100" height="12" uuid="a1b2c3d4-e5f6-7890-1234-567890abcdef"/>
-                <textElement>
-                    <font fontName="SansSerif" size="8"/>
-                </textElement>
-                <textFieldExpression><![CDATA[$P{filtroColumna1}]]></textFieldExpression>
-            </textField>
-            
-            <textField isStretchWithOverflow="true">
-                <reportElement x="202" y="42" width="100" height="12" uuid="b2c3d4e5-f6a7-8901-2345-678901bcdef0"/>
-                <textElement>
-                    <font fontName="SansSerif" size="8"/>
-                </textElement>
-                <textFieldExpression><![CDATA[$P{filtroColumna2}]]></textFieldExpression>
-            </textField>
-            
-            <textField isStretchWithOverflow="true">
-                <reportElement x="290" y="42" width="112" height="12" uuid="c3d4e5f6-a7b8-9012-3456-789012cdef01"/>
-                <textElement>
-                    <font fontName="SansSerif" size="8"/>
-                </textElement>
-                <textFieldExpression><![CDATA[$P{filtroColumna3}]]></textFieldExpression>
-            </textField>
-            
-            <!-- Segundo filtro en la columna 3 (subfamilia debajo de vencimiento) -->
-            <textField isStretchWithOverflow="true">
-                <reportElement x="290" y="51" width="112" height="12" uuid="f4e5d6c7-a8b9-0123-4567-890123abcdef"/>
-                <textElement>
-                    <font fontName="SansSerif" size="8"/>
-                </textElement>
-                <textFieldExpression><![CDATA[$P{filtroColumna4}]]></textFieldExpression>
-            </textField>
-            
-            <textField isStretchWithOverflow="true">
-                <reportElement x="384" y="42" width="156" height="12" uuid="d4e5f6a7-b8c9-0123-4567-890123def012"/>
-                <textElement>
-                    <font fontName="SansSerif" size="8"/>
-                </textElement>
-                <textFieldExpression><![CDATA[$P{filtroStock}]]></textFieldExpression>
-            </textField>
-            
-            <!-- Información del reporte - Debajo del recuadro -->
-            <staticText>
-                <reportElement x="130" y="60" width="70" height="14" uuid="4c91f639-4e4b-4bb2-965f-156eaed3a91c"/>
-                <textElement>
-                    <font fontName="SansSerif" size="8"/>
-                </textElement>
-                <text><![CDATA[Creado en:]]></text>
-            </staticText>
-            
-            <textField>
-                <reportElement x="200" y="60" width="90" height="14" uuid="7e8c778b-0e6c-4e04-a4c7-de5b9f3403f6"/>
-                <textElement>
-                    <font fontName="SansSerif" size="8"/>
-                </textElement>
-                <textFieldExpression><![CDATA[$P{fechaReporte}]]></textFieldExpression>
-            </textField>
-            
-            <staticText>
-                <reportElement x="290" y="60" width="50" height="14" uuid="186428af-f5d4-4389-8c9b-cadb45c47034"/>
-                <textElement>
-                    <font fontName="SansSerif" size="8"/>
-                </textElement>
-                <text><![CDATA[Usuario:]]></text>
-            </staticText>
-            
-            <textField>
-                <reportElement x="340" y="60" width="100" height="14" uuid="09ce4efd-2860-4013-b158-a83a2fdcc811"/>
-                <textElement>
-                    <font fontName="SansSerif" size="8"/>
-                </textElement>
-                <textFieldExpression><![CDATA[$P{usuario}]]></textFieldExpression>
-            </textField>
-            
-            <!-- Total de productos -->
-            <staticText>
-                <reportElement x="450" y="60" width="70" height="14" uuid="b61efa33-0ea0-4fed-9d78-a768de817cb3"/>
-                <textElement>
-                    <font fontName="SansSerif" size="8"/>
-                </textElement>
-                <text><![CDATA[Cantidad total:]]></text>
-            </staticText>
-            
-            <textField>
-                <reportElement x="520" y="60" width="30" height="14" uuid="379411ab-dcc4-4b01-8c84-9d828909f10a"/>
-                <textElement>
-                    <font fontName="SansSerif" size="8" isBold="true"/>
-                </textElement>
-                <textFieldExpression><![CDATA[$P{totalProductos}]]></textFieldExpression>
-            </textField>
-            
-        </band>
-    </title>
-    
-    <columnHeader>
-        <band height="20">
-            <!-- Fondo del header -->
-            <rectangle>
-                <reportElement x="0" y="0" width="555" height="18" forecolor="#9E9E9E" backcolor="#EDEDED" uuid="3006dae7-3228-4979-bda4-adc9f14e4ac7"/>
-            </rectangle>
-            
-            <!-- Headers de columnas -->
-            <staticText>
-                <reportElement x="5" y="2" width="40" height="15" uuid="08dc1fb0-906c-4084-8135-fb291fb2a7c4"/>
-                <textElement textAlignment="Center">
-                    <font fontName="SansSerif" size="10" isBold="true"/>
-                </textElement>
-                <text><![CDATA[ID]]></text>
-            </staticText>
-            
-            <staticText>
-                <reportElement x="50" y="2" width="180" height="15" uuid="61b9db21-b68f-456d-a027-5b8a5fa7752a"/>
-                <textElement textAlignment="Left">
-                    <font fontName="SansSerif" size="10" isBold="true"/>
-                </textElement>
-                <text><![CDATA[Descripción]]></text>
-            </staticText>
-            
-            <staticText>
-                <reportElement x="235" y="2" width="60" height="15" uuid="4ca7cd51-a227-419c-9ba8-9f7386c52e03"/>
-                <textElement textAlignment="Center">
-                    <font fontName="SansSerif" size="10" isBold="true"/>
-                </textElement>
-                <text><![CDATA[Cantidad]]></text>
-            </staticText>
-
-            <staticText>
-                <reportElement x="300" y="2" width="80" height="15" uuid="8d7bc123-4567-8901-2345-6789abcdef01"/>
-                <textElement textAlignment="Center">
-                    <font fontName="SansSerif" size="10" isBold="true"/>
-                </textElement>
-                <text><![CDATA[Código]]></text>
-            </staticText>
-            
-            <staticText>
-                <reportElement x="385" y="2" width="70" height="15" uuid="ae2f5ab0-6c66-490d-849d-3d1e68574946"/>
-                <textElement textAlignment="Center">
-                    <font fontName="SansSerif" size="10" isBold="true"/>
-                </textElement>
-                <text><![CDATA[Costo Medio]]></text>
-            </staticText>
-            
-            <staticText>
-                <reportElement x="460" y="2" width="80" height="15" uuid="418ff70c-c807-4714-b37f-c153978430c1"/>
-                <textElement textAlignment="Center">
-                    <font fontName="SansSerif" size="10" isBold="true"/>
-                </textElement>
-                <text><![CDATA[Precio Venta]]></text>
-            </staticText>
-        </band>
-    </columnHeader>
-    
-    <detail>
-        <band height="18">
-            <!-- ID -->
-            <textField>
-                <reportElement x="5" y="1" width="40" height="15" uuid="b1abaa13-7b48-4130-859a-eeeaacbc0cf6"/>
-                <textElement textAlignment="Center">
-                    <font fontName="SansSerif" size="9"/>
-                </textElement>
-                <textFieldExpression><![CDATA[$F{id}]]></textFieldExpression>
-            </textField>
-            
-            <!-- Descripción -->
-            <textField>
-                <reportElement x="50" y="1" width="180" height="15" uuid="1edb9846-46a2-4dc9-9a9d-9d3be5113abd"/>
-                <textElement textAlignment="Left">
-                    <font fontName="SansSerif" size="9"/>
-                </textElement>
-                <textFieldExpression><![CDATA[$F{descripcion}]]></textFieldExpression>
-            </textField>
-            
-            <!-- Cantidad -->
-            <textField pattern="#,##0.##">
-                <reportElement x="235" y="1" width="60" height="15" uuid="2f9144d6-83b8-4f1f-acf7-24d09ab3ce73"/>
-                <textElement textAlignment="Center">
-                    <font fontName="SansSerif" size="9"/>
-                </textElement>
-                <textFieldExpression><![CDATA[$F{cantidad}]]></textFieldExpression>
-            </textField>
-
-            <!-- Código Principal -->
-            <textField>
-                <reportElement x="300" y="1" width="80" height="15" uuid="9a8b7c6d-5e4f-3210-9876-543210fedcba"/>
-                <textElement textAlignment="Center">
-                    <font fontName="SansSerif" size="9"/>
-                </textElement>
-                <textFieldExpression><![CDATA[$F{codigoPrincipal}]]></textFieldExpression>
-            </textField>
-            
-            <!-- Costo Medio -->
-            <textField pattern="#,##0">
-                <reportElement x="385" y="1" width="70" height="15" uuid="8fb71000-51f6-46e1-bb3f-48fa3024a081"/>
-                <textElement textAlignment="Center">
-                    <font fontName="SansSerif" size="9"/>
-                </textElement>
-                <textFieldExpression><![CDATA[$F{precioCosto}]]></textFieldExpression>
-            </textField>
-            
-            <!-- Precio Venta -->
-            <textField pattern="#,##0">
-                <reportElement x="460" y="1" width="80" height="15" uuid="16091ed4-b9c8-4869-94d0-c0732c680193"/>
-                <textElement textAlignment="Center">
-                    <font fontName="SansSerif" size="9"/>
-                </textElement>
-                <textFieldExpression><![CDATA[$F{precioVenta}]]></textFieldExpression>
-            </textField>
-            
-            <!-- Línea separadora entre filas -->
-            <line>
-                <reportElement x="0" y="16" width="555" height="1" forecolor="#E0E0E0" uuid="4ec0e0b5-8031-4e33-8c82-3efd769d8371"/>
-            </line>
-        </band>
-    </detail>
+	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="One Empty Record"/>
+	<parameter name="logo" class="java.lang.String"/>
+	<parameter name="fechaReporte" class="java.lang.String"/>
+	<parameter name="usuario" class="java.lang.String"/>
+	<parameter name="filtroBusqueda" class="java.lang.String"/>
+	<parameter name="filtroEstado" class="java.lang.String"/>
+	<parameter name="filtroPesable" class="java.lang.String"/>
+	<parameter name="filtroMovStock" class="java.lang.String"/>
+	<parameter name="filtroCostoCero" class="java.lang.String"/>
+	<parameter name="filtroVencimiento" class="java.lang.String"/>
+	<parameter name="filtroSubfamilia" class="java.lang.String"/>
+	<parameter name="filtroStock" class="java.lang.String"/>
+	<parameter name="totalProductos" class="java.lang.Integer"/>
+	<field name="id" class="java.lang.Long"/>
+	<field name="descripcion" class="java.lang.String"/>
+	<field name="cantidad" class="java.lang.Double"/>
+	<field name="codigoPrincipal" class="java.lang.String"/>
+	<field name="precioCosto" class="java.lang.Double"/>
+	<field name="precioVenta" class="java.lang.Double"/>
+	<variable name="costoTotalGeneral" class="java.lang.Double" calculation="Sum">
+		<variableExpression><![CDATA[$F{precioCosto} * $F{cantidad}]]></variableExpression>
+	</variable>
+	<title>
+		<band height="95" splitType="Stretch">
+			<image hAlign="Center">
+				<reportElement x="0" y="13" width="120" height="69" uuid="94883631-a913-43e2-b182-ab8d77d0181e"/>
+				<imageExpression><![CDATA[$P{logo}]]></imageExpression>
+			</image>
+			<staticText>
+				<reportElement x="150" y="2" width="300" height="25" uuid="c0c9f5b8-f0b7-4503-9428-2d7be98aa4e6"/>
+				<textElement textAlignment="Center">
+					<font fontName="SansSerif" size="14" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Reporte de Productos]]></text>
+			</staticText>
+			<textField textAdjust="StretchHeight">
+				<reportElement x="130" y="25" width="415" height="10" uuid="f2a3b4c5-d6e7-8901-2345-678901bcdef2"/>
+				<textElement>
+					<font fontName="SansSerif" size="10" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroBusqueda}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight">
+				<reportElement x="130" y="38" width="110" height="11" uuid="a1b2c3d4-e5f6-7890-1234-567890abcdef"/>
+				<textElement>
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroEstado}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight">
+				<reportElement x="245" y="38" width="110" height="11" uuid="b2c3d4e5-f6a7-8901-2345-678901bcdef0"/>
+				<textElement>
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroMovStock}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight">
+				<reportElement x="360" y="38" width="110" height="11" uuid="c3d4e5f6-a7b8-9012-3456-789012cdef01"/>
+				<textElement>
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroVencimiento}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight">
+				<reportElement x="130" y="51" width="110" height="11" uuid="d1e2f3a4-b5c6-7890-1234-567890abcdef"/>
+				<textElement>
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroPesable}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight">
+				<reportElement x="245" y="51" width="110" height="11" uuid="e1f2a3b4-c5d6-7890-1234-567890abcdef"/>
+				<textElement>
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroCostoCero}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight">
+				<reportElement x="360" y="51" width="190" height="11" uuid="f1a2b3c4-d5e6-7890-1234-567890abcdef"/>
+				<textElement>
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroSubfamilia}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight">
+				<reportElement x="130" y="64" width="305" height="11" uuid="d4e5f6a7-b8c9-0123-4567-890123def012"/>
+				<textElement>
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroStock}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="130" y="78" width="60" height="14" uuid="4c91f639-4e4b-4bb2-965f-156eaed3a91c"/>
+				<textElement>
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<text><![CDATA[CREADO EN:]]></text>
+			</staticText>
+			<textField>
+				<reportElement x="190" y="78" width="90" height="14" uuid="7e8c778b-0e6c-4e04-a4c7-de5b9f3403f6"/>
+				<textElement>
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{fechaReporte}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="280" y="78" width="40" height="14" uuid="186428af-f5d4-4389-8c9b-cadb45c47034"/>
+				<textElement>
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<text><![CDATA[USUARIO:]]></text>
+			</staticText>
+			<textField>
+				<reportElement x="320" y="78" width="115" height="14" uuid="09ce4efd-2860-4013-b158-a83a2fdcc811"/>
+				<textElement>
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{usuario}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="440" y="64" width="60" height="11" uuid="b61efa33-0ea0-4fed-9d78-a768de817cb3"/>
+				<textElement>
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<text><![CDATA[CANT. TOTAL:]]></text>
+			</staticText>
+			<textField>
+				<reportElement x="500" y="64" width="50" height="11" uuid="379411ab-dcc4-4b01-8c84-9d828909f10a"/>
+				<textElement textAlignment="Right">
+					<font fontName="SansSerif" size="8" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{totalProductos}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="440" y="78" width="60" height="14" uuid="f5a8f731-af8c-4cf6-857e-8acf6841bab1"/>
+				<textElement>
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<text><![CDATA[COSTO TOTAL:]]></text>
+			</staticText>
+			<textField evaluationTime="Report" pattern="#,##0">
+				<reportElement x="500" y="78" width="50" height="14" uuid="a1b2c3d4-e5f6-7890-1234-567890abcdef">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Right" verticalAlignment="Top">
+					<font fontName="SansSerif" size="8" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$V{costoTotalGeneral}]]></textFieldExpression>
+			</textField>
+		</band>
+	</title>
+	<columnHeader>
+		<band height="20">
+			<rectangle>
+				<reportElement x="0" y="0" width="555" height="18" forecolor="#9E9E9E" backcolor="#EDEDED" uuid="3006dae7-3228-4979-bda4-adc9f14e4ac7"/>
+			</rectangle>
+			<staticText>
+				<reportElement x="5" y="2" width="35" height="15" uuid="08dc1fb0-906c-4084-8135-fb291fb2a7c4"/>
+				<textElement textAlignment="Center">
+					<font fontName="SansSerif" size="10" isBold="true"/>
+				</textElement>
+				<text><![CDATA[ID]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="45" y="2" width="150" height="15" uuid="61b9db21-b68f-456d-a027-5b8a5fa7752a"/>
+				<textElement textAlignment="Left">
+					<font fontName="SansSerif" size="10" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Descripción]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="200" y="2" width="50" height="15" uuid="4ca7cd51-a227-419c-9ba8-9f7386c52e03"/>
+				<textElement textAlignment="Center">
+					<font fontName="SansSerif" size="10" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Cantidad]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="255" y="2" width="75" height="15" uuid="8d7bc123-4567-8901-2345-6789abcdef01"/>
+				<textElement textAlignment="Center">
+					<font fontName="SansSerif" size="10" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Código]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="335" y="2" width="65" height="15" uuid="ae2f5ab0-6c66-490d-849d-3d1e68574946"/>
+				<textElement textAlignment="Center">
+					<font fontName="SansSerif" size="10" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Costo Medio]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="405" y="2" width="75" height="15" uuid="7fb81000-51f6-46e1-bb3f-48fa3024a082"/>
+				<textElement textAlignment="Center">
+					<font fontName="SansSerif" size="10" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Costo Total]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="485" y="2" width="65" height="15" uuid="418ff70c-c807-4714-b37f-c153978430c1"/>
+				<textElement textAlignment="Center">
+					<font fontName="SansSerif" size="10" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Precio Venta]]></text>
+			</staticText>
+		</band>
+	</columnHeader>
+	<detail>
+		<band height="18">
+			<textField>
+				<reportElement x="5" y="1" width="35" height="15" uuid="b1abaa13-7b48-4130-859a-eeeaacbc0cf6"/>
+				<textElement textAlignment="Center">
+					<font fontName="SansSerif" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{id}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="45" y="1" width="150" height="15" uuid="1edb9846-46a2-4dc9-9a9d-9d3be5113abd"/>
+				<textElement textAlignment="Left">
+					<font fontName="SansSerif" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{descripcion}]]></textFieldExpression>
+			</textField>
+			<textField pattern="#,##0.##">
+				<reportElement x="200" y="1" width="50" height="15" uuid="2f9144d6-83b8-4f1f-acf7-24d09ab3ce73"/>
+				<textElement textAlignment="Center">
+					<font fontName="SansSerif" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{cantidad}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="255" y="1" width="75" height="15" uuid="9a8b7c6d-5e4f-3210-9876-543210fedcba"/>
+				<textElement textAlignment="Center">
+					<font fontName="SansSerif" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{codigoPrincipal}]]></textFieldExpression>
+			</textField>
+			<textField pattern="#,##0">
+				<reportElement x="335" y="1" width="65" height="15" uuid="8fb71000-51f6-46e1-bb3f-48fa3024a081"/>
+				<textElement textAlignment="Center">
+					<font fontName="SansSerif" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{precioCosto}]]></textFieldExpression>
+			</textField>
+			<textField pattern="#,##0">
+				<reportElement x="405" y="1" width="75" height="15" uuid="8fb81000-51f6-46e1-bb3f-48fa3024a082"/>
+				<textElement textAlignment="Center">
+					<font fontName="SansSerif" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{precioCosto} * $F{cantidad}]]></textFieldExpression>
+			</textField>
+			<textField pattern="#,##0">
+				<reportElement x="485" y="1" width="65" height="15" uuid="16091ed4-b9c8-4869-94d0-c0732c680193"/>
+				<textElement textAlignment="Center">
+					<font fontName="SansSerif" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{precioVenta}]]></textFieldExpression>
+			</textField>
+			<line>
+				<reportElement x="0" y="16" width="555" height="1" forecolor="#E0E0E0" uuid="4ec0e0b5-8031-4e33-8c82-3efd769d8371"/>
+			</line>
+		</band>
+	</detail>
 </jasperReport>


### PR DESCRIPTION
### Qué resuelve 
Se ha mejorado integralmente el reporte de productos para proporcionar informacion financiera mas detallada y una mejor experiencia de lectura. Los cambios principales incluyen:

1. Implementacion de una columna de costo total por producto (cantidad multiplicada por costo medio).
2. Adicion de un resumen de costo total general en el encabezado del reporte, permitiendo ver el valor total del inventario filtrado de forma inmediata.
3. Reorganizacion de la seccion de filtros, separando los campos que antes estaban agrupados en columnas genericas en parametros individuales e independientes.
4. Estandarizacion visual mediante la conversion de todas las etiquetas de filtros, etiquetas de encabezado y terminos de busqueda a mayusculas.
5. Correccion de la logica de evaluacion del reporte para asegurar que el total general se calcule correctamente antes de ser mostrado en el encabezado.

### Cómo usarlo

1. Acceder al modulo de productos en el frontend.
2. Aplicar los filtros deseados (Estado, Pesable, Movimiento de Stock, etc.).
3. Generar el reporte de productos.
4. Verificar en el documento PDF resultante que:
5. Los filtros aplicados aparezcan en mayusculas y bien organizados en el encabezado.
6. El campo COSTO TOTAL aparezca al lado de CANT. TOTAL en la parte superior.
7. Cada fila de producto incluya su calculo de costo total.
8. El diseño se mantenga alineado y legible con los nuevos anchos de columna.

### Impacto DB 
**No aplica**. Los cambios se realizaron exclusivamente en la logica de generacion de reportes (JasperReports) y en la capa de servicios del backend.

### Riesgo 
**Bajo**. Los cambios afectan unicamente a la representacion visual y logica de calculo dentro del reporte, sin alterar procesos de persistencia o integridad de datos.