### PR TITLE
fix(productos): estandarización esquema graphql

### DIFF
--- a/src/main/resources/graphql/productos/producto/productos.graphqls
+++ b/src/main/resources/graphql/productos/producto/productos.graphqls
@@ -81,17 +81,17 @@ extend type Query {
     producto(id:ID!):Producto
     productos(page:Int = 0, size:Int = 10):[Producto]!
     countProducto: Int
-    productoSearch(texto:String, offset:Int, sucursalId: Int, conStock: Boolean, isEnvase: Boolean, activo: Boolean):[Producto]
+    productoSearch(texto:String, offset:Int, sucursalId: ID, conStock: Boolean, isEnvase: Boolean, activo: Boolean):[Producto]
     productoPorProveedorId(id: ID!, texto: String): [Producto]
     productoPorSucursalStock(proId: ID!, sucId: ID!): Float
     productoPorCodigo(texto:String):Producto
     printProducto(id: ID!):Producto
     exportarReporte(texto: String): String
-    exportarReporteConFiltros(texto: String, codigo: Boolean, activo: Boolean, stock: Boolean, balanza: Boolean, vencimiento: Boolean, costoCero: Boolean, familiaId: Int, subfamiliaId: ID, stockFiltro: String, sucursalId: ID, usuarioId: ID, usuario: String): String
-    lucroPorProducto(fechaInicio: String, fechaFin: String, sucursalIdList: [Int], usuarioId: ID!, usuarioIdList:[ID], productoIdList:[ID], subfamiliaId: ID, familiaId: ID): String
+    exportarReporteConFiltros(texto: String, codigo: Boolean, activo: Boolean, stock: Boolean, balanza: Boolean, vencimiento: Boolean, costoCero: Boolean, familiaId: ID, subfamiliaId: ID, stockFiltro: String, sucursalId: ID, usuarioId: ID, usuario: String): String
+    lucroPorProducto(fechaInicio: String, fechaFin: String, sucursalIdList: [ID], usuarioId: ID!, usuarioIdList:[ID], productoIdList:[ID], subfamiliaId: ID, familiaId: ID): String
     lucroPorProductoList(fechaInicio: String, fechaFin: String, sucursalIdList: [ID], usuarioIdList: [ID], productoIdList: [ID], subfamiliaId: ID, page: Int, size: Int, familiaId: ID): LucroPorProductoResponse
-    imprimirCodigoBarra(codigoId: Int): Boolean
-    searchProductoWithFilters(texto: String, codigo: String, activo: Boolean, stock: Boolean, balanza: Boolean, familia: Int, subfamilia: Int, vencimiento: Boolean, costoCero: Boolean, stockFiltro: String, sucursalId: Int, page: Int, size: Int):ProductoPage
+    imprimirCodigoBarra(codigoId: ID): Boolean
+    searchProductoWithFilters(texto: String, codigo: String, activo: Boolean, stock: Boolean, balanza: Boolean, familia: ID, subfamilia: ID, vencimiento: Boolean, costoCero: Boolean, stockFiltro: String, sucursalId: ID, page: Int, size: Int):ProductoPage
     productoDescripcionExists(descripcion: String): Boolean
 }
 


### PR DESCRIPTION
### Qué resuelve 
Corrección de errores de validación de GraphQL (Query failed to validate) detectados en el servidor alpha. El problema se originaba por una discrepancia entre los tipos de variables enviados por el frontend (ID) y los tipos definidos en el esquema del backend (Int) para ciertos campos de identificadores. Se estandarizaron los parámetros de sucursal, familia y subfamilia al tipo ID en las consultas de productos y reportes de lucro para garantizar la compatibilidad entre entornos.

### Como probarlo

1. Ingresar al módulo de Lucro por Producto y aplicar filtros de Sucursal, Familia o Subfamilia.
2. Verificar que la tabla cargue los datos correctamente y que no se generen errores de validación en los logs del servidor ni en la consola del navegador.
3. Probar la generación de reportes en PDF y la búsqueda con filtros en el listado general de productos para asegurar que la estandarización no afectó otras funcionalidades.

### Impacto DB 
Ninguno.

### Riesgo 
Bajo

