### PR TITLE
feat(graficos): consultas ventas y compras por periodo para analisis de producto

### DIFF
--- a/src/main/java/com/franco/dev/graphql/operaciones/VentaItemGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/VentaItemGraphQL.java
@@ -4,6 +4,8 @@ import com.franco.dev.domain.EmbebedPrimaryKey;
 import com.franco.dev.domain.operaciones.Venta;
 import com.franco.dev.domain.operaciones.VentaItem;
 import com.franco.dev.graphql.operaciones.dto.ProductoVendidoEstadistica;
+import com.franco.dev.graphql.operaciones.dto.ProductoCompraPorPeriodo;
+import com.franco.dev.graphql.operaciones.dto.ProductoVentaPorPeriodo;
 import com.franco.dev.graphql.operaciones.input.VentaItemInput;
 import com.franco.dev.service.operaciones.VentaItemService;
 import com.franco.dev.service.operaciones.VentaService;
@@ -22,6 +24,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.Optional;
 
 @Component
@@ -106,7 +109,7 @@ public class VentaItemGraphQL implements GraphQLQueryResolver, GraphQLMutationRe
     }
 
     public List<ProductoVendidoEstadistica> productosMasVendidos(String inicio, String fin, Integer limit,
-            Long sucursalId, Long familiaId) {
+            Long sucursalId, Long familiaId, Boolean ascendente, Long productoId, List<Long> productoIds) {
         if (limit == null)
             limit = 10;
         LocalDateTime fechaInicio = null;
@@ -119,6 +122,71 @@ public class VentaItemGraphQL implements GraphQLQueryResolver, GraphQLMutationRe
             fechaFin = LocalDateTime.parse(fin, DATE_FORMATTER);
         }
 
-        return service.obtenerProductosMasVendidos(fechaInicio, fechaFin, limit, sucursalId, familiaId);
+        List<Long> idsFiltro = productoIds != null
+                ? productoIds.stream().filter(id -> id != null && id > 0).collect(Collectors.toList())
+                : null;
+
+        return service.obtenerProductosMasVendidos(fechaInicio, fechaFin, limit, sucursalId, familiaId, ascendente,
+                productoId, idsFiltro != null && !idsFiltro.isEmpty() ? idsFiltro : null);
+    }
+
+    public List<ProductoVentaPorPeriodo> ventasProductoPorDia(String inicio, String fin, Long productoId,
+            Long sucursalId) {
+        LocalDateTime fechaInicio = null;
+        LocalDateTime fechaFin = null;
+
+        if (inicio != null && !inicio.isEmpty()) {
+            fechaInicio = LocalDateTime.parse(inicio, DATE_FORMATTER);
+        }
+        if (fin != null && !fin.isEmpty()) {
+            fechaFin = LocalDateTime.parse(fin, DATE_FORMATTER);
+        }
+
+        return service.obtenerVentasProductoPorDia(fechaInicio, fechaFin, productoId, sucursalId);
+    }
+
+    public List<ProductoVentaPorPeriodo> ventasProductoPorMes(String inicio, String fin, Long productoId,
+            Long sucursalId) {
+        LocalDateTime fechaInicio = null;
+        LocalDateTime fechaFin = null;
+
+        if (inicio != null && !inicio.isEmpty()) {
+            fechaInicio = LocalDateTime.parse(inicio, DATE_FORMATTER);
+        }
+        if (fin != null && !fin.isEmpty()) {
+            fechaFin = LocalDateTime.parse(fin, DATE_FORMATTER);
+        }
+
+        return service.obtenerVentasProductoPorMes(fechaInicio, fechaFin, productoId, sucursalId);
+    }
+
+    public List<ProductoCompraPorPeriodo> comprasProductoPorDia(String inicio, String fin, Long productoId,
+            Long sucursalId) {
+        LocalDateTime fechaInicio = null;
+        LocalDateTime fechaFin = null;
+
+        if (inicio != null && !inicio.isEmpty()) {
+            fechaInicio = LocalDateTime.parse(inicio, DATE_FORMATTER);
+        }
+        if (fin != null && !fin.isEmpty()) {
+            fechaFin = LocalDateTime.parse(fin, DATE_FORMATTER);
+        }
+
+        return service.obtenerComprasProductoPorDia(fechaInicio, fechaFin, productoId, sucursalId);
+    }
+
+    public List<ProductoCompraPorPeriodo> comprasProductoPorMes(String inicio, String fin, Long productoId,
+            Long sucursalId) {
+        LocalDateTime fechaInicio = null;
+        LocalDateTime fechaFin = null;
+
+        if (inicio != null && !inicio.isEmpty()) {
+            fechaInicio = LocalDateTime.parse(inicio, DATE_FORMATTER);
+        }
+        if (fin != null && !fin.isEmpty()) {
+            fechaFin = LocalDateTime.parse(fin, DATE_FORMATTER);
+        }
+
+        return service.obtenerComprasProductoPorMes(fechaInicio, fechaFin, productoId, sucursalId);
     }
 }

--- a/src/main/java/com/franco/dev/graphql/operaciones/dto/ProductoCompraPorPeriodo.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/dto/ProductoCompraPorPeriodo.java
@@ -1,0 +1,14 @@
+package com.franco.dev.graphql.operaciones.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductoCompraPorPeriodo {
+    private String periodo;
+    private Double cantidad;
+    private Integer cantidadCompras;
+}

--- a/src/main/java/com/franco/dev/graphql/operaciones/dto/ProductoVentaPorPeriodo.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/dto/ProductoVentaPorPeriodo.java
@@ -1,0 +1,14 @@
+package com.franco.dev.graphql.operaciones.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductoVentaPorPeriodo {
+    private String periodo;
+    private Double cantidad;
+    private Double totalMonto;
+}

--- a/src/main/java/com/franco/dev/service/operaciones/VentaItemService.java
+++ b/src/main/java/com/franco/dev/service/operaciones/VentaItemService.java
@@ -7,6 +7,8 @@ import com.franco.dev.domain.operaciones.enums.VentaEstado;
 import com.franco.dev.domain.productos.CostoPorProducto;
 import com.franco.dev.domain.productos.Producto;
 import com.franco.dev.graphql.operaciones.dto.ProductoVendidoEstadistica;
+import com.franco.dev.graphql.operaciones.dto.ProductoCompraPorPeriodo;
+import com.franco.dev.graphql.operaciones.dto.ProductoVentaPorPeriodo;
 import com.franco.dev.repository.operaciones.VentaItemRepository;
 import com.franco.dev.service.CrudService;
 import com.franco.dev.service.productos.CostosPorProductoService;
@@ -67,7 +69,8 @@ public class VentaItemService extends CrudService<VentaItem, VentaItemRepository
      * CriteriaBuilder
      */
     public List<ProductoVendidoEstadistica> obtenerProductosMasVendidos(LocalDateTime inicio, LocalDateTime fin,
-            Integer limit, Long sucursalId, Long familiaId) {
+            Integer limit, Long sucursalId, Long familiaId, Boolean ascendente, Long productoId,
+            List<Long> productoIds) {
         String sql = "SELECT p.id, p.descripcion, SUM(vi.cantidad) as cantidad, " +
                 "SUM((vi.precio * vi.cantidad) - COALESCE(vi.descuento_unitario * vi.cantidad, 0)) as total_monto " +
                 "FROM operaciones.venta_item vi " +
@@ -80,20 +83,154 @@ public class VentaItemService extends CrudService<VentaItem, VentaItemRepository
         if (fin != null) sql += "AND vi.creado_en < :fin ";
         if (sucursalId != null && sucursalId > 0) sql += "AND vi.sucursal_id = :sucursalId ";
         if (familiaId != null && familiaId > 0) sql += "AND sf.familia_id = :familiaId ";
+        if (productoIds != null && !productoIds.isEmpty()) {
+            sql += "AND vi.producto_id IN :productoIds ";
+        } else if (productoId != null && productoId > 0) {
+            sql += "AND vi.producto_id = :productoId ";
+        }
 
-        sql += "GROUP BY p.id, p.descripcion ORDER BY total_monto DESC";
+        boolean ordenAsc = Boolean.TRUE.equals(ascendente);
+        sql += "GROUP BY p.id, p.descripcion ORDER BY cantidad " + (ordenAsc ? "ASC" : "DESC");
 
         javax.persistence.Query query = em.createNativeQuery(sql);
         if (inicio != null) query.setParameter("inicio", inicio);
         if (fin != null) query.setParameter("fin", fin);
         if (sucursalId != null && sucursalId > 0) query.setParameter("sucursalId", sucursalId);
         if (familiaId != null && familiaId > 0) query.setParameter("familiaId", familiaId);
+        if (productoIds != null && !productoIds.isEmpty()) {
+            query.setParameter("productoIds", productoIds);
+        } else if (productoId != null && productoId > 0) {
+            query.setParameter("productoId", productoId);
+        }
 
         query.setMaxResults(limit != null ? limit : 10);
 
+        @SuppressWarnings("unchecked")
         List<Object[]> resultados = query.getResultList();
 
         return transformarResultadosAEstadisticas(resultados);
+    }
+
+    public List<ProductoVentaPorPeriodo> obtenerVentasProductoPorDia(LocalDateTime inicio, LocalDateTime fin,
+            Long productoId, Long sucursalId) {
+        String sql = "SELECT CAST(vi.creado_en AS DATE) as periodo, SUM(vi.cantidad) as cantidad, " +
+                "SUM((vi.precio * vi.cantidad) - COALESCE(vi.descuento_unitario * vi.cantidad, 0)) as total_monto " +
+                "FROM operaciones.venta_item vi " +
+                "JOIN operaciones.venta v ON vi.venta_id = v.id AND vi.sucursal_id = v.sucursal_id " +
+                "WHERE v.estado = 'CONCLUIDA' AND vi.activo = true AND vi.producto_id = :productoId ";
+
+        if (inicio != null) sql += "AND vi.creado_en >= :inicio ";
+        if (fin != null) sql += "AND vi.creado_en < :fin ";
+        if (sucursalId != null && sucursalId > 0) sql += "AND vi.sucursal_id = :sucursalId ";
+
+        sql += "GROUP BY CAST(vi.creado_en AS DATE) ORDER BY periodo ASC";
+
+        javax.persistence.Query query = em.createNativeQuery(sql);
+        query.setParameter("productoId", productoId);
+        if (inicio != null) query.setParameter("inicio", inicio);
+        if (fin != null) query.setParameter("fin", fin);
+        if (sucursalId != null && sucursalId > 0) query.setParameter("sucursalId", sucursalId);
+
+        @SuppressWarnings("unchecked")
+        List<Object[]> resultados = query.getResultList();
+        return mapearPeriodos(resultados);
+    }
+
+    public List<ProductoVentaPorPeriodo> obtenerVentasProductoPorMes(LocalDateTime inicio, LocalDateTime fin,
+            Long productoId, Long sucursalId) {
+        String sql = "SELECT TO_CHAR(vi.creado_en, 'YYYY-MM') as periodo, SUM(vi.cantidad) as cantidad, " +
+                "SUM((vi.precio * vi.cantidad) - COALESCE(vi.descuento_unitario * vi.cantidad, 0)) as total_monto " +
+                "FROM operaciones.venta_item vi " +
+                "JOIN operaciones.venta v ON vi.venta_id = v.id AND vi.sucursal_id = v.sucursal_id " +
+                "WHERE v.estado = 'CONCLUIDA' AND vi.activo = true AND vi.producto_id = :productoId ";
+
+        if (inicio != null) sql += "AND vi.creado_en >= :inicio ";
+        if (fin != null) sql += "AND vi.creado_en < :fin ";
+        if (sucursalId != null && sucursalId > 0) sql += "AND vi.sucursal_id = :sucursalId ";
+
+        sql += "GROUP BY TO_CHAR(vi.creado_en, 'YYYY-MM') ORDER BY periodo ASC";
+
+        javax.persistence.Query query = em.createNativeQuery(sql);
+        query.setParameter("productoId", productoId);
+        if (inicio != null) query.setParameter("inicio", inicio);
+        if (fin != null) query.setParameter("fin", fin);
+        if (sucursalId != null && sucursalId > 0) query.setParameter("sucursalId", sucursalId);
+
+        @SuppressWarnings("unchecked")
+        List<Object[]> resultados = query.getResultList();
+        return mapearPeriodos(resultados);
+    }
+
+    public List<ProductoCompraPorPeriodo> obtenerComprasProductoPorDia(LocalDateTime inicio, LocalDateTime fin,
+            Long productoId, Long sucursalId) {
+        String sql = "SELECT CAST(rm.fecha AS DATE) as periodo, SUM(rmi.cantidad_recibida) as cantidad, " +
+                "COUNT(DISTINCT rm.id) as cantidad_compras " +
+                "FROM operaciones.recepcion_mercaderia_item rmi " +
+                "JOIN operaciones.recepcion_mercaderia rm ON rmi.recepcion_mercaderia_id = rm.id " +
+                "WHERE rm.estado = 'FINALIZADA' AND rmi.producto_id = :productoId ";
+
+        if (inicio != null) sql += "AND rm.fecha >= :inicio ";
+        if (fin != null) sql += "AND rm.fecha < :fin ";
+        if (sucursalId != null && sucursalId > 0) sql += "AND rmi.sucursal_entrega_id = :sucursalId ";
+
+        sql += "GROUP BY CAST(rm.fecha AS DATE) ORDER BY periodo ASC";
+
+        javax.persistence.Query query = em.createNativeQuery(sql);
+        query.setParameter("productoId", productoId);
+        if (inicio != null) query.setParameter("inicio", inicio);
+        if (fin != null) query.setParameter("fin", fin);
+        if (sucursalId != null && sucursalId > 0) query.setParameter("sucursalId", sucursalId);
+
+        @SuppressWarnings("unchecked")
+        List<Object[]> resultados = query.getResultList();
+        return mapearComprasPeriodos(resultados);
+    }
+
+    public List<ProductoCompraPorPeriodo> obtenerComprasProductoPorMes(LocalDateTime inicio, LocalDateTime fin,
+            Long productoId, Long sucursalId) {
+        String sql = "SELECT TO_CHAR(rm.fecha, 'YYYY-MM') as periodo, SUM(rmi.cantidad_recibida) as cantidad, " +
+                "COUNT(DISTINCT rm.id) as cantidad_compras " +
+                "FROM operaciones.recepcion_mercaderia_item rmi " +
+                "JOIN operaciones.recepcion_mercaderia rm ON rmi.recepcion_mercaderia_id = rm.id " +
+                "WHERE rm.estado = 'FINALIZADA' AND rmi.producto_id = :productoId ";
+
+        if (inicio != null) sql += "AND rm.fecha >= :inicio ";
+        if (fin != null) sql += "AND rm.fecha < :fin ";
+        if (sucursalId != null && sucursalId > 0) sql += "AND rmi.sucursal_entrega_id = :sucursalId ";
+
+        sql += "GROUP BY TO_CHAR(rm.fecha, 'YYYY-MM') ORDER BY periodo ASC";
+
+        javax.persistence.Query query = em.createNativeQuery(sql);
+        query.setParameter("productoId", productoId);
+        if (inicio != null) query.setParameter("inicio", inicio);
+        if (fin != null) query.setParameter("fin", fin);
+        if (sucursalId != null && sucursalId > 0) query.setParameter("sucursalId", sucursalId);
+
+        @SuppressWarnings("unchecked")
+        List<Object[]> resultados = query.getResultList();
+        return mapearComprasPeriodos(resultados);
+    }
+
+    private List<ProductoCompraPorPeriodo> mapearComprasPeriodos(List<Object[]> resultados) {
+        List<ProductoCompraPorPeriodo> periodos = new ArrayList<>();
+        for (Object[] fila : resultados) {
+            String periodo = fila[0] != null ? fila[0].toString() : "";
+            Double cantidad = fila[1] != null ? ((Number) fila[1]).doubleValue() : 0.0;
+            Integer cantidadCompras = fila[2] != null ? ((Number) fila[2]).intValue() : 0;
+            periodos.add(new ProductoCompraPorPeriodo(periodo, cantidad, cantidadCompras));
+        }
+        return periodos;
+    }
+
+    private List<ProductoVentaPorPeriodo> mapearPeriodos(List<Object[]> resultados) {
+        List<ProductoVentaPorPeriodo> periodos = new ArrayList<>();
+        for (Object[] fila : resultados) {
+            String periodo = fila[0] != null ? fila[0].toString() : "";
+            Double cantidad = fila[1] != null ? ((Number) fila[1]).doubleValue() : 0.0;
+            Double totalMonto = fila[2] != null ? ((Number) fila[2]).doubleValue() : 0.0;
+            periodos.add(new ProductoVentaPorPeriodo(periodo, cantidad, totalMonto));
+        }
+        return periodos;
     }
 
     /**

--- a/src/main/resources/graphql/operaciones/venta-item.graphqls
+++ b/src/main/resources/graphql/operaciones/venta-item.graphqls
@@ -39,12 +39,28 @@ type ProductoVendidoEstadistica {
     porcentaje: Float
 }
 
+type ProductoVentaPorPeriodo {
+    periodo: String
+    cantidad: Float
+    totalMonto: Float
+}
+
+type ProductoCompraPorPeriodo {
+    periodo: String
+    cantidad: Float
+    cantidadCompras: Int
+}
+
 extend type Query {
     ventaItem(id:ID!, sucId: ID):VentaItem
     ventaItems(page:Int = 0, size:Int = 10, sucId: ID):[VentaItem]!
     countVentaItem: Int
     ventaItemListPorVentaId(id:ID!, sucId: ID):[VentaItem]
-    productosMasVendidos(inicio: String, fin: String, limit: Int, sucursalId: ID, familiaId: ID): [ProductoVendidoEstadistica]
+    productosMasVendidos(inicio: String, fin: String, limit: Int, sucursalId: ID, familiaId: ID, ascendente: Boolean, productoId: ID, productoIds: [ID]): [ProductoVendidoEstadistica]
+    ventasProductoPorDia(inicio: String, fin: String, productoId: ID!, sucursalId: ID): [ProductoVentaPorPeriodo]
+    ventasProductoPorMes(inicio: String, fin: String, productoId: ID!, sucursalId: ID): [ProductoVentaPorPeriodo]
+    comprasProductoPorDia(inicio: String, fin: String, productoId: ID!, sucursalId: ID): [ProductoCompraPorPeriodo]
+    comprasProductoPorMes(inicio: String, fin: String, productoId: ID!, sucursalId: ID): [ProductoCompraPorPeriodo]
 }
 
 extend type Mutation {


### PR DESCRIPTION
## Summary
- Agrega DTOs `ProductoVentaPorPeriodo` y `ProductoCompraPorPeriodo` para series temporales del analisis de producto.
- Expone queries GraphQL `ventasProductoPorDia`, `ventasProductoPorMes`, `comprasProductoPorDia` y `comprasProductoPorMes`.
- Extiende `productosMasVendidos` con filtros por producto, ranking ascendente/descendente y multiples IDs.
- Implementa agregaciones en `VentaItemService` usando ventas concluidas y recepciones de mercaderia finalizadas.

## Test plan
- [ ] Reiniciar el backend y verificar el schema GraphQL en `/graphql`.
- [ ] Probar `comprasProductoPorMes` y `ventasProductoPorMes` con un `productoId` y rango de fechas valido.
- [ ] Validar `productosMasVendidos` con `ascendente`, `productoId` y `productoIds`.
- [ ] Confirmar que el modulo Angular de analisis de producto carga ventas y compras en el grafico temporal.


Made with [Cursor](https://cursor.com)