### PR TITLE
fix(compras): evitar cast Integer a Long en savePedidoFull

### DIFF
--- a/src/main/java/com/franco/dev/graphql/operaciones/PedidoGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/PedidoGraphQL.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.HashSet;
 
 import static com.franco.dev.utilitarios.DateUtils.stringToDate;
 
@@ -134,8 +133,8 @@ public class PedidoGraphQL implements GraphQLQueryResolver, GraphQLMutationResol
     }
 
     public Pedido savePedidoFull(PedidoInput input, List<String> fechaEntregaList,
-            List<Long> sucursalEntregaList, List<Long> sucursalInfluenciaList,
-            Long usuarioId) {
+            List<Integer> sucursalEntregaList, List<Integer> sucursalInfluenciaList,
+            Integer usuarioId) {
         ModelMapper m = new ModelMapper();
         Boolean isNew = input.getId() == null;
         Pedido e = m.map(input, Pedido.class);
@@ -153,29 +152,34 @@ public class PedidoGraphQL implements GraphQLQueryResolver, GraphQLMutationResol
         Pedido pedido = service.save(e);
 
         if (fechaEntregaList != null) {
-            updatePedidoFechaEntrega(pedido, fechaEntregaList, usuarioId);
+            updatePedidoFechaEntrega(pedido, fechaEntregaList, usuarioId != null ? usuarioId.longValue() : null);
         }
         if (sucursalEntregaList != null) {
             // Si la lista contiene -1, significa "Todos" - obtener todas las sucursales de entrega (deposito=true y activo=true)
-            List<Long> sucursalesEntregaFinal = sucursalEntregaList;
-            if (sucursalEntregaList.contains(-1L)) {
+            List<Long> sucursalesEntregaFinal = sucursalEntregaList.stream()
+                    .map(Integer::longValue)
+                    .collect(Collectors.toList());
+            if (sucursalEntregaList.contains(-1)) {
                 sucursalesEntregaFinal = sucursalService.findAllSucursalesEntrega()
                         .stream()
                         .map(Sucursal::getId)
                         .collect(Collectors.toList());
             }
-            updatePedidoSucursalEntrega(pedido, sucursalesEntregaFinal, usuarioId);
+            updatePedidoSucursalEntrega(pedido, sucursalesEntregaFinal, usuarioId != null ? usuarioId.longValue() : null);
         }
         if (sucursalInfluenciaList != null) {
             // Si la lista contiene -1, significa "Todos" - obtener todas las sucursales de influencia (activo=true y excluir servidor)
-            List<Long> sucursalesInfluenciaFinal = sucursalInfluenciaList;
-            if (sucursalInfluenciaList.contains(-1L)) {
+            List<Long> sucursalesInfluenciaFinal = sucursalInfluenciaList.stream()
+                    .map(Integer::longValue)
+                    .collect(Collectors.toList());
+            if (sucursalInfluenciaList.contains(-1)) {
                 sucursalesInfluenciaFinal = sucursalService.findAllSucursalesInfluencia()
                         .stream()
                         .map(Sucursal::getId)
                         .collect(Collectors.toList());
             }
-            updatePedidoSucursalInfluencia(pedido, sucursalesInfluenciaFinal, usuarioId);
+            updatePedidoSucursalInfluencia(pedido, sucursalesInfluenciaFinal,
+                    usuarioId != null ? usuarioId.longValue() : null);
         }
 
         if (isNew) {
@@ -189,7 +193,7 @@ public class PedidoGraphQL implements GraphQLQueryResolver, GraphQLMutationResol
 
     @Transactional
     public void updatePedidoFechaEntrega(Pedido pedido, List<String> newDates, Long usuarioId) {
-        Usuario usuario = usuarioService.findById(usuarioId).orElse(null);
+        Usuario usuario = usuarioId != null ? usuarioService.findById(usuarioId).orElse(null) : null;
         Set<LocalDateTime> newDatesSet = newDates.stream()
                 .map(dateStr -> stringToDate(dateStr))
                 .collect(Collectors.toSet());
@@ -220,7 +224,7 @@ public class PedidoGraphQL implements GraphQLQueryResolver, GraphQLMutationResol
 
     @Transactional
     public void updatePedidoSucursalEntrega(Pedido pedido, List<Long> newSucursalesList, Long usuarioId) {
-        Usuario usuario = usuarioService.findById(usuarioId).orElse(null);
+        Usuario usuario = usuarioId != null ? usuarioService.findById(usuarioId).orElse(null) : null;
         // Filtrar: solo procesar sucursales con deposito=true y activo=true, excluir servidor (id 0)
         List<Long> newDatesSet = newSucursalesList.stream()
                 .filter(id -> !id.equals(0L))
@@ -266,7 +270,7 @@ public class PedidoGraphQL implements GraphQLQueryResolver, GraphQLMutationResol
 
     @Transactional
     public void updatePedidoSucursalInfluencia(Pedido pedido, List<Long> newSucursalesList, Long usuarioId) {
-        Usuario usuario = usuarioService.findById(usuarioId).orElse(null);
+        Usuario usuario = usuarioId != null ? usuarioService.findById(usuarioId).orElse(null) : null;
         // Filtrar: solo procesar sucursales con activo=true, excluir servidor (id 0)
         List<Long> newDatesSet = newSucursalesList.stream()
                 .filter(id -> !id.equals(0L))


### PR DESCRIPTION
## Summary
- Ajusta `savePedidoFull` para recibir listas e `usuarioId` como `Int` desde GraphQL y convertirlos explícitamente a `Long` en el resolver.
- Evita el `ClassCastException` (`Integer` -> `Long`) al procesar sucursales de entrega/influencia durante el guardado del pedido.
- Mantiene el contrato GraphQL actual sin incluir cambios locales de configuración (`application.properties` y `V0__initial_schema.sql`).

## Test plan
- [ ] Ejecutar `savePedidoFull` desde la UI de compras con sucursales de entrega e influencia.
- [ ] Verificar que ya no aparece `class java.lang.Integer cannot be cast to class java.lang.Long`.
- [ ] Confirmar que el pedido se guarda correctamente con sus relaciones de sucursales.

Made with [Cursor](https://cursor.com)