### PR TITLE
chore(config): activar perfil user-dev y comentar suscripciones de filiales

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,7 +9,7 @@
 #spring.devtools.livereload.enabled=true
 #spring.devtools.restart.enabled=false
 #spring.devtools.restart.exclude=static/**,public/**,templates/**,META-INF/**,resources/**
-
+spring.profiles.active=user-dev
 # ----------------------------------------------------------------------------
 # DataSource Configuration
 # ----------------------------------------------------------------------------

--- a/src/main/resources/db/migration/V0__initial_schema.sql
+++ b/src/main/resources/db/migration/V0__initial_schema.sql
@@ -15296,28 +15296,28 @@ ALTER PUBLICATION central_pub ADD TABLE ONLY vehiculos.vehiculo_sucursal;
 
 -- Name: filial_farmacia_1_sub; Type: SUBSCRIPTION; Schema: -; Owner: -
 --
-CREATE SUBSCRIPTION filial_farmacia_1_sub CONNECTION 'dbname=general host=172.25.3.1 user=franco password=franco port=5551' PUBLICATION filial1_pub WITH (connect = false, slot_name = 'filial_farmacia_1_sub', origin = none);
+--CREATE SUBSCRIPTION filial_farmacia_1_sub CONNECTION 'dbname=general host=172.25.3.1 user=franco password=franco port=5551' PUBLICATION filial1_pub WITH (connect = false, slot_name = 'filial_farmacia_1_sub', origin = none);
 
 
 --
 -- Name: filial_farmacia_2_sub; Type: SUBSCRIPTION; Schema: -; Owner: -
 --
 
-CREATE SUBSCRIPTION filial_farmacia_2_sub CONNECTION 'dbname=general host=172.25.3.2 user=franco password=franco port=5551' PUBLICATION filial2_pub WITH (connect = false, slot_name = 'filial_farmacia_2_sub', origin = none);
+--CREATE SUBSCRIPTION filial_farmacia_2_sub CONNECTION 'dbname=general host=172.25.3.2 user=franco password=franco port=5551' PUBLICATION filial2_pub WITH (connect = false, slot_name = 'filial_farmacia_2_sub', origin = none);
 
 
 --
 -- Name: filial_farmacia_3_sub; Type: SUBSCRIPTION; Schema: -; Owner: -
 --
 
-CREATE SUBSCRIPTION filial_farmacia_3_sub CONNECTION 'dbname=general host=172.25.3.3 user=franco password=franco port=5551' PUBLICATION filial3_pub WITH (connect = false, slot_name = 'filial_farmacia_3_sub', origin = none);
+--CREATE SUBSCRIPTION filial_farmacia_3_sub CONNECTION 'dbname=general host=172.25.3.3 user=franco password=franco port=5551' PUBLICATION filial3_pub WITH (connect = false, slot_name = 'filial_farmacia_3_sub', origin = none);
 
 
 --
 -- Name: filial_farmacia_4_sub; Type: SUBSCRIPTION; Schema: -; Owner: -
 --
 
-CREATE SUBSCRIPTION filial_farmacia_4_sub CONNECTION 'dbname=general host=172.25.3.4 user=franco password=franco port=5551' PUBLICATION filial4_pub WITH (connect = false, slot_name = 'filial_farmacia_4_sub', origin = none);
+--CREATE SUBSCRIPTION filial_farmacia_4_sub CONNECTION 'dbname=general host=172.25.3.4 user=franco password=franco port=5551' PUBLICATION filial4_pub WITH (connect = false, slot_name = 'filial_farmacia_4_sub', origin = none);
 
 
 --


### PR DESCRIPTION
## Summary
- Activa el perfil `user-dev` en `application.properties` para el entorno de desarrollo local.
- Comenta las suscripciones de replicación de filiales (`filial_farmacia_1_sub` a `filial_farmacia_4_sub`) en el schema inicial para evitar conexiones a hosts de filiales durante el arranque local.

## Test plan
- [ ] Verificar que la aplicación arranca correctamente con el perfil `user-dev` activo.
- [ ] Confirmar que Flyway aplica `V0__initial_schema.sql` sin errores de suscripción.
- [ ] Validar que en entornos de producción/staging las suscripciones sigan configuradas según corresponda.


Made with [Cursor](https://cursor.com)