### PR TITLE
feat(productos): add filtro de familia en list-productos

### DIFF
--- a/src/main/java/com/franco/dev/graphql/productos/ProductoGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/productos/ProductoGraphQL.java
@@ -112,7 +112,7 @@ public class ProductoGraphQL implements GraphQLQueryResolver, GraphQLMutationRes
     }
 
     public Page<Producto> searchProductoWithFilters(String texto, String codigo, Boolean activo, Boolean stock,
-            Boolean balanza, Long subfamilia, Boolean vencimiento, Boolean costoCero, String stockFiltro,
+            Boolean balanza, Long familia, Long subfamilia, Boolean vencimiento, Boolean costoCero, String stockFiltro,
             Long sucursalId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
 
@@ -133,7 +133,7 @@ public class ProductoGraphQL implements GraphQLQueryResolver, GraphQLMutationRes
         }
 
         texto = texto != null ? texto.replace(" ", "%").toUpperCase() : "";
-        return service.findWithFilters(texto, activo, stock, balanza, subfamilia, vencimiento, costoCero, stockFiltro,
+        return service.findWithFilters(texto, activo, stock, balanza, subfamilia, familia, vencimiento, costoCero, stockFiltro,
                 sucursalId, pageable);
     }
 
@@ -211,6 +211,7 @@ public class ProductoGraphQL implements GraphQLQueryResolver, GraphQLMutationRes
             Boolean balanza,
             Boolean vencimiento,
             Boolean costoCero,
+            Long familiaId,
             Long subfamiliaId,
             String stockFiltro,
             Long sucursalId,
@@ -218,7 +219,7 @@ public class ProductoGraphQL implements GraphQLQueryResolver, GraphQLMutationRes
             String usuario) throws FileNotFoundException {
         return service.exportarReporteConFiltros(
                 texto, codigo, activo, stock, balanza, vencimiento,
-                costoCero, subfamiliaId, stockFiltro, sucursalId, usuarioId, usuario);
+                costoCero, subfamiliaId, familiaId, stockFiltro, sucursalId, usuarioId, usuario);
     }
 
     public List<Producto> findByPdvGrupoProducto(Long id) {

--- a/src/main/java/com/franco/dev/repository/productos/ProductoRepository.java
+++ b/src/main/java/com/franco/dev/repository/productos/ProductoRepository.java
@@ -169,7 +169,6 @@ public interface ProductoRepository extends HelperRepository<Producto, Long> {
                         @Param("filtrarProducto") Boolean filtrarProducto);
 
         @Query("select distinct p from Producto p " +
-                        "join p.subfamilia sub " +
                         "left join Presentacion pres on pres.producto.id = p.id " +
                         "left join Codigo cod on cod.presentacion.id = pres.id " +
                         "where  (CAST(p.id as string) like CONCAT('%', :texto, '%') or UPPER(p.descripcion) like CONCAT('%', UPPER(:texto), '%') "
@@ -179,7 +178,9 @@ public interface ProductoRepository extends HelperRepository<Producto, Long> {
                         "and ((:stock) is null or p.stock = :stock) " +
                         "and ((:balanza) is null or p.balanza = :balanza) " +
                         "and ((:vencimiento) is null or p.vencimiento = :vencimiento) " +
-                        "and ((:subfamiliaId) is null or sub.id = :subfamiliaId) " +
+                        "and ((:subfamiliaId) is null or p.subfamilia.id = :subfamiliaId) " +
+                        "and ((:familiaId) is null or p.subfamilia.id IN " +
+                        "     (SELECT sf.id FROM Subfamilia sf WHERE sf.familia.id = :familiaId)) " +
                         "and ((:costoCero) is null or " +
                         "     ((:costoCero) = true and (p.id IN (SELECT c1.producto.id FROM CostoPorProducto c1 " +
                         "WHERE (c1.costoMedio = 0 OR c1.costoMedio IS NULL) AND c1.creadoEn = (SELECT MAX(c2.creadoEn) "
@@ -207,6 +208,7 @@ public interface ProductoRepository extends HelperRepository<Producto, Long> {
                         @Param("stock") Boolean stock,
                         @Param("balanza") Boolean balanza,
                         @Param("subfamiliaId") Long subfamiliaId,
+                        @Param("familiaId") Long familiaId,
                         @Param("vencimiento") Boolean vencimiento,
                         @Param("costoCero") Boolean costoCero,
                         @Param("stockFiltro") String stockFiltro,

--- a/src/main/java/com/franco/dev/service/productos/ProductoService.java
+++ b/src/main/java/com/franco/dev/service/productos/ProductoService.java
@@ -5,6 +5,7 @@ import com.franco.dev.domain.dto.ProductoReportDto;
 import com.franco.dev.domain.operaciones.dto.LucroPorProductosDto;
 import com.franco.dev.domain.productos.Codigo;
 import com.franco.dev.domain.productos.CostoPorProducto;
+import com.franco.dev.domain.productos.Familia;
 import com.franco.dev.domain.productos.PrecioPorSucursal;
 import com.franco.dev.domain.productos.Presentacion;
 import com.franco.dev.domain.productos.Producto;
@@ -52,6 +53,8 @@ public class ProductoService extends CrudService<Producto, ProductoRepository, L
     private final UsuarioService usuarioService;
     @Autowired
     private final SubFamiliaService subFamiliaService;
+    @Autowired
+    private final FamiliaService familiaService;
     @Autowired
     private final MovimientoStockService movimientoStockService;
     @Autowired
@@ -111,9 +114,9 @@ public class ProductoService extends CrudService<Producto, ProductoRepository, L
     }
 
     public Page<Producto> findWithFilters(String texto, Boolean activo, Boolean stock, Boolean balanza,
-            Long subfamiliaId, Boolean vencimiento, Boolean costoCero, String stockFiltro, Long sucursalId,
+            Long subfamiliaId, Long familiaId, Boolean vencimiento, Boolean costoCero, String stockFiltro, Long sucursalId,
             Pageable page) {
-        return repository.searchWithFilters(texto, activo, stock, balanza, subfamiliaId, vencimiento, costoCero,
+        return repository.searchWithFilters(texto, activo, stock, balanza, subfamiliaId, familiaId, vencimiento, costoCero,
                 stockFiltro, sucursalId, page);
     }
 
@@ -316,6 +319,7 @@ public class ProductoService extends CrudService<Producto, ProductoRepository, L
             Boolean vencimiento,
             Boolean costoCero,
             Long subfamiliaId,
+            Long familiaId,
             String stockFiltro,
             Long sucursalId,
             Long usuarioId,
@@ -328,6 +332,7 @@ public class ProductoService extends CrudService<Producto, ProductoRepository, L
                 stock,
                 balanza,
                 subfamiliaId,
+                familiaId,
                 vencimiento,
                 costoCero,
                 stockFiltro,
@@ -369,6 +374,23 @@ public class ProductoService extends CrudService<Producto, ProductoRepository, L
                 }
             } catch (Exception e) {
                 filtroSubfamiliaStr = "SUBFAMILIA ID: " + subfamiliaId;
+            }
+        }
+
+        String filtroFamiliaStr = "FAMILIA: TODOS";
+        if (familiaId != null) {
+            try {
+                Familia familia = familiaService.findById(familiaId).orElse(null);
+                if (familia != null) {
+                    String nombreCorto = familia.getNombre().length() > 35
+                            ? familia.getNombre().substring(0, 32) + "..."
+                            : familia.getNombre();
+                    filtroFamiliaStr = "FAMILIA: " + nombreCorto.toUpperCase();
+                } else {
+                    filtroFamiliaStr = "FAMILIA ID: " + familiaId;
+                }
+            } catch (Exception e) {
+                filtroFamiliaStr = "FAMILIA ID: " + familiaId;
             }
         }
 
@@ -484,6 +506,7 @@ public class ProductoService extends CrudService<Producto, ProductoRepository, L
             parameters.put("filtroCostoCero", filtroCostoCero);
             parameters.put("filtroVencimiento", filtroVencimiento);
             parameters.put("filtroSubfamilia", filtroSubfamiliaStr);
+            parameters.put("filtroFamilia", filtroFamiliaStr);
             parameters.put("filtroStock", filtroStock.toString());
 
             // Total de productos encontrados

--- a/src/main/resources/graphql/productos/producto/productos.graphqls
+++ b/src/main/resources/graphql/productos/producto/productos.graphqls
@@ -87,11 +87,11 @@ extend type Query {
     productoPorCodigo(texto:String):Producto
     printProducto(id: ID!):Producto
     exportarReporte(texto: String): String
-    exportarReporteConFiltros(texto: String, codigo: Boolean, activo: Boolean, stock: Boolean, balanza: Boolean, vencimiento: Boolean, costoCero: Boolean, subfamiliaId: ID, stockFiltro: String, sucursalId: ID, usuarioId: ID, usuario: String): String
+    exportarReporteConFiltros(texto: String, codigo: Boolean, activo: Boolean, stock: Boolean, balanza: Boolean, vencimiento: Boolean, costoCero: Boolean, familiaId: Int, subfamiliaId: ID, stockFiltro: String, sucursalId: ID, usuarioId: ID, usuario: String): String
     lucroPorProducto(fechaInicio: String, fechaFin: String, sucursalIdList: [Int], usuarioId: ID!, usuarioIdList:[ID], productoIdList:[ID], subfamiliaId: ID): String
     lucroPorProductoList(fechaInicio: String, fechaFin: String, sucursalIdList: [ID], usuarioIdList: [ID], productoIdList: [ID], subfamiliaId: ID, page: Int, size: Int): LucroPorProductoResponse
     imprimirCodigoBarra(codigoId: Int): Boolean
-    searchProductoWithFilters(texto: String, codigo: String, activo: Boolean, stock: Boolean, balanza: Boolean, subfamilia: Int, vencimiento: Boolean, costoCero: Boolean, stockFiltro: String, sucursalId: Int, page: Int, size: Int):ProductoPage
+    searchProductoWithFilters(texto: String, codigo: String, activo: Boolean, stock: Boolean, balanza: Boolean, familia: Int, subfamilia: Int, vencimiento: Boolean, costoCero: Boolean, stockFiltro: String, sucursalId: Int, page: Int, size: Int):ProductoPage
     productoDescripcionExists(descripcion: String): Boolean
 }
 

--- a/src/main/resources/reports/productos.jrxml
+++ b/src/main/resources/reports/productos.jrxml
@@ -12,6 +12,7 @@
 	<parameter name="filtroCostoCero" class="java.lang.String"/>
 	<parameter name="filtroVencimiento" class="java.lang.String"/>
 	<parameter name="filtroSubfamilia" class="java.lang.String"/>
+	<parameter name="filtroFamilia" class="java.lang.String"/>
 	<parameter name="filtroStock" class="java.lang.String"/>
 	<parameter name="totalProductos" class="java.lang.Integer"/>
 	<field name="id" class="java.lang.Long"/>
@@ -24,7 +25,7 @@
 		<variableExpression><![CDATA[$F{precioCosto} * $F{cantidad}]]></variableExpression>
 	</variable>
 	<title>
-		<band height="95" splitType="Stretch">
+		<band height="110" splitType="Stretch">
 			<image hAlign="Center">
 				<reportElement x="0" y="13" width="120" height="69" uuid="94883631-a913-43e2-b182-ab8d77d0181e"/>
 				<imageExpression><![CDATA[$P{logo}]]></imageExpression>
@@ -83,66 +84,73 @@
 				<textElement>
 					<font fontName="SansSerif" size="8"/>
 				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroFamilia}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight">
+				<reportElement x="130" y="64" width="305" height="11" uuid="e1f2a3b4-c5d6-7890-1234-567890abcdef"/>
+				<textElement>
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
 				<textFieldExpression><![CDATA[$P{filtroSubfamilia}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight">
-				<reportElement x="130" y="64" width="305" height="11" uuid="d4e5f6a7-b8c9-0123-4567-890123def012"/>
+				<reportElement x="130" y="77" width="305" height="11" uuid="d4e5f6a7-b8c9-0123-4567-890123def012"/>
 				<textElement>
 					<font fontName="SansSerif" size="8"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$P{filtroStock}]]></textFieldExpression>
 			</textField>
 			<staticText>
-				<reportElement x="130" y="78" width="60" height="14" uuid="4c91f639-4e4b-4bb2-965f-156eaed3a91c"/>
+				<reportElement x="130" y="90" width="60" height="14" uuid="4c91f639-4e4b-4bb2-965f-156eaed3a91c"/>
 				<textElement>
 					<font fontName="SansSerif" size="8"/>
 				</textElement>
 				<text><![CDATA[CREADO EN:]]></text>
 			</staticText>
 			<textField>
-				<reportElement x="190" y="78" width="90" height="14" uuid="7e8c778b-0e6c-4e04-a4c7-de5b9f3403f6"/>
+				<reportElement x="190" y="90" width="90" height="14" uuid="7e8c778b-0e6c-4e04-a4c7-de5b9f3403f6"/>
 				<textElement>
 					<font fontName="SansSerif" size="8"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$P{fechaReporte}]]></textFieldExpression>
 			</textField>
 			<staticText>
-				<reportElement x="280" y="78" width="40" height="14" uuid="186428af-f5d4-4389-8c9b-cadb45c47034"/>
+				<reportElement x="280" y="90" width="40" height="14" uuid="186428af-f5d4-4389-8c9b-cadb45c47034"/>
 				<textElement>
 					<font fontName="SansSerif" size="8"/>
 				</textElement>
 				<text><![CDATA[USUARIO:]]></text>
 			</staticText>
 			<textField>
-				<reportElement x="320" y="78" width="115" height="14" uuid="09ce4efd-2860-4013-b158-a83a2fdcc811"/>
+				<reportElement x="320" y="90" width="115" height="14" uuid="09ce4efd-2860-4013-b158-a83a2fdcc811"/>
 				<textElement>
 					<font fontName="SansSerif" size="8"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$P{usuario}]]></textFieldExpression>
 			</textField>
 			<staticText>
-				<reportElement x="440" y="64" width="60" height="11" uuid="b61efa33-0ea0-4fed-9d78-a768de817cb3"/>
+				<reportElement x="440" y="77" width="60" height="11" uuid="b61efa33-0ea0-4fed-9d78-a768de817cb3"/>
 				<textElement>
 					<font fontName="SansSerif" size="8"/>
 				</textElement>
 				<text><![CDATA[CANT. TOTAL:]]></text>
 			</staticText>
 			<textField>
-				<reportElement x="500" y="64" width="50" height="11" uuid="379411ab-dcc4-4b01-8c84-9d828909f10a"/>
+				<reportElement x="500" y="77" width="50" height="11" uuid="379411ab-dcc4-4b01-8c84-9d828909f10a"/>
 				<textElement textAlignment="Right">
 					<font fontName="SansSerif" size="8" isBold="true"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$P{totalProductos}]]></textFieldExpression>
 			</textField>
 			<staticText>
-				<reportElement x="440" y="78" width="60" height="14" uuid="f5a8f731-af8c-4cf6-857e-8acf6841bab1"/>
+				<reportElement x="440" y="90" width="60" height="14" uuid="f5a8f731-af8c-4cf6-857e-8acf6841bab1"/>
 				<textElement>
 					<font fontName="SansSerif" size="8"/>
 				</textElement>
 				<text><![CDATA[COSTO TOTAL:]]></text>
 			</staticText>
 			<textField evaluationTime="Report" pattern="#,##0">
-				<reportElement x="500" y="78" width="50" height="14" uuid="a1b2c3d4-e5f6-7890-1234-567890abcdef">
+				<reportElement x="500" y="90" width="50" height="14" uuid="a1b2c3d4-e5f6-7890-1234-567890abcdef">
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 				</reportElement>
 				<textElement textAlignment="Right" verticalAlignment="Top">


### PR DESCRIPTION
### Qué resuelve

- Corrección de filtrado y desincronización: Se solucionó un error donde los IDs de familia y subfamilia se intercambiaban en el backend al generar reportes, lo que causaba que estos aparecieran en blanco.
- Independencia de búsqueda por Subfamilia: Se modificó la lógica del diálogo de búsqueda de subfamilias para que sea versátil: permite buscar subfamilias de forma global cuando no hay una familia seleccionada, o filtrar por familia cuando esta ya ha sido elegida.
- Error de tipos en GraphQL: Se corrigió el error VariableTypeMismatch en la exportación de reportes, alineando el tipo de dato $familiaId (de ID a Int) con el esquema esperado por el servidor.
- Optimización de Interfaz (UI): Se rediseñó la fila de filtros en el listado de productos para agrupar Familia, Subfamilia, Stock y Sucursal en una sola línea, mejorando el uso del espacio y la estética del formulario.
- Control de Paginación: Se implementó el reinicio automático a la página 1 al aplicar cualquier filtro, incluyendo la sincronización visual del componente de paginación para evitar que el usuario quede en páginas inexistentes tras filtrar.
- Plantilla de Reportes (JRXML): Se actualizó el archivo productos.jrxml para incluir el campo de texto del filtro de familia en el encabezado y se ajustaron las coordenadas de los elementos para evitar solapamientos de texto en el PDF generado.

### Cómo probarlo

1. Filtrado Independiente: En el listado de productos, abrir el diálogo de subfamilia sin seleccionar una familia previa. Verificar que se puedan buscar y seleccionar subfamilias (ej. buscar "VINOS").
2. Filtrado Jerárquico: Seleccionar una familia (ej. "BEBIDAS") y luego abrir el diálogo de subfamilia. Verificar que la lista esté filtrada solo para esa familia.
3. Reinicio de Página: Navegar hasta la página 2 de cualquier resultado, cambiar un filtro (ej. elegir otra familia) y verificar que el sistema regrese automáticamente a la página 1.
4. Generación de Reporte: Aplicar filtros de familia y subfamilia, luego presionar "Generar PDF". Confirmar que el reporte se genere sin errores y que el encabezado muestre los nombres de los filtros aplicados correctamente.
5. Validación de UI: Verificar que los campos Familia, Subfamilia, Stock y Sucursal aparezcan en una sola fila con espaciados uniformes (10px).

### Impacto DB
**No aplica**. No se realizaron cambios en la estructura de las tablas ni migraciones de base de datos.

### Riesgo
**Bajo.** Los cambios se limitan a la capa de presentación, lógica de filtrado en el cliente y ajustes menores en resolvers de GraphQL y plantillas de JasperReports.