### PR TITLE
feat(lucro):add filtro de familia en lucro-por-producto

### DIFF
--- a/src/main/java/com/franco/dev/graphql/productos/ProductoGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/productos/ProductoGraphQL.java
@@ -5,6 +5,7 @@ import com.franco.dev.domain.empresarial.Sucursal;
 import com.franco.dev.domain.operaciones.dto.LucroPorProductosDto;
 import com.franco.dev.domain.personas.Usuario;
 import com.franco.dev.domain.productos.Codigo;
+import com.franco.dev.domain.productos.Familia;
 import com.franco.dev.domain.productos.Producto;
 import com.franco.dev.domain.productos.Subfamilia;
 import com.franco.dev.fmc.model.PushNotificationRequest;
@@ -57,6 +58,9 @@ public class ProductoGraphQL implements GraphQLQueryResolver, GraphQLMutationRes
 
     @Autowired
     private SubFamiliaService subFamiliaService;
+
+    @Autowired
+    private FamiliaService familiaService;
 
     @Autowired
     private IngredienteService ingredienteService;
@@ -227,7 +231,7 @@ public class ProductoGraphQL implements GraphQLQueryResolver, GraphQLMutationRes
     }
 
     public String lucroPorProducto(String fechaInicio, String fechaFin, List<Long> sucursalIdList, Long usuarioId,
-            List<Long> usuarioIdList, List<Long> productoIdList, Long subfamiliaId) {
+            List<Long> usuarioIdList, List<Long> productoIdList, Long subfamiliaId, Long familiaId) {
         Usuario usuario = usuarioService.findById(usuarioId).orElse(null);
         StringBuilder filtro = new StringBuilder();
         if (usuarioIdList != null && !usuarioIdList.isEmpty()) {
@@ -257,6 +261,12 @@ public class ProductoGraphQL implements GraphQLQueryResolver, GraphQLMutationRes
             if (suc != null)
                 filtro.append(suc.getNombre() + ", ");
         }
+        if (familiaId != null) {
+            Familia familia = familiaService.findById(familiaId).orElse(null);
+            if (familia != null && familia.getNombre() != null) {
+                filtro.append("\nFamilia: " + familia.getNombre());
+            }
+        }
         if (subfamiliaId != null) {
             Subfamilia subfamilia = subFamiliaService.findById(subfamiliaId).orElse(null);
             if (subfamilia != null && subfamilia.getNombre() != null) {
@@ -264,7 +274,7 @@ public class ProductoGraphQL implements GraphQLQueryResolver, GraphQLMutationRes
             }
         }
         List<LucroPorProductosDto> lucroPorProductosDtoList = service.findLucroPorProductos(fechaInicio, fechaFin,
-                sucursalIdList, usuarioIdList, productoIdList, subfamiliaId);
+                sucursalIdList, usuarioIdList, productoIdList, subfamiliaId, familiaId);
         return impresionService.imprimirReporteLucroPorProducto(lucroPorProductosDtoList, fechaInicio, fechaFin, "",
                 filtro.toString(), usuario);
     }
@@ -277,10 +287,11 @@ public class ProductoGraphQL implements GraphQLQueryResolver, GraphQLMutationRes
             List<Long> productoIdList,
             Long subfamiliaId,
             Integer page,
-            Integer size) {
+            Integer size,
+            Long familiaId) {
 
         List<LucroPorProductosDto> fullList = service.findLucroPorProductos(fechaInicio, fechaFin,
-                sucursalIdList, usuarioIdList, productoIdList, subfamiliaId);
+                sucursalIdList, usuarioIdList, productoIdList, subfamiliaId, familiaId);
 
         // 1. Calculate Global Summary
         LucroPorProductoSummary summary = new LucroPorProductoSummary();

--- a/src/main/java/com/franco/dev/repository/productos/ProductoRepository.java
+++ b/src/main/java/com/franco/dev/repository/productos/ProductoRepository.java
@@ -131,7 +131,8 @@ public interface ProductoRepository extends HelperRepository<Producto, Long> {
                         "(:sucursalId is null or v.sucursalId = :sucursalId) AND " +
                         "(:filtrarUsuario = false or u.id IN (:usuarioIdList)) AND " +
                         "(:filtrarProducto = false or pro.id IN (:productoIdList)) AND " +
-                        "((:subfamiliaId) is null or pro.subfamilia.id = :subfamiliaId) " +
+                        "((:subfamiliaId) is null or pro.subfamilia.id = :subfamiliaId) AND " +
+                        "((:familiaId) is null or pro.subfamilia.id IN (SELECT sf.id FROM Subfamilia sf WHERE sf.familia.id = :familiaId)) " +
                         "group by pro.id " +
                         "ORDER BY SUM(vi.precio * vi.cantidad * pre.cantidad) DESC")
         public List<LucroPorProductosDto> findLucroPorProducto(
@@ -141,6 +142,7 @@ public interface ProductoRepository extends HelperRepository<Producto, Long> {
                         @Param("usuarioIdList") List<Long> usuarioIdList,
                         @Param("productoIdList") List<Long> productoIdList,
                         @Param("subfamiliaId") Long subfamiliaId,
+                        @Param("familiaId") Long familiaId,
                         @Param("filtrarUsuario") Boolean filtrarUsuario,
                         @Param("filtrarProducto") Boolean filtrarProducto);
 
@@ -156,7 +158,8 @@ public interface ProductoRepository extends HelperRepository<Producto, Long> {
                         "((:sucursalId) is null or v.sucursalId = (:sucursalId)) AND " +
                         "(:filtrarUsuario = false or u.id IN (:usuarioIdList)) AND " +
                         "(:filtrarProducto = false or pro.id IN (:productoIdList)) AND " +
-                        "((:subfamiliaId) is null or pro.subfamilia.id = :subfamiliaId) " +
+                        "((:subfamiliaId) is null or pro.subfamilia.id = :subfamiliaId) AND " +
+                        "((:familiaId) is null or pro.subfamilia.id IN (SELECT sf.id FROM Subfamilia sf WHERE sf.familia.id = :familiaId)) " +
                         "GROUP BY pro.id")
         public List<Object[]> findTotalVentaPacksPorProducto(
                         @Param("sucursalId") Long sucursalId,
@@ -165,6 +168,7 @@ public interface ProductoRepository extends HelperRepository<Producto, Long> {
                         @Param("usuarioIdList") List<Long> usuarioIdList,
                         @Param("productoIdList") List<Long> productoIdList,
                         @Param("subfamiliaId") Long subfamiliaId,
+                        @Param("familiaId") Long familiaId,
                         @Param("filtrarUsuario") Boolean filtrarUsuario,
                         @Param("filtrarProducto") Boolean filtrarProducto);
 

--- a/src/main/java/com/franco/dev/service/productos/ProductoService.java
+++ b/src/main/java/com/franco/dev/service/productos/ProductoService.java
@@ -535,7 +535,7 @@ public class ProductoService extends CrudService<Producto, ProductoRepository, L
     }
 
     public List<LucroPorProductosDto> findLucroPorProductos(String inicio, String fin, List<Long> sucIdList,
-            List<Long> usuarioIdList, List<Long> productoIdList, Long subfamiliaId) {
+            List<Long> usuarioIdList, List<Long> productoIdList, Long subfamiliaId, Long familiaId) {
         List<LucroPorProductosDto> aggregatedResult = new ArrayList<>();
         Map<Long, Double> totalVentaPacksMap = new HashMap<>();
 
@@ -548,14 +548,14 @@ public class ProductoService extends CrudService<Producto, ProductoRepository, L
             List<Long> finalProductoIdList = filtrarProducto ? productoIdList : Arrays.asList(-1L);
 
             List<LucroPorProductosDto> lucroPorProductosDtoList = repository.findLucroPorProducto(sucId,
-                    stringToDate(inicio), stringToDate(fin), finalUsuarioIdList, finalProductoIdList, subfamiliaId, filtrarUsuario,
+                    stringToDate(inicio), stringToDate(fin), finalUsuarioIdList, finalProductoIdList, subfamiliaId, familiaId, filtrarUsuario,
                     filtrarProducto);
             aggregatedResult.addAll(lucroPorProductosDtoList);
 
             // Obtener totalVentaPacks (SUM(vi.precio * vi.cantidad)) para calcular
             // ventaMedia correctamente
             List<Object[]> totalVentaPacksList = repository.findTotalVentaPacksPorProducto(sucId, stringToDate(inicio),
-                    stringToDate(fin), finalUsuarioIdList, finalProductoIdList, subfamiliaId, filtrarUsuario, filtrarProducto);
+                    stringToDate(fin), finalUsuarioIdList, finalProductoIdList, subfamiliaId, familiaId, filtrarUsuario, filtrarProducto);
             for (Object[] row : totalVentaPacksList) {
                 Long productoId = ((Number) row[0]).longValue();
                 Double totalVentaPacks = ((Number) row[1]).doubleValue();
@@ -574,7 +574,6 @@ public class ProductoService extends CrudService<Producto, ProductoRepository, L
 
         // Calcular todos los campos derivados después de la agregación
         for (LucroPorProductosDto dto : result) {
-            // Log para debug
 
             if (dto.getCantidad() != null && dto.getCantidad() > 0) {
                 // Calcular costo unitario
@@ -618,15 +617,6 @@ public class ProductoService extends CrudService<Producto, ProductoRepository, L
                     dto.setPercent(0.0);
                 }
 
-                // Log para debug de cálculos
-                log.info("DEBUG - Cálculos para ID " + dto.getProductoId() +
-                        ": CostoUnitario=" + dto.getCostoUnitario() +
-                        ", VentaMedia=" + dto.getVentaMedia() +
-                        ", Lucro=" + dto.getLucro() +
-                        ", Margen=" + dto.getMargen() +
-                        ", Percent=" + dto.getPercent() +
-                        ", Descuento=" + dto.getTotalDescuento() +
-                        ", Aumento=" + dto.getTotalAumento());
             } else {
                 // Si no hay cantidad, todos los valores son 0
                 dto.setCostoUnitario(0.0);

--- a/src/main/resources/graphql/productos/producto/productos.graphqls
+++ b/src/main/resources/graphql/productos/producto/productos.graphqls
@@ -88,8 +88,8 @@ extend type Query {
     printProducto(id: ID!):Producto
     exportarReporte(texto: String): String
     exportarReporteConFiltros(texto: String, codigo: Boolean, activo: Boolean, stock: Boolean, balanza: Boolean, vencimiento: Boolean, costoCero: Boolean, familiaId: Int, subfamiliaId: ID, stockFiltro: String, sucursalId: ID, usuarioId: ID, usuario: String): String
-    lucroPorProducto(fechaInicio: String, fechaFin: String, sucursalIdList: [Int], usuarioId: ID!, usuarioIdList:[ID], productoIdList:[ID], subfamiliaId: ID): String
-    lucroPorProductoList(fechaInicio: String, fechaFin: String, sucursalIdList: [ID], usuarioIdList: [ID], productoIdList: [ID], subfamiliaId: ID, page: Int, size: Int): LucroPorProductoResponse
+    lucroPorProducto(fechaInicio: String, fechaFin: String, sucursalIdList: [Int], usuarioId: ID!, usuarioIdList:[ID], productoIdList:[ID], subfamiliaId: ID, familiaId: ID): String
+    lucroPorProductoList(fechaInicio: String, fechaFin: String, sucursalIdList: [ID], usuarioIdList: [ID], productoIdList: [ID], subfamiliaId: ID, page: Int, size: Int, familiaId: ID): LucroPorProductoResponse
     imprimirCodigoBarra(codigoId: Int): Boolean
     searchProductoWithFilters(texto: String, codigo: String, activo: Boolean, stock: Boolean, balanza: Boolean, familia: Int, subfamilia: Int, vencimiento: Boolean, costoCero: Boolean, stockFiltro: String, sucursalId: Int, page: Int, size: Int):ProductoPage
     productoDescripcionExists(descripcion: String): Boolean

--- a/src/main/resources/reports/lucro-por-producto.jrxml
+++ b/src/main/resources/reports/lucro-por-producto.jrxml
@@ -80,10 +80,10 @@
 				<text><![CDATA[Reporte de lucro por productos]]></text>
 			</staticText>
 			<textField>
-				<reportElement x="153" y="80" width="70" height="11" forecolor="#000000" uuid="7e8c778b-0e6c-4e04-a4c7-de5b9f3403f6">
+				<reportElement x="150" y="80" width="80" height="11" forecolor="#000000" uuid="7e8c778b-0e6c-4e04-a4c7-de5b9f3403f6">
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 				</reportElement>
-				<textElement textAlignment="Center">
+				<textElement textAlignment="Right">
 					<font fontName="Verdana" size="8"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$P{fechaReporte}]]></textFieldExpression>
@@ -91,6 +91,7 @@
 			<staticText>
 				<reportElement x="112" y="80" width="41" height="11" forecolor="#000000" uuid="4c91f639-4e4b-4bb2-965f-156eaed3a91c">
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 				</reportElement>
 				<textElement>
 					<font size="8"/>
@@ -98,17 +99,17 @@
 				<text><![CDATA[Creado en:]]></text>
 			</staticText>
 			<staticText>
-				<reportElement x="223" y="80" width="16" height="11" forecolor="#000000" uuid="186428af-f5d4-4389-8c9b-cadb45c47034">
+				<reportElement x="230" y="80" width="17" height="11" forecolor="#000000" uuid="186428af-f5d4-4389-8c9b-cadb45c47034">
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 					<property name="com.jaspersoft.studio.unit.width" value="px"/>
 				</reportElement>
-				<textElement>
-					<font size="8"/>
+				<textElement textAlignment="Center" verticalAlignment="Top">
+					<font fontName="Verdana" size="8"/>
 				</textElement>
 				<text><![CDATA[por:]]></text>
 			</staticText>
 			<textField>
-				<reportElement x="239" y="80" width="85" height="11" forecolor="#000000" uuid="09ce4efd-2860-4013-b158-a83a2fdcc811">
+				<reportElement x="247" y="80" width="78" height="11" forecolor="#000000" uuid="09ce4efd-2860-4013-b158-a83a2fdcc811">
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 				</reportElement>
 				<textElement>
@@ -171,7 +172,7 @@
 				<text><![CDATA[Total de lucro:]]></text>
 			</staticText>
 			<staticText>
-				<reportElement x="112" y="58" width="57" height="11" forecolor="#000000" uuid="952a2b7b-2b18-4daa-823e-3241f57c0708">
+				<reportElement x="112" y="58" width="56" height="11" forecolor="#000000" uuid="952a2b7b-2b18-4daa-823e-3241f57c0708">
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 					<property name="com.jaspersoft.studio.unit.width" value="px"/>
 				</reportElement>
@@ -182,7 +183,7 @@
 				<text><![CDATA[Fecha Inicio:]]></text>
 			</staticText>
 			<staticText>
-				<reportElement x="112" y="69" width="57" height="11" forecolor="#000000" uuid="d6c50cb5-67d5-41eb-8304-19f12525266e">
+				<reportElement x="112" y="69" width="55" height="11" forecolor="#000000" uuid="d6c50cb5-67d5-41eb-8304-19f12525266e">
 					<property name="com.jaspersoft.studio.unit.width" value="px"/>
 				</reportElement>
 				<box rightPadding="4"/>
@@ -233,7 +234,7 @@
 				</textElement>
 				<textFieldExpression><![CDATA[$P{costoTotal}]]></textFieldExpression>
 			</textField>
-			<textField pattern="#,##0.00'%'">
+			<textField pattern="#,##0.00&apos;%&apos;">
 				<reportElement x="491" y="80" width="62" height="11" forecolor="#000000" uuid="5bae2fe2-6a72-431f-80a2-939d18fe82f8">
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 				</reportElement>
@@ -276,7 +277,7 @@
 				<textFieldExpression><![CDATA[$P{filtroTexto}]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement x="169" y="69" width="153" height="11" forecolor="#000000" uuid="de978e8e-d9c0-41b3-92c5-845bf8bbf604">
+				<reportElement x="167" y="69" width="153" height="11" forecolor="#000000" uuid="de978e8e-d9c0-41b3-92c5-845bf8bbf604">
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 				</reportElement>
 				<textElement>
@@ -285,7 +286,7 @@
 				<textFieldExpression><![CDATA[$P{filtroFechaFin}]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement x="169" y="58" width="153" height="11" forecolor="#000000" uuid="9fea43b1-2dec-48a2-907d-79ceeb4c8b82">
+				<reportElement x="167" y="58" width="153" height="11" forecolor="#000000" uuid="9fea43b1-2dec-48a2-907d-79ceeb4c8b82">
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 				</reportElement>
 				<textElement>


### PR DESCRIPTION
### Qué resuelve 
Implementación del filtro por familia en el reporte de lucro por productos, permitiendo un análisis más preciso de la rentabilidad por categorías principales. Además, se optimizó el layout de los filtros en la interfaz de usuario para mejorar la usabilidad y el aprovechamiento del espacio horizontal.

### Como probarlo

1. Ingresar al módulo de reporte de lucro por producto.
2. Seleccionar una familia en el nuevo campo de filtro.
3. Verificar que los resultados en la tabla se filtren correctamente por la familia elegida.
4. Generar el reporte en PDF y confirmar que el filtro de familia aparezca en la cabecera y los datos coincidan con lo seleccionado.
5. Observar que los campos de búsqueda (Producto, Familia y Subfamilia) ahora se encuentran alineados en una sola fila con una distribución equilibrada.

### Impacto DB 
Ninguno.

### Riesgo 
Bajo.