### PR TITLE
fix(gastos): filtrar pre-gastos con Specification en lugar de SQL nativo

### DIFF
--- a/src/main/java/com/franco/dev/repository/financiero/PreGastoRepository.java
+++ b/src/main/java/com/franco/dev/repository/financiero/PreGastoRepository.java
@@ -4,14 +4,14 @@ import com.franco.dev.domain.EmbebedPrimaryKey;
 import com.franco.dev.domain.financiero.PreGasto;
 import com.franco.dev.domain.financiero.enums.EstadoPreGasto;
 import com.franco.dev.repository.HelperRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import java.util.List;
 
-public interface PreGastoRepository extends HelperRepository<PreGasto, EmbebedPrimaryKey> {
+public interface PreGastoRepository extends HelperRepository<PreGasto, EmbebedPrimaryKey>,
+        JpaSpecificationExecutor<PreGasto> {
 
     PreGasto findByIdAndSucursalId(Long id, Long sucursalId);
 
@@ -43,51 +43,6 @@ public interface PreGastoRepository extends HelperRepository<PreGasto, EmbebedPr
             "AND (CAST(:sucursalId AS bigint) IS NULL OR pg.sucursal_id = CAST(:sucursalId AS bigint)) " +
             "ORDER BY pg.id DESC", nativeQuery = true)
     List<PreGasto> buscarPorTexto(@Param("texto") String texto, @Param("sucursalId") Long sucursalId);
-
-    @Query(value = "SELECT pg.* FROM financiero.pre_gasto pg " +
-            "WHERE (CAST(:id AS bigint) IS NULL OR pg.id = CAST(:id AS bigint)) " +
-            "AND ((CAST(:id AS bigint) IS NOT NULL) OR CAST(:cajaId AS bigint) IS NULL OR pg.caja_id = CAST(:cajaId AS bigint)) " +
-            "AND (CAST(:estado AS text) IS NULL OR cast(pg.estado as text) = CAST(:estado AS text)) " +
-            "AND cast(pg.estado as text) IN (:estados) " +
-            "AND (CAST(:inicio AS text) IS NULL OR pg.creado_en >= CAST(CAST(:inicio AS text) AS timestamp)) " +
-            "AND (CAST(:fin AS text) IS NULL OR pg.creado_en <= CAST(CAST(:fin AS text) AS timestamp)) " +
-            "ORDER BY pg.id DESC",
-            countQuery = "SELECT count(*) FROM financiero.pre_gasto pg " +
-            "WHERE (CAST(:id AS bigint) IS NULL OR pg.id = CAST(:id AS bigint)) " +
-            "AND ((CAST(:id AS bigint) IS NOT NULL) OR CAST(:cajaId AS bigint) IS NULL OR pg.caja_id = CAST(:cajaId AS bigint)) " +
-            "AND (CAST(:estado AS text) IS NULL OR cast(pg.estado as text) = CAST(:estado AS text)) " +
-            "AND cast(pg.estado as text) IN (:estados) " +
-            "AND (CAST(:inicio AS text) IS NULL OR pg.creado_en >= CAST(CAST(:inicio AS text) AS timestamp)) " +
-            "AND (CAST(:fin AS text) IS NULL OR pg.creado_en <= CAST(CAST(:fin AS text) AS timestamp))",
-            nativeQuery = true)
-    Page<PreGasto> filterPreGastos(@Param("id") Long id,
-                                   @Param("cajaId") Long cajaId,
-                                   @Param("estado") String estado,
-                                   @Param("estados") List<String> estados,
-                                   @Param("inicio") String inicio,
-                                   @Param("fin") String fin,
-                                   Pageable pageable);
-
-    @Query(value = "SELECT pg.* FROM financiero.pre_gasto pg " +
-            "WHERE (CAST(:id AS bigint) IS NULL OR pg.id = CAST(:id AS bigint)) " +
-            "AND ((CAST(:id AS bigint) IS NOT NULL) OR CAST(:cajaId AS bigint) IS NULL OR pg.caja_id = CAST(:cajaId AS bigint)) " +
-            "AND (CAST(:estado AS text) IS NULL OR cast(pg.estado as text) = CAST(:estado AS text)) " +
-            "AND (CAST(:inicio AS text) IS NULL OR pg.creado_en >= CAST(CAST(:inicio AS text) AS timestamp)) " +
-            "AND (CAST(:fin AS text) IS NULL OR pg.creado_en <= CAST(CAST(:fin AS text) AS timestamp)) " +
-            "ORDER BY pg.id DESC",
-            countQuery = "SELECT count(*) FROM financiero.pre_gasto pg " +
-                    "WHERE (CAST(:id AS bigint) IS NULL OR pg.id = CAST(:id AS bigint)) " +
-                    "AND ((CAST(:id AS bigint) IS NOT NULL) OR CAST(:cajaId AS bigint) IS NULL OR pg.caja_id = CAST(:cajaId AS bigint)) " +
-                    "AND (CAST(:estado AS text) IS NULL OR cast(pg.estado as text) = CAST(:estado AS text)) " +
-                    "AND (CAST(:inicio AS text) IS NULL OR pg.creado_en >= CAST(CAST(:inicio AS text) AS timestamp)) " +
-                    "AND (CAST(:fin AS text) IS NULL OR pg.creado_en <= CAST(CAST(:fin AS text) AS timestamp))",
-            nativeQuery = true)
-    Page<PreGasto> filterPreGastosSinEstados(@Param("id") Long id,
-                                             @Param("cajaId") Long cajaId,
-                                             @Param("estado") String estado,
-                                             @Param("inicio") String inicio,
-                                             @Param("fin") String fin,
-                                             Pageable pageable);
 
     @Query(value = "SELECT max(pg.id) FROM financiero.pre_gasto pg WHERE pg.sucursal_id = CAST(:sucursalId AS bigint)", nativeQuery = true)
     Long findMaxId(@Param("sucursalId") Long sucursalId);

--- a/src/main/java/com/franco/dev/service/financiero/PreGastoService.java
+++ b/src/main/java/com/franco/dev/service/financiero/PreGastoService.java
@@ -34,6 +34,11 @@ import com.franco.dev.service.personas.ProveedorService;
 import com.franco.dev.service.personas.UsuarioService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -42,7 +47,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.criteria.Predicate;
+
+import static com.franco.dev.utilitarios.DateUtils.stringToDate;
 
 @Service
 @RequiredArgsConstructor
@@ -146,14 +156,59 @@ public class PreGastoService extends CrudService<PreGasto, PreGastoRepository, E
         return repository.buscarPorTexto(texto, sucursalId);
     }
 
-    public org.springframework.data.domain.Page<PreGasto> filterPreGastos(Long id, Long cajaId, String estado,
-            List<String> estados, String inicio,
-            String fin, org.springframework.data.domain.Pageable pageable) {
-        List<String> estadosFiltro = estados != null ? estados : new ArrayList<>();
-        if (estadosFiltro.isEmpty()) {
-            return repository.filterPreGastosSinEstados(id, cajaId, estado, inicio, fin, pageable);
-        }
-        return repository.filterPreGastos(id, cajaId, estado, estadosFiltro, inicio, fin, pageable);
+    public Page<PreGasto> filterPreGastos(Long id, Long cajaId, String estado,
+            List<String> estados, String inicio, String fin, Pageable pageable) {
+        Specification<PreGasto> spec = buildFilterSpecification(id, cajaId, estado, estados, inicio, fin);
+        Pageable sorted = PageRequest.of(
+                pageable.getPageNumber(),
+                pageable.getPageSize(),
+                Sort.by(Sort.Direction.DESC, "id"));
+        return repository.findAll(spec, sorted);
+    }
+
+    private Specification<PreGasto> buildFilterSpecification(Long id, Long cajaId, String estado,
+            List<String> estados, String inicio, String fin) {
+        return (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+
+            if (id != null) {
+                predicates.add(cb.equal(root.get("id"), id));
+            } else if (cajaId != null) {
+                predicates.add(cb.equal(root.get("cajaId"), cajaId));
+            }
+
+            if (estado != null && !estado.trim().isEmpty()) {
+                predicates.add(cb.equal(root.get("estado"), EstadoPreGasto.valueOf(estado.trim())));
+            }
+
+            if (estados != null && !estados.isEmpty()) {
+                List<EstadoPreGasto> estadosEnum = estados.stream()
+                        .filter(e -> e != null && !e.trim().isEmpty())
+                        .map(e -> EstadoPreGasto.valueOf(e.trim()))
+                        .collect(Collectors.toList());
+                if (!estadosEnum.isEmpty()) {
+                    predicates.add(root.get("estado").in(estadosEnum));
+                }
+            }
+
+            LocalDateTime inicioDt = stringToDate(inicio);
+            if (inicioDt != null) {
+                predicates.add(cb.greaterThanOrEqualTo(root.get("creadoEn"), inicioDt));
+            }
+
+            LocalDateTime finDt = stringToDate(fin);
+            if (finDt != null) {
+                predicates.add(cb.lessThanOrEqualTo(root.get("creadoEn"), finDt));
+            }
+
+            if (query != null) {
+                query.orderBy(cb.desc(root.get("id")));
+            }
+
+            return predicates.isEmpty()
+                    ? cb.conjunction()
+                    : cb.and(predicates.toArray(new Predicate[0]));
+        };
     }
 
     @Transactional


### PR DESCRIPTION
## Summary

- Reemplaza las consultas nativas `filterPreGastos` / `filterPreGastosSinEstados` por `JpaSpecificationExecutor` y Criteria API.
- Corrige el error de PostgreSQL `cannot cast type bytea to bigint` / `bigint = bytea` cuando Hibernate enlaza parámetros nulos en SQL nativo con `CAST`.
- Afecta pantallas que usan `filterPreGastos` (Venta Touch, Solicitudes de Gasto).

## Test plan

- [ ] Desplegar en servidor central y abrir Venta Touch con caja abierta: no debe aparecer error GraphQL en `/data`.
- [ ] Listar Solicitudes de Gasto con filtros por fecha y estado.
- [ ] Filtrar por `id`, `cajaId` y `estado` con valores nulos y no nulos.


Made with [Cursor](https://cursor.com)