### PR TITLE
feat(productos): búsqueda por código escaneado y fix exportación Lucene

### DIFF
--- a/src/main/java/com/franco/dev/service/productos/ProductoService.java
+++ b/src/main/java/com/franco/dev/service/productos/ProductoService.java
@@ -187,8 +187,14 @@ public class ProductoService extends CrudService<Producto, ProductoRepository, L
     private Page<Producto> buscarConFiltrosLucene(String texto, Boolean activo, Boolean stock, Boolean balanza,
             Long subfamiliaId, Long familiaId, Boolean vencimiento, Boolean costoCero, String stockFiltro,
             Long sucursalId, Pageable page) {
-        int overFetch = Math.min(2000, (page.getPageNumber() + 1) * page.getPageSize() * 8);
-        overFetch = Math.max(overFetch, 100);
+        final int overFetch;
+        if (page.isUnpaged()) {
+            // En exportación se usa Pageable.unpaged(); evitar getPageNumber/getPageSize
+            // porque Unpaged lanza UnsupportedOperationException.
+            overFetch = 50000;
+        } else {
+            overFetch = Math.max(Math.min(2000, (page.getPageNumber() + 1) * page.getPageSize() * 8), 100);
+        }
 
         List<Long> ids = productoSearchService.buscarIdsPorTexto(
                 texto, overFetch, activo, null, familiaId, subfamiliaId);
@@ -208,6 +214,10 @@ public class ProductoService extends CrudService<Producto, ProductoRepository, L
                 .collect(Collectors.toList());
 
         int total = ordenados.size();
+        if (page.isUnpaged()) {
+            return new PageImpl<>(ordenados, Pageable.unpaged(), total);
+        }
+
         int from = (int) page.getOffset();
         int to = Math.min(from + page.getPageSize(), total);
         List<Producto> content = from >= total ? Collections.emptyList() : ordenados.subList(from, to);

--- a/src/main/java/com/franco/dev/service/productos/ProductoService.java
+++ b/src/main/java/com/franco/dev/service/productos/ProductoService.java
@@ -290,7 +290,16 @@ public class ProductoService extends CrudService<Producto, ProductoRepository, L
     }
 
     public Producto findByCodigo(String texto) {
-        return repository.findByCodigo(texto);
+        if (texto == null || texto.isBlank()) {
+            return null;
+        }
+        for (String codigo : com.franco.dev.utilitarios.BarcodeSearchUtils.codigosParaBuscar(texto)) {
+            Producto producto = repository.findByCodigo(codigo);
+            if (producto != null) {
+                return producto;
+            }
+        }
+        return null;
     }
 
     public List<Producto> findAllForPdv() {

--- a/src/main/java/com/franco/dev/utilitarios/BarcodeSearchUtils.java
+++ b/src/main/java/com/franco/dev/utilitarios/BarcodeSearchUtils.java
@@ -1,0 +1,86 @@
+package com.franco.dev.utilitarios;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Interpreta escaneos de código de barras / QR y genera candidatos para búsqueda en BD.
+ */
+public final class BarcodeSearchUtils {
+
+    private static final Pattern NUMERIC_PREFIX = Pattern.compile("^(\\d{6,14})");
+    private static final Pattern ALPHANUM_TOKEN = Pattern.compile("^([A-Z0-9][A-Z0-9\\-._]{3,31})", Pattern.CASE_INSENSITIVE);
+    private static final Pattern SINGLE_TOKEN = Pattern.compile("^[A-Z0-9\\-._]{4,32}$", Pattern.CASE_INSENSITIVE);
+    private static final Pattern GS1_GTIN = Pattern.compile("\\(01\\)(\\d{14})");
+
+    private BarcodeSearchUtils() {
+    }
+
+    public static List<String> codigosParaBuscar(String texto) {
+        List<String> candidatos = new ArrayList<>();
+        if (texto == null || texto.isBlank()) {
+            return candidatos;
+        }
+
+        String trimmed = texto.trim();
+        String upper = trimmed.toUpperCase();
+
+        if (esCodigoPesable(trimmed)) {
+            agregar(candidatos, trimmed);
+        }
+
+        Matcher numeric = NUMERIC_PREFIX.matcher(trimmed);
+        String prefijoNumerico = null;
+        if (numeric.find()) {
+            prefijoNumerico = numeric.group(1);
+            agregar(candidatos, prefijoNumerico);
+        }
+
+        Matcher gs1 = GS1_GTIN.matcher(trimmed);
+        if (gs1.find()) {
+            String gtin14 = gs1.group(1);
+            agregar(candidatos, gtin14);
+            if (gtin14.length() == 14 && gtin14.startsWith("0")) {
+                agregar(candidatos, gtin14.substring(1));
+            }
+        }
+
+        Matcher alpha = ALPHANUM_TOKEN.matcher(trimmed);
+        if (alpha.find()) {
+            String token = alpha.group(1);
+            if (prefijoNumerico == null || !token.equalsIgnoreCase(prefijoNumerico)) {
+                agregar(candidatos, token);
+            }
+        }
+
+        if (!trimmed.contains(" ") && SINGLE_TOKEN.matcher(trimmed).matches()) {
+            agregar(candidatos, upper);
+        }
+
+        if (trimmed.matches("\\d{6,14}")) {
+            agregar(candidatos, trimmed);
+        }
+
+        return candidatos;
+    }
+
+    public static boolean esCodigoPesable(String texto) {
+        if (texto == null) {
+            return false;
+        }
+        String t = texto.trim();
+        return t.length() == 13 && t.startsWith("20");
+    }
+
+    private static void agregar(List<String> lista, String codigo) {
+        if (codigo == null || codigo.isBlank()) {
+            return;
+        }
+        String normalizado = codigo.trim().toUpperCase();
+        if (!lista.contains(normalizado)) {
+            lista.add(normalizado);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Mejora `findByCodigo` para resolver productos a partir de escaneos de código de barras/QR (GTIN GS1, prefijos numéricos, tokens alfanuméricos y códigos pesables) mediante `BarcodeSearchUtils`.
- Corrige la búsqueda con filtros Lucene cuando se usa `Pageable.unpaged()` (exportación), evitando `UnsupportedOperationException` al invocar `getPageNumber()` / `getPageSize()` en un pageable sin paginación.

## Test plan

- [ ] Buscar producto escaneando código de barras EAN/GTIN en PDV o listado de productos
- [ ] Buscar con código pesable (prefijo `20`, 13 dígitos)
- [ ] Exportar listado de productos con filtro de texto activo (búsqueda Lucene) y verificar que no falle
- [ ] Verificar que la búsqueda paginada normal sigue funcionando con los mismos filtros


Made with [Cursor](https://cursor.com)