### PR TITLE
refactor(marcacion): refactorizacion-servicio-marcacion

### DIFF
--- a/src/main/java/com/franco/dev/repository/administrativo/JornadaRepository.java
+++ b/src/main/java/com/franco/dev/repository/administrativo/JornadaRepository.java
@@ -32,4 +32,12 @@ public interface JornadaRepository extends HelperRepository<Jornada, EmbebedPrim
 
     Optional<Jornada> findByMarcacionEntradaId(Long id);
 
+    @Query("SELECT j FROM Jornada j WHERE j.usuario.id = :usuarioId " +
+            "AND j.estado = 'INCOMPLETO' AND j.marcacionSalida IS NULL " +
+            "AND (j.turno IN ('NOCHE', 'MADRUGADA') " +
+            "OR (j.horaEntradaHorario IS NOT NULL AND j.horaSalidaHorario IS NOT NULL " +
+            "AND j.horaSalidaHorario < j.horaEntradaHorario)) " +
+            "ORDER BY j.fecha DESC, j.id DESC")
+    List<Jornada> findIncompletasSinSalidaNocturnasByUsuarioId(@Param("usuarioId") Long usuarioId);
+
 }

--- a/src/main/java/com/franco/dev/service/administrativo/JornadaService.java
+++ b/src/main/java/com/franco/dev/service/administrativo/JornadaService.java
@@ -41,6 +41,22 @@ public class JornadaService extends CrudService<Jornada, JornadaRepository, Embe
         return repository.findByMarcacionEntradaId(id);
     }
 
+    public Optional<Jornada> findIncompletaSinSalidaNocturnaParaSalida(Long usuarioId, java.time.LocalDate fechaSalida) {
+        List<Jornada> jornadas = repository.findIncompletasSinSalidaNocturnasByUsuarioId(usuarioId);
+        if (jornadas == null || jornadas.isEmpty()) {
+            return Optional.empty();
+        }
+        Optional<Jornada> delMismoDia = jornadas.stream()
+                .filter(j -> j.getFecha().equals(fechaSalida))
+                .findFirst();
+        if (delMismoDia.isPresent()) {
+            return delMismoDia;
+        }
+        return jornadas.stream()
+                .filter(j -> j.getFecha().isBefore(fechaSalida))
+                .findFirst();
+    }
+
     public Jornada ajustarA8Horas(Long id, Long sucursalId, String observacion) {
         Optional<Jornada> optionalJornada = repository.findById(new EmbebedPrimaryKey(id, sucursalId));
         if (optionalJornada.isPresent()) {

--- a/src/main/java/com/franco/dev/service/administrativo/MarcacionService.java
+++ b/src/main/java/com/franco/dev/service/administrativo/MarcacionService.java
@@ -1,32 +1,39 @@
 package com.franco.dev.service.administrativo;
 
+import com.franco.dev.domain.EmbebedPrimaryKey;
+import com.franco.dev.domain.administrativo.Horario;
+import com.franco.dev.domain.administrativo.Jornada;
 import com.franco.dev.domain.administrativo.Marcacion;
+import com.franco.dev.domain.administrativo.enums.TipoMarcacion;
 import com.franco.dev.repository.administrativo.MarcacionRepository;
-import com.franco.dev.repository.administrativo.HorarioRepository;
 import com.franco.dev.service.CrudService;
+import com.franco.dev.service.administrativo.helper.*;
 import lombok.AllArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import com.franco.dev.domain.administrativo.Jornada;
-import com.franco.dev.domain.administrativo.Horario;
-import com.franco.dev.domain.administrativo.enums.EstadoJornada;
-import com.franco.dev.domain.administrativo.enums.Dia;
-import com.franco.dev.domain.EmbebedPrimaryKey;
-import java.time.temporal.ChronoUnit;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
+import java.util.Optional;
 
 @Service
 @AllArgsConstructor
 public class MarcacionService extends CrudService<Marcacion, MarcacionRepository, EmbebedPrimaryKey> {
 
+    private static final Logger log = LoggerFactory.getLogger(MarcacionService.class);
+
     private final MarcacionRepository repository;
     private final JornadaService jornadaService;
-    private final com.franco.dev.service.personas.FuncionarioService funcionarioService;
-    private final HorarioRepository horarioRepository;
+    private final HorarioResolver horarioResolver;
+    private final JornadaMarcacionResolver jornadaMarcacionResolver;
+    private final TardanzaCalculator tardanzaCalculator;
+    private final HorasTrabajadasCalculator horasTrabajadasCalculator;
+    private final AlmuerzoProcessor almuerzoProcessor;
 
     @Override
     public MarcacionRepository getRepository() {
@@ -34,24 +41,20 @@ public class MarcacionService extends CrudService<Marcacion, MarcacionRepository
     }
 
     public Page<Marcacion> findAllPaged(Integer page, Integer size) {
-        Pageable pageable = PageRequest.of(page, size);
-        return repository.findAll(pageable);
+        return repository.findAll(PageRequest.of(page, size));
     }
 
     public Page<Marcacion> findByUsuarioId(Long usuarioId, Integer page, Integer size) {
-        Pageable pageable = PageRequest.of(page, size);
-        return repository.findByUsuarioId(usuarioId, pageable);
+        return repository.findByUsuarioId(usuarioId, PageRequest.of(page, size));
     }
 
     public Page<Marcacion> findByUsuarioIdAndFechaRange(Long usuarioId, String fechaInicio, String fechaFin,
             Integer page, Integer size) {
-        Pageable pageable = PageRequest.of(page, size);
-        return repository.findByUsuarioIdAndFechaRange(usuarioId, fechaInicio, fechaFin, pageable);
+        return repository.findByUsuarioIdAndFechaRange(usuarioId, fechaInicio, fechaFin, PageRequest.of(page, size));
     }
 
     public Page<Marcacion> findByFechaRange(String fechaInicio, String fechaFin, Integer page, Integer size) {
-        Pageable pageable = PageRequest.of(page, size);
-        return repository.findByFechaRange(fechaInicio, fechaFin, pageable);
+        return repository.findByFechaRange(fechaInicio, fechaFin, PageRequest.of(page, size));
     }
 
     public List<Marcacion> findBySucursalEntradaId(Long sucursalId) {
@@ -63,357 +66,92 @@ public class MarcacionService extends CrudService<Marcacion, MarcacionRepository
     }
 
     @Override
-    @org.springframework.transaction.annotation.Transactional(isolation = org.springframework.transaction.annotation.Isolation.SERIALIZABLE)
-    public Marcacion save(Marcacion entity) {
-        if (entity.getId() == null) {
-            Long lastId = repository.findMaxId(entity.getSucursalId());
-            long newId = (lastId == null ? 0L : lastId) + 1L;
-            if (newId % 2 == 0) {
-                newId++;
-            }
-            entity.setId(newId);
+    @Transactional(isolation = Isolation.SERIALIZABLE)
+    public Marcacion save(Marcacion marcacion) {
+        prepararMarcacion(marcacion);
 
-            if (entity.getFechaEntrada() == null && entity.getFechaSalida() == null) {
-                entity.setFechaEntrada(LocalDateTime.now());
+        // Guardamos el estado transiente antes de la persistencia
+        Boolean esSalidaAlmuerzo = marcacion.getEsSalidaAlmuerzo();
+
+        Marcacion marcacionGuardada = super.save(marcacion);
+
+        // Restauramos el estado transiente y dependencias
+        restaurarEstado(marcacionGuardada, marcacion, esSalidaAlmuerzo);
+
+        procesarJornada(marcacionGuardada);
+
+        return marcacionGuardada;
+    }
+
+    private void prepararMarcacion(Marcacion marcacion) {
+        if (marcacion.getId() == null) {
+            asignarNuevoId(marcacion);
+            if (marcacion.getFechaEntrada() == null && marcacion.getFechaSalida() == null) {
+                marcacion.setFechaEntrada(LocalDateTime.now());
             }
         }
 
-        if (entity.getTipo() == null) {
-            if (entity.getFechaSalida() != null) {
-                entity.setTipo(com.franco.dev.domain.administrativo.enums.TipoMarcacion.SALIDA);
-            } else {
-                entity.setTipo(com.franco.dev.domain.administrativo.enums.TipoMarcacion.ENTRADA);
-            }
+        if (marcacion.getTipo() == null) {
+            marcacion.setTipo(marcacion.getFechaSalida() != null ? TipoMarcacion.SALIDA : TipoMarcacion.ENTRADA);
         }
+    }
 
-        Boolean esSalidaAlmuerzo = entity.getEsSalidaAlmuerzo();
+    private void asignarNuevoId(Marcacion marcacion) {
+        Long lastId = repository.findMaxId(marcacion.getSucursalId());
+        long newId = (lastId == null ? 0L : lastId) + 1L;
+        if (newId % 2 == 0)
+            newId++;
+        marcacion.setId(newId);
+    }
 
-        Marcacion e = super.save(entity);
-        if (e.getUsuario() == null && entity.getUsuario() != null) {
-            e.setUsuario(entity.getUsuario());
+    private void restaurarEstado(Marcacion guardada, Marcacion original, Boolean esSalidaAlmuerzo) {
+        if (guardada.getUsuario() == null && original.getUsuario() != null) {
+            guardada.setUsuario(original.getUsuario());
         }
-
-        e.setEsSalidaAlmuerzo(esSalidaAlmuerzo);
-
-        procesarJornada(e);
-        return e;
+        guardada.setEsSalidaAlmuerzo(esSalidaAlmuerzo);
     }
 
     private void procesarJornada(Marcacion marcacion) {
         try {
             if (marcacion.getUsuario() == null || marcacion.getUsuario().getId() == null) {
+                log.warn("No se puede procesar jornada: Marcación sin usuario. ID: {}", marcacion.getId());
                 return;
             }
 
-            LocalDateTime fechaReferencia = marcacion.getFechaEntrada();
-            if (fechaReferencia == null)
-                fechaReferencia = marcacion.getFechaSalida();
-            if (fechaReferencia == null)
-                fechaReferencia = LocalDateTime.now();
+            LocalDateTime fechaReferencia = obtenerFechaReferencia(marcacion);
+            Horario horario = horarioResolver.resolver(marcacion, fechaReferencia);
+            Jornada jornada = jornadaMarcacionResolver.resolver(marcacion, fechaReferencia.toLocalDate());
 
-            int dayOfWeekValue = fechaReferencia.getDayOfWeek().getValue();
-            Dia diaSemana = Dia.values()[dayOfWeekValue];
-
-            Horario horario = null;
-
-            com.franco.dev.domain.personas.Funcionario funcionario = null;
-            if (marcacion.getUsuario() != null) {
-                if (marcacion.getUsuario().getPersona() != null) {
-                    funcionario = funcionarioService.findByPersonaId(marcacion.getUsuario().getPersona().getId());
-                } else {
-                    funcionario = funcionarioService.findByUsuarioId(marcacion.getUsuario().getId());
-                }
-            }
-
-            if (funcionario != null) {
-
-                if (funcionario.getHorario() != null) {
-                    horario = funcionario.getHorario();
-
-                    if (horario.getDias() != null && !horario.getDias().isEmpty() && diaSemana != null) {
-                        if (!horario.getDias().contains(diaSemana) && !horario.getDias().contains(Dia.TODOS)) {
-                            List<Horario> horariosUsuario = horarioRepository
-                                    .findByUsuarioIdOrderByIdDesc(marcacion.getUsuario().getId());
-                            if (horariosUsuario != null && !horariosUsuario.isEmpty()) {
-                                Horario alternativo = null;
-                                for (Horario h : horariosUsuario) {
-                                    if (h.getDias() != null
-                                            && (h.getDias().contains(diaSemana) || h.getDias().contains(Dia.TODOS))
-                                            && h.getHoraEntrada() != null) {
-                                        alternativo = h;
-                                        break;
-                                    }
-                                }
-                                if (alternativo == null) {
-                                    for (Horario h : horariosUsuario) {
-                                        if (h.getHoraEntrada() != null) {
-                                            alternativo = h;
-                                            break;
-                                        }
-                                    }
-                                }
-                                if (alternativo != null) {
-                                    horario = alternativo;
-                                }
-                            }
-                        }
-                    }
-                } else {
-
-                    horario = null;
-                }
-            } else {
-
-                if (marcacion.getUsuario() != null && diaSemana != null) {
-                    horario = horarioRepository.findByUsuarioIdAndDia(marcacion.getUsuario().getId(), diaSemana);
-                }
-            }
-
-            java.time.LocalDate fechaJornada = fechaReferencia.toLocalDate();
-
-            if (marcacion.getTipo() == com.franco.dev.domain.administrativo.enums.TipoMarcacion.SALIDA) {
-                java.time.LocalDate ayer = fechaJornada.minusDays(1);
-                List<Jornada> jornadasAyer = jornadaService.findByUsuarioIdAndFecha(
-                        marcacion.getUsuario().getId(),
-                        ayer.toString());
-                if (jornadasAyer != null && !jornadasAyer.isEmpty()) {
-                    Jornada ultimaAyer = jornadasAyer.get(jornadasAyer.size() - 1);
-
-                    if (ultimaAyer.getEstado() == EstadoJornada.INCOMPLETO) {
-                        if (ultimaAyer.getTurno() == com.franco.dev.domain.administrativo.enums.Turno.MADRUGADA) {
-                            fechaJornada = ayer;
-                        }
-                    }
-                }
-            }
-
-            List<Jornada> jornadas = jornadaService.findByUsuarioIdAndFecha(
-                    marcacion.getUsuario().getId(),
-                    fechaJornada.toString());
-
-            Jornada jornada = null;
-            if (jornadas != null && !jornadas.isEmpty()) {
-                Jornada lastJornada = jornadas.get(jornadas.size() - 1);
-                boolean crearNueva = false;
-
-                if (lastJornada.getEstado() == EstadoJornada.NORMAL || lastJornada.getMarcacionSalida() != null) {
-                    if (marcacion.getTipo() == com.franco.dev.domain.administrativo.enums.TipoMarcacion.ENTRADA
-                            || marcacion.getFechaEntrada() != null) {
-                        crearNueva = true;
-                    } else {
-                        jornada = lastJornada;
-                    }
-                } else {
-                    jornada = lastJornada;
-                }
-
-                if (crearNueva) {
-                    jornada = new Jornada();
-                    jornada.setUsuario(marcacion.getUsuario());
-                    jornada.setFecha(fechaJornada);
-                    jornada.setEstado(EstadoJornada.INCOMPLETO);
-                    jornada.setSucursalId(marcacion.getSucursalId());
-                }
-            } else {
-                jornada = new Jornada();
-                jornada.setUsuario(marcacion.getUsuario());
-                jornada.setFecha(fechaJornada);
-                jornada.setEstado(EstadoJornada.INCOMPLETO);
-                jornada.setSucursalId(marcacion.getSucursalId());
-            }
             if (horario != null && jornada.getHoraEntradaHorario() == null) {
-                jornada.setTurno(horario.getTurno());
-                jornada.setHoraEntradaHorario(horario.getHoraEntrada());
-                jornada.setHoraSalidaHorario(horario.getHoraSalida());
-                jornada.setInicioDescansoHorario(horario.getInicioDescanso());
-                jornada.setFinDescansoHorario(horario.getFinDescanso());
-                jornada.setToleranciaMinutosHorario(horario.getToleranciaMinutos());
+                aplicarHorarioAJornada(jornada, horario);
             }
 
-            Marcacion marcacionEntradaActual = null;
+            almuerzoProcessor.procesar(jornada, marcacion);
+            tardanzaCalculator.calcular(jornada);
+            horasTrabajadasCalculator.calcular(jornada);
 
-            if (marcacion.getTipo() == com.franco.dev.domain.administrativo.enums.TipoMarcacion.ENTRADA) {
-                if (jornada.getMarcacionEntrada() == null) {
-                    jornada.setMarcacionEntrada(marcacion);
-                    marcacionEntradaActual = marcacion;
-                } else if (jornada.getMarcacionSalidaAlmuerzo() != null
-                        && jornada.getMarcacionEntradaAlmuerzo() == null) {
-                    jornada.setMarcacionEntradaAlmuerzo(marcacion);
-                } else {
-                    if (jornada.getMarcacionEntrada().getId().equals(marcacion.getId())) {
-                        marcacionEntradaActual = marcacion;
-                    }
-                }
-            } else if (marcacion.getTipo() == com.franco.dev.domain.administrativo.enums.TipoMarcacion.SALIDA) {
-                if (jornada.getMarcacionEntrada() != null && jornada.getMarcacionSalidaAlmuerzo() == null) {
-                    Boolean esAlmuerzo = marcacion.getEsSalidaAlmuerzo();
-                    if (Boolean.TRUE.equals(esAlmuerzo)) {
-                        jornada.setMarcacionSalidaAlmuerzo(marcacion);
-                    } else {
-                        jornada.setMarcacionSalida(marcacion);
-                        jornada.setEstado(EstadoJornada.NORMAL);
-                    }
-                } else if (jornada.getMarcacionEntradaAlmuerzo() != null && jornada.getMarcacionSalida() == null) {
-                    jornada.setMarcacionSalida(marcacion);
-                    jornada.setEstado(EstadoJornada.NORMAL);
-                } else if (jornada.getMarcacionEntrada() == null) {
-                    jornada.setMarcacionEntrada(marcacion);
-                    jornada.setMarcacionSalida(marcacion);
-                    jornada.setEstado(EstadoJornada.NORMAL);
-                }
-            }
-
-            long minutosTrabajados = 0;
-            long minutosExtras = 0;
-            Marcacion entradaParaCalculo = marcacionEntradaActual != null ? marcacionEntradaActual
-                    : jornada.getMarcacionEntrada();
-
-            if (entradaParaCalculo != null && entradaParaCalculo.getFechaEntrada() != null) {
-                long minutosLlegadaTardiaTotal = 0;
-                long llegadaTardiaAlmuerzo = 0;
-                long minutosDescanso = 60;
-                long descansoADescontar = 60;
-
-                java.time.LocalTime horaEntradaHorario = jornada.getHoraEntradaHorario();
-                java.time.LocalTime horaSalidaHorario = jornada.getHoraSalidaHorario();
-                java.time.LocalTime inicioDescansoHorario = jornada.getInicioDescansoHorario();
-                java.time.LocalTime finDescansoHorario = jornada.getFinDescansoHorario();
-
-                if (horaEntradaHorario != null) {
-                    long diff = 0;
-                    if (jornada.getTurno() == com.franco.dev.domain.administrativo.enums.Turno.MADRUGADA) {
-                        LocalDateTime hEntradaOficial = jornada.getFecha().atTime(horaEntradaHorario);
-                        diff = ChronoUnit.MINUTES.between(hEntradaOficial, entradaParaCalculo.getFechaEntrada());
-                    } else {
-                        java.time.LocalTime horaEntradaReal = entradaParaCalculo.getFechaEntrada().toLocalTime();
-                        diff = ChronoUnit.MINUTES.between(horaEntradaHorario, horaEntradaReal);
-                    }
-                    if (diff > 0) {
-                        minutosLlegadaTardiaTotal = diff;
-                    }
-                } else {
-
-                }
-
-                if (inicioDescansoHorario != null && finDescansoHorario != null) {
-                    minutosDescanso = ChronoUnit.MINUTES.between(inicioDescansoHorario,
-                            finDescansoHorario);
-                    if (minutosDescanso < 0)
-                        minutosDescanso += 1440;
-                }
-
-                long tiempoAlmuerzoReal = -1;
-                if (jornada.getMarcacionSalidaAlmuerzo() != null && jornada.getMarcacionEntradaAlmuerzo() != null) {
-                    LocalDateTime salidaAlmuerzo = jornada.getMarcacionSalidaAlmuerzo().getFechaSalida() != null
-                            ? jornada.getMarcacionSalidaAlmuerzo().getFechaSalida()
-                            : jornada.getMarcacionSalidaAlmuerzo().getFechaEntrada();
-                    LocalDateTime entradaAlmuerzo = jornada.getMarcacionEntradaAlmuerzo().getFechaEntrada();
-                    if (entradaAlmuerzo.isAfter(salidaAlmuerzo)) {
-                        tiempoAlmuerzoReal = ChronoUnit.MINUTES.between(salidaAlmuerzo, entradaAlmuerzo);
-                    }
-                }
-
-                descansoADescontar = minutosDescanso;
-                if (tiempoAlmuerzoReal > 0) {
-                    if (tiempoAlmuerzoReal > minutosDescanso) {
-                        llegadaTardiaAlmuerzo = (tiempoAlmuerzoReal - minutosDescanso);
-                    }
-                    descansoADescontar = Math.max(minutosDescanso, tiempoAlmuerzoReal);
-                }
-
-                jornada.setMinutosLlegadaTardia(minutosLlegadaTardiaTotal);
-                jornada.setMinutosLlegadaTardiaAlmuerzo(llegadaTardiaAlmuerzo);
-
-                LocalDateTime entradaReal = entradaParaCalculo.getFechaEntrada();
-                LocalDateTime salidaReal = null;
-
-                if (jornada.getMarcacionSalida() != null) {
-                    salidaReal = jornada.getMarcacionSalida().getFechaSalida() != null
-                            ? jornada.getMarcacionSalida().getFechaSalida()
-                            : jornada.getMarcacionSalida().getFechaEntrada();
-                } else if (jornada.getMarcacionEntradaAlmuerzo() != null) {
-                    salidaReal = jornada.getMarcacionEntradaAlmuerzo().getFechaEntrada();
-                } else if (jornada.getMarcacionSalidaAlmuerzo() != null) {
-                    salidaReal = jornada.getMarcacionSalidaAlmuerzo().getFechaSalida() != null
-                            ? jornada.getMarcacionSalidaAlmuerzo().getFechaSalida()
-                            : jornada.getMarcacionSalidaAlmuerzo().getFechaEntrada();
-                }
-
-                if (salidaReal != null) {
-                    if (horaEntradaHorario != null && horaSalidaHorario != null) {
-                        LocalDateTime hEntradaHorario;
-                        LocalDateTime hSalidaHorario;
-
-                        if (jornada.getTurno() == com.franco.dev.domain.administrativo.enums.Turno.MADRUGADA) {
-                            hEntradaHorario = jornada.getFecha().atTime(horaEntradaHorario);
-                            hSalidaHorario = jornada.getFecha().atTime(horaSalidaHorario);
-                        } else {
-                            hEntradaHorario = entradaReal.toLocalDate().atTime(horaEntradaHorario);
-                            hSalidaHorario = entradaReal.toLocalDate().atTime(horaSalidaHorario);
-                        }
-
-                        if (hSalidaHorario.isBefore(hEntradaHorario)) {
-                            hSalidaHorario = hSalidaHorario.plusDays(1);
-                        }
-
-                        LocalDateTime entradaCalculo = entradaReal;
-                        if (entradaReal.isBefore(hEntradaHorario)) {
-                            long diffEntrada = ChronoUnit.MINUTES.between(entradaReal, hEntradaHorario);
-                            if (diffEntrada <= 40) {
-                                entradaCalculo = hEntradaHorario;
-                            }
-                        }
-
-                        long totalMinutos = ChronoUnit.MINUTES.between(entradaCalculo, salidaReal);
-
-                        if (totalMinutos > (5 * 60) || tiempoAlmuerzoReal >= 0) {
-                            totalMinutos -= descansoADescontar;
-                        }
-                        if (totalMinutos < 0)
-                            totalMinutos = 0;
-
-                        long horasProgramadas = ChronoUnit.MINUTES.between(hEntradaHorario, hSalidaHorario);
-                        if (horasProgramadas > minutosDescanso) {
-                            horasProgramadas -= minutosDescanso;
-                        }
-
-                        if (totalMinutos > horasProgramadas) {
-                            minutosTrabajados = horasProgramadas;
-                            minutosExtras = totalMinutos - horasProgramadas;
-                        } else {
-                            minutosTrabajados = totalMinutos;
-                            minutosExtras = 0;
-                        }
-
-                    } else {
-                        long totalMinutos = ChronoUnit.MINUTES.between(entradaReal, salidaReal);
-
-                        if (totalMinutos > 5 * 60 || tiempoAlmuerzoReal >= 0) {
-                            totalMinutos -= descansoADescontar;
-                        }
-                        if (totalMinutos < 0)
-                            totalMinutos = 0;
-
-                        long jornadaBase = 8 * 60;
-                        if (totalMinutos > jornadaBase) {
-                            minutosTrabajados = jornadaBase;
-                            minutosExtras = totalMinutos - jornadaBase;
-                        } else {
-                            minutosTrabajados = totalMinutos;
-                            minutosExtras = 0;
-                        }
-                    }
-                }
-            }
-
-            jornada.setMinutosTrabajados(minutosTrabajados);
-            jornada.setMinutosExtras(minutosExtras);
             jornadaService.save(jornada);
 
-        } catch (
-
-        Exception e) {
-            e.printStackTrace();
+        } catch (Exception e) {
+            log.error("Error crítico procesando jornada para marcación ID: {} en sucursal: {}",
+                    marcacion.getId(), marcacion.getSucursalId(), e);
         }
+    }
+
+    private LocalDateTime obtenerFechaReferencia(Marcacion marcacion) {
+        if (marcacion.getFechaEntrada() != null)
+            return marcacion.getFechaEntrada();
+        if (marcacion.getFechaSalida() != null)
+            return marcacion.getFechaSalida();
+        return LocalDateTime.now();
+    }
+
+    private void aplicarHorarioAJornada(Jornada jornada, Horario horario) {
+        jornada.setTurno(horario.getTurno());
+        jornada.setHoraEntradaHorario(horario.getHoraEntrada());
+        jornada.setHoraSalidaHorario(horario.getHoraSalida());
+        jornada.setInicioDescansoHorario(horario.getInicioDescanso());
+        jornada.setFinDescansoHorario(horario.getFinDescanso());
+        jornada.setToleranciaMinutosHorario(horario.getToleranciaMinutos());
     }
 }

--- a/src/main/java/com/franco/dev/service/administrativo/helper/AlmuerzoProcessor.java
+++ b/src/main/java/com/franco/dev/service/administrativo/helper/AlmuerzoProcessor.java
@@ -1,0 +1,51 @@
+package com.franco.dev.service.administrativo.helper;
+
+import com.franco.dev.domain.administrativo.Jornada;
+import com.franco.dev.domain.administrativo.Marcacion;
+import com.franco.dev.domain.administrativo.enums.EstadoJornada;
+import com.franco.dev.domain.administrativo.enums.TipoMarcacion;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AlmuerzoProcessor {
+
+    private static final Logger log = LoggerFactory.getLogger(AlmuerzoProcessor.class);
+
+    public void procesar(Jornada jornada, Marcacion marcacion) {
+        if (marcacion.getTipo() == TipoMarcacion.ENTRADA) {
+            handleEntrada(jornada, marcacion);
+        } else if (marcacion.getTipo() == TipoMarcacion.SALIDA) {
+            handleSalida(jornada, marcacion);
+        }
+    }
+
+    private void handleEntrada(Jornada jornada, Marcacion marcacion) {
+        if (jornada.getMarcacionEntrada() == null) {
+            jornada.setMarcacionEntrada(marcacion);
+        } else if (jornada.getMarcacionSalidaAlmuerzo() != null && jornada.getMarcacionEntradaAlmuerzo() == null) {
+            jornada.setMarcacionEntradaAlmuerzo(marcacion);
+        }
+    }
+
+    private void handleSalida(Jornada jornada, Marcacion marcacion) {
+        if (jornada.getMarcacionEntrada() != null && jornada.getMarcacionSalidaAlmuerzo() == null) {
+            if (Boolean.TRUE.equals(marcacion.getEsSalidaAlmuerzo())) {
+                jornada.setMarcacionSalidaAlmuerzo(marcacion);
+            } else {
+                jornada.setMarcacionSalida(marcacion);
+                jornada.setEstado(EstadoJornada.NORMAL);
+            }
+        } else if (jornada.getMarcacionEntradaAlmuerzo() != null && jornada.getMarcacionSalida() == null) {
+            jornada.setMarcacionSalida(marcacion);
+            jornada.setEstado(EstadoJornada.NORMAL);
+        } else if (jornada.getMarcacionEntrada() == null) {
+            log.error(
+                    "Salida sin jornada con entrada previa. Jornada id={}, usuarioId={}, marcacionId={}",
+                    jornada.getId(),
+                    jornada.getUsuario() != null ? jornada.getUsuario().getId() : null,
+                    marcacion.getId());
+        }
+    }
+}

--- a/src/main/java/com/franco/dev/service/administrativo/helper/HorarioResolver.java
+++ b/src/main/java/com/franco/dev/service/administrativo/helper/HorarioResolver.java
@@ -1,0 +1,84 @@
+package com.franco.dev.service.administrativo.helper;
+
+import com.franco.dev.domain.administrativo.Horario;
+import com.franco.dev.domain.administrativo.Marcacion;
+import com.franco.dev.domain.administrativo.enums.Dia;
+import com.franco.dev.domain.personas.Funcionario;
+import com.franco.dev.repository.administrativo.HorarioRepository;
+import com.franco.dev.service.personas.FuncionarioService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class HorarioResolver {
+
+    private final FuncionarioService funcionarioService;
+    private final HorarioRepository horarioRepository;
+
+    public Horario resolver(Marcacion marcacion, LocalDateTime fechaReferencia) {
+        Dia diaSemana = mapToDia(fechaReferencia.getDayOfWeek());
+
+        return getFuncionario(marcacion)
+                .map(f -> {
+                    Horario horario = f.getHorario();
+                    if (horario == null) return null;
+                    if (cumpleCondiciones(horario, diaSemana)) {
+                        return horario;
+                    }
+                    return buscarAlternativo(marcacion.getUsuario().getId(), diaSemana);
+                })
+                .orElseGet(() -> buscarPorUsuarioYDia(marcacion, diaSemana));
+    }
+
+    private Dia mapToDia(DayOfWeek dayOfWeek) {
+        switch (dayOfWeek) {
+            case MONDAY: return Dia.LUNES;
+            case TUESDAY: return Dia.MARTES;
+            case WEDNESDAY: return Dia.MIERCOLES;
+            case THURSDAY: return Dia.JUEVES;
+            case FRIDAY: return Dia.VIERNES;
+            case SATURDAY: return Dia.SABADO;
+            case SUNDAY: return Dia.DOMINGO;
+            default: return null;
+        }
+    }
+
+    private Optional<Funcionario> getFuncionario(Marcacion marcacion) {
+        if (marcacion.getUsuario() == null) return Optional.empty();
+        if (marcacion.getUsuario().getPersona() != null) {
+            return Optional.ofNullable(funcionarioService.findByPersonaId(marcacion.getUsuario().getPersona().getId()));
+        }
+        return Optional.ofNullable(funcionarioService.findByUsuarioId(marcacion.getUsuario().getId()));
+    }
+
+    private boolean cumpleCondiciones(Horario horario, Dia diaSemana) {
+        if (horario.getDias() == null || horario.getDias().isEmpty()) return false;
+        return horario.getDias().contains(diaSemana) || horario.getDias().contains(Dia.TODOS);
+    }
+
+    private Horario buscarAlternativo(Long usuarioId, Dia diaSemana) {
+        List<Horario> horariosUsuario = horarioRepository.findByUsuarioIdOrderByIdDesc(usuarioId);
+        if (horariosUsuario == null || horariosUsuario.isEmpty()) return null;
+
+        return horariosUsuario.stream()
+                .filter(h -> h.getHoraEntrada() != null && cumpleCondiciones(h, diaSemana))
+                .findFirst()
+                .orElseGet(() -> horariosUsuario.stream()
+                        .filter(h -> h.getHoraEntrada() != null)
+                        .findFirst()
+                        .orElse(null));
+    }
+
+    private Horario buscarPorUsuarioYDia(Marcacion marcacion, Dia diaSemana) {
+        if (marcacion.getUsuario() != null && diaSemana != null) {
+            return horarioRepository.findByUsuarioIdAndDia(marcacion.getUsuario().getId(), diaSemana);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/franco/dev/service/administrativo/helper/HorasTrabajadasCalculator.java
+++ b/src/main/java/com/franco/dev/service/administrativo/helper/HorasTrabajadasCalculator.java
@@ -1,0 +1,137 @@
+package com.franco.dev.service.administrativo.helper;
+
+import com.franco.dev.domain.administrativo.Jornada;
+import com.franco.dev.domain.administrativo.Marcacion;
+import com.franco.dev.domain.administrativo.enums.Turno;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+
+@Component
+public class HorasTrabajadasCalculator {
+
+    public void calcular(Jornada jornada) {
+        Marcacion entradaParaCalculo = jornada.getMarcacionEntrada();
+        if (entradaParaCalculo == null || entradaParaCalculo.getFechaEntrada() == null) return;
+
+        LocalDateTime entradaReal = entradaParaCalculo.getFechaEntrada();
+        LocalDateTime salidaReal = determinarSalidaReal(jornada);
+
+        if (salidaReal == null) return;
+
+        long minutosDescanso = getMinutosDescanso(jornada);
+        long tiempoAlmuerzoReal = getTiempoAlmuerzoReal(jornada);
+        long descansoADescontar = Math.max(minutosDescanso, tiempoAlmuerzoReal);
+
+        long totalMinutos;
+        long horasProgramadas;
+
+        if (jornada.getHoraEntradaHorario() != null && jornada.getHoraSalidaHorario() != null) {
+            LocalDateTime hEntradaHorario = getHorarioEntrada(jornada);
+            LocalDateTime hSalidaHorario = getHorarioSalida(jornada, hEntradaHorario);
+
+            LocalDateTime entradaCalculo = ajustarEntrada(entradaReal, hEntradaHorario);
+            totalMinutos = ChronoUnit.MINUTES.between(entradaCalculo, salidaReal);
+            
+            if (shouldDeductBreak(totalMinutos, tiempoAlmuerzoReal, jornada.getTurno())) {
+                totalMinutos -= descansoADescontar;
+            }
+            totalMinutos = Math.max(0, totalMinutos);
+
+            horasProgramadas = ChronoUnit.MINUTES.between(hEntradaHorario, hSalidaHorario);
+            if (horasProgramadas > minutosDescanso && isShiftWithBreak(jornada.getTurno())) {
+                horasProgramadas -= minutosDescanso;
+            }
+        } else {
+            totalMinutos = ChronoUnit.MINUTES.between(entradaReal, salidaReal);
+            if (shouldDeductBreak(totalMinutos, tiempoAlmuerzoReal, jornada.getTurno())) {
+                totalMinutos -= descansoADescontar;
+            }
+            totalMinutos = Math.max(0, totalMinutos);
+            horasProgramadas = 8 * 60;
+        }
+
+        asignarResultados(jornada, totalMinutos, horasProgramadas);
+    }
+
+    private LocalDateTime determinarSalidaReal(Jornada jornada) {
+        if (jornada.getMarcacionSalida() != null) {
+            return getFechaMarcacion(jornada.getMarcacionSalida());
+        } else if (jornada.getMarcacionEntradaAlmuerzo() != null) {
+            return jornada.getMarcacionEntradaAlmuerzo().getFechaEntrada();
+        } else if (jornada.getMarcacionSalidaAlmuerzo() != null) {
+            return getFechaMarcacion(jornada.getMarcacionSalidaAlmuerzo());
+        }
+        return null;
+    }
+
+    private long getMinutosDescanso(Jornada jornada) {
+        if (jornada.getInicioDescansoHorario() != null && jornada.getFinDescansoHorario() != null) {
+            long diff = ChronoUnit.MINUTES.between(jornada.getInicioDescansoHorario(), jornada.getFinDescansoHorario());
+            return diff < 0 ? diff + 1440 : diff;
+        }
+        return 60;
+    }
+
+    private long getTiempoAlmuerzoReal(Jornada jornada) {
+        if (jornada.getMarcacionSalidaAlmuerzo() != null && jornada.getMarcacionEntradaAlmuerzo() != null) {
+            LocalDateTime salida = getFechaMarcacion(jornada.getMarcacionSalidaAlmuerzo());
+            LocalDateTime entrada = jornada.getMarcacionEntradaAlmuerzo().getFechaEntrada();
+            if (entrada != null && salida != null && entrada.isAfter(salida)) {
+                return ChronoUnit.MINUTES.between(salida, entrada);
+            }
+        }
+        return -1;
+    }
+
+    private boolean shouldDeductBreak(long totalMinutos, long tiempoAlmuerzoReal, Turno turno) {
+        return (totalMinutos > (5 * 60) || tiempoAlmuerzoReal >= 0) && isShiftWithBreak(turno);
+    }
+
+    private boolean isShiftWithBreak(Turno turno) {
+        return turno != Turno.NOCHE && turno != Turno.MADRUGADA;
+    }
+
+    private LocalDateTime getHorarioEntrada(Jornada jornada) {
+        LocalTime hora = jornada.getHoraEntradaHorario();
+        if (jornada.getTurno() == Turno.MADRUGADA) {
+            return jornada.getFecha().atTime(hora);
+        }
+        return jornada.getMarcacionEntrada().getFechaEntrada().toLocalDate().atTime(hora);
+    }
+
+    private LocalDateTime getHorarioSalida(Jornada jornada, LocalDateTime hEntradaHorario) {
+        LocalTime hora = jornada.getHoraSalidaHorario();
+        LocalDateTime hSalida;
+        if (jornada.getTurno() == Turno.MADRUGADA) {
+            hSalida = jornada.getFecha().atTime(hora);
+        } else {
+            hSalida = hEntradaHorario.toLocalDate().atTime(hora);
+        }
+        return hSalida.isBefore(hEntradaHorario) ? hSalida.plusDays(1) : hSalida;
+    }
+
+    private LocalDateTime ajustarEntrada(LocalDateTime entradaReal, LocalDateTime hEntradaHorario) {
+        if (entradaReal.isBefore(hEntradaHorario)) {
+            long diff = ChronoUnit.MINUTES.between(entradaReal, hEntradaHorario);
+            if (diff <= 40) return hEntradaHorario;
+        }
+        return entradaReal;
+    }
+
+    private void asignarResultados(Jornada jornada, long totalMinutos, long horasProgramadas) {
+        if (totalMinutos > horasProgramadas) {
+            jornada.setMinutosTrabajados(horasProgramadas);
+            jornada.setMinutosExtras(totalMinutos - horasProgramadas);
+        } else {
+            jornada.setMinutosTrabajados(totalMinutos);
+            jornada.setMinutosExtras(0L);
+        }
+    }
+
+    private LocalDateTime getFechaMarcacion(Marcacion m) {
+        return m.getFechaSalida() != null ? m.getFechaSalida() : m.getFechaEntrada();
+    }
+}

--- a/src/main/java/com/franco/dev/service/administrativo/helper/JornadaFactory.java
+++ b/src/main/java/com/franco/dev/service/administrativo/helper/JornadaFactory.java
@@ -1,0 +1,21 @@
+package com.franco.dev.service.administrativo.helper;
+
+import com.franco.dev.domain.administrativo.Jornada;
+import com.franco.dev.domain.administrativo.Marcacion;
+import com.franco.dev.domain.administrativo.enums.EstadoJornada;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Component
+public class JornadaFactory {
+
+    public Jornada crearNuevaJornada(Marcacion marcacion, LocalDate fechaJornada) {
+        Jornada jornada = new Jornada();
+        jornada.setUsuario(marcacion.getUsuario());
+        jornada.setFecha(fechaJornada);
+        jornada.setEstado(EstadoJornada.INCOMPLETO);
+        jornada.setSucursalId(marcacion.getSucursalId());
+        return jornada;
+    }
+}

--- a/src/main/java/com/franco/dev/service/administrativo/helper/JornadaMarcacionResolver.java
+++ b/src/main/java/com/franco/dev/service/administrativo/helper/JornadaMarcacionResolver.java
@@ -1,0 +1,90 @@
+package com.franco.dev.service.administrativo.helper;
+
+import com.franco.dev.domain.administrativo.Jornada;
+import com.franco.dev.domain.administrativo.Marcacion;
+import com.franco.dev.domain.administrativo.enums.EstadoJornada;
+import com.franco.dev.domain.administrativo.enums.TipoMarcacion;
+import com.franco.dev.service.administrativo.JornadaService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class JornadaMarcacionResolver {
+
+    private static final Logger log = LoggerFactory.getLogger(JornadaMarcacionResolver.class);
+
+    private final JornadaService jornadaService;
+    private final JornadaFactory jornadaFactory;
+
+    public Jornada resolver(Marcacion marcacion, LocalDate fechaReferencia) {
+        if (marcacion.getTipo() == TipoMarcacion.SALIDA) {
+            return resolverSalida(marcacion, fechaReferencia);
+        }
+
+        return resolverEntrada(marcacion, fechaReferencia);
+    }
+
+    private Jornada resolverSalida(Marcacion marcacion, LocalDate fechaReferencia) {
+        Optional<Jornada> jornadaNocturnaAbierta = jornadaService.findIncompletaSinSalidaNocturnaParaSalida(
+                marcacion.getUsuario().getId(), fechaReferencia);
+        if (jornadaNocturnaAbierta.isPresent()) {
+            return jornadaNocturnaAbierta.get();
+        }
+
+        List<Jornada> jornadasHoy = jornadaService.findByUsuarioIdAndFecha(
+                marcacion.getUsuario().getId(),
+                fechaReferencia.toString());
+
+        if (jornadasHoy != null && !jornadasHoy.isEmpty()) {
+            Jornada lastJornada = jornadasHoy.get(jornadasHoy.size() - 1);
+            if (!shouldCreateNewJornada(lastJornada, marcacion)) {
+                return lastJornada;
+            }
+        }
+
+        log.warn("Salida rechazada: no hay jornada abierta para usuario {} en fecha {}",
+                marcacion.getUsuario().getId(), fechaReferencia);
+        throw new IllegalStateException("No existe una jornada abierta para registrar la salida");
+    }
+
+    private Jornada resolverEntrada(Marcacion marcacion, LocalDate fechaReferencia) {
+        Optional<Jornada> jornadaCruzaMedianoche = jornadaService.findIncompletaSinSalidaNocturnaParaSalida(
+                marcacion.getUsuario().getId(), fechaReferencia);
+        if (jornadaCruzaMedianoche.isPresent()) {
+            Jornada abierta = jornadaCruzaMedianoche.get();
+            if (abierta.getMarcacionEntrada() != null && abierta.getMarcacionSalida() == null) {
+                return abierta;
+            }
+        }
+
+        List<Jornada> jornadas = jornadaService.findByUsuarioIdAndFecha(
+                marcacion.getUsuario().getId(),
+                fechaReferencia.toString());
+
+        if (jornadas == null || jornadas.isEmpty()) {
+            return jornadaFactory.crearNuevaJornada(marcacion, fechaReferencia);
+        }
+
+        Jornada lastJornada = jornadas.get(jornadas.size() - 1);
+
+        if (shouldCreateNewJornada(lastJornada, marcacion)) {
+            return jornadaFactory.crearNuevaJornada(marcacion, fechaReferencia);
+        }
+
+        return lastJornada;
+    }
+
+    private boolean shouldCreateNewJornada(Jornada lastJornada, Marcacion marcacion) {
+        if (lastJornada.getEstado() == EstadoJornada.NORMAL || lastJornada.getMarcacionSalida() != null) {
+            return marcacion.getTipo() == TipoMarcacion.ENTRADA || marcacion.getFechaEntrada() != null;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/franco/dev/service/administrativo/helper/TardanzaCalculator.java
+++ b/src/main/java/com/franco/dev/service/administrativo/helper/TardanzaCalculator.java
@@ -1,0 +1,67 @@
+package com.franco.dev.service.administrativo.helper;
+
+import com.franco.dev.domain.administrativo.Jornada;
+import com.franco.dev.domain.administrativo.enums.Turno;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+
+@Component
+public class TardanzaCalculator {
+
+    public void calcular(Jornada jornada) {
+        LocalTime horaEntradaHorario = jornada.getHoraEntradaHorario();
+        if (horaEntradaHorario == null || jornada.getMarcacionEntrada() == null) return;
+
+        LocalDateTime entradaReal = jornada.getMarcacionEntrada().getFechaEntrada();
+        if (entradaReal == null) return;
+
+        long diff = 0;
+        if (jornada.getTurno() == Turno.MADRUGADA) {
+            LocalDateTime hEntradaOficial = jornada.getFecha().atTime(horaEntradaHorario);
+            diff = ChronoUnit.MINUTES.between(hEntradaOficial, entradaReal);
+        } else {
+            LocalTime horaEntradaReal = entradaReal.toLocalTime();
+            diff = ChronoUnit.MINUTES.between(horaEntradaHorario, horaEntradaReal);
+        }
+
+        jornada.setMinutosLlegadaTardia(Math.max(0, diff));
+        
+        calcularTardanzaAlmuerzo(jornada);
+    }
+
+    private void calcularTardanzaAlmuerzo(Jornada jornada) {
+        if (jornada.getMarcacionSalidaAlmuerzo() == null || jornada.getMarcacionEntradaAlmuerzo() == null) {
+            jornada.setMinutosLlegadaTardiaAlmuerzo(0L);
+            return;
+        }
+
+        LocalDateTime salidaAlmuerzo = getFechaMarcacion(jornada.getMarcacionSalidaAlmuerzo());
+        LocalDateTime entradaAlmuerzo = jornada.getMarcacionEntradaAlmuerzo().getFechaEntrada();
+
+        if (entradaAlmuerzo != null && salidaAlmuerzo != null && entradaAlmuerzo.isAfter(salidaAlmuerzo)) {
+            long tiempoAlmuerzoReal = ChronoUnit.MINUTES.between(salidaAlmuerzo, entradaAlmuerzo);
+            long minutosDescanso = getMinutosDescanso(jornada);
+
+            if (tiempoAlmuerzoReal > minutosDescanso) {
+                jornada.setMinutosLlegadaTardiaAlmuerzo(tiempoAlmuerzoReal - minutosDescanso);
+            } else {
+                jornada.setMinutosLlegadaTardiaAlmuerzo(0L);
+            }
+        }
+    }
+
+    private LocalDateTime getFechaMarcacion(com.franco.dev.domain.administrativo.Marcacion m) {
+        return m.getFechaSalida() != null ? m.getFechaSalida() : m.getFechaEntrada();
+    }
+
+    private long getMinutosDescanso(Jornada jornada) {
+        if (jornada.getInicioDescansoHorario() != null && jornada.getFinDescansoHorario() != null) {
+            long diff = ChronoUnit.MINUTES.between(jornada.getInicioDescansoHorario(), jornada.getFinDescansoHorario());
+            return diff < 0 ? diff + 1440 : diff;
+        }
+        return 60; // Default
+    }
+}

--- a/src/main/resources/db/migration/V0__initial_schema.sql
+++ b/src/main/resources/db/migration/V0__initial_schema.sql
@@ -15295,7 +15295,6 @@ ALTER PUBLICATION central_pub ADD TABLE ONLY vehiculos.vehiculo_sucursal;
 --
 -- Name: filial_farmacia_1_sub; Type: SUBSCRIPTION; Schema: -; Owner: -
 --
-
 CREATE SUBSCRIPTION filial_farmacia_1_sub CONNECTION 'dbname=general host=172.25.3.1 user=franco password=franco port=5551' PUBLICATION filial1_pub WITH (connect = false, slot_name = 'filial_farmacia_1_sub', origin = none);
 
 


### PR DESCRIPTION
Resumen

Corrige la asignación de marcaciones a jornadas cuando el turno NOCHE o MADRUGADA inicia un día calendario y la salida (o una nueva entrada) ocurre después de medianoche. Antes, el resolver solo buscaba jornadas por fechaReferencia del día actual, lo que podía crear jornadas duplicadas o impedir cerrar la jornada abierta del día anterior.

Qué no cambia

Modelo de datos (jornada, marcacion): sin migraciones.
API GraphQL: mismos contratos.
AlmuerzoProcessor, TardanzaCalculator, HorasTrabajadasCalculator: misma lógica una vez resuelta la jornada.
Turnos DIA y jornadas NORMAL cerradas: shouldCreateNewJornada sigue forzando nueva jornada en nueva entrada.