### PR TITLE
fix(ci): respaldo de token para descargar dependencia

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           </settings>
           EOF
         env:
-          PACKAGES_PAT: ${{ secrets.PACKAGES_PAT }}
+          PACKAGES_PAT: ${{ secrets.PACKAGES_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Build & Test
         run: ./mvnw clean verify -B -DskipFlyway=true
@@ -57,7 +57,7 @@ jobs:
           SPRING_DATASOURCE_URL: jdbc:postgresql://localhost:5432/bodega
           SPRING_DATASOURCE_USERNAME: franco
           SPRING_DATASOURCE_PASSWORD: franco
-          PACKAGES_PAT: ${{ secrets.PACKAGES_PAT }}
+          PACKAGES_PAT: ${{ secrets.PACKAGES_PAT || secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
 
       - name: Upload JAR artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,5 +44,5 @@ jobs:
         run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PACKAGES_PAT: ${{ secrets.PACKAGES_PAT }}
+          PACKAGES_PAT: ${{ secrets.PACKAGES_PAT || secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}


### PR DESCRIPTION
# Descripcion del Pull Request

## Que resuelve
Corrige los fallos de compilacion en el pipeline de Integracion Continua (CI) de GitHub Actions ocurridos durante la descarga de la dependencia customizada jsifenlib desde GitHub Packages. 

Anteriormente, el pipeline dependia exclusivamente del secreto PACKAGES_PAT. Este secreto no esta disponible en determinados contextos de ejecucion de Pull Requests por politicas de seguridad de GitHub, o bien puede expirar, provocando fallos de autenticacion (error 401 Unauthorized) en Maven.

Se implemento un mecanismo de respaldo (fallback) que utiliza la variable nativa secrets.GITHUB_TOKEN si secrets.PACKAGES_PAT no esta definido o se encuentra vacio:
* PACKAGES_PAT: ${{ secrets.PACKAGES_PAT || secrets.GITHUB_TOKEN }}

Esto aplica tanto para el workflow de CI (ci.yml) como para el de liberacion (release.yml).

## Como probarlo
1. Crear un Pull Request en el repositorio Franco System Backend Servidor.
2. Verificar que los pasos "Configure Maven settings (GitHub Packages)" y "Build & Test" del workflow de GitHub Actions se completen exitosamente.
3. Confirmar que Maven logra resolver y descargar la dependencia io.github.gabfrank:jsifenlib sin arrojar errores de autorizacion.

## Impacto DB
No aplica. Este cambio es exclusivo de la configuracion de infraestructura de CI/CD.

## Riesgo
Bajo. Solo modifica variables de entorno en los archivos de definicion de workflows de GitHub Actions (.github/workflows/ci.yml y .github/workflows/release.yml) sin alterar el codigo fuente de la aplicacion.
