### PR TITLE
fix(deploy): inyectar credenciales Firebase en el JAR durante deploy

### DIFF
--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -32,6 +32,13 @@ if [[ ! -f "${RELEASE_DIR}/${JAR_NAME}" ]]; then
   exit 1
 fi
 
+FIREBASE_FILE="bodega-franco-frc-18e8c6ef35cf.json"
+if jar tf "${RELEASE_DIR}/${JAR_NAME}" | grep -q "${FIREBASE_FILE}"; then
+  echo "Firebase credentials found in JAR"
+else
+  echo "WARNING: Firebase credentials not found in JAR (${FIREBASE_FILE}). Push notifications will fail."
+fi
+
 # --- Save current version for rollback ---
 PREVIOUS_VERSION=""
 if [[ -f "${INSTANCE_DIR}/.current-version" ]]; then

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,6 +85,38 @@ jobs:
               | jq -r '.assets[] | select(.name == "frc-central-server.jar") | .url')"
           ls -lh frc-central-server.jar
 
+      - name: Inject Firebase credentials into JAR
+        env:
+          FIREBASE_CREDENTIALS_JSON: ${{ secrets.FIREBASE_CREDENTIALS_JSON }}
+        run: |
+          FIREBASE_FILE="bodega-franco-frc-18e8c6ef35cf.json"
+
+          if [[ -z "${FIREBASE_CREDENTIALS_JSON}" ]]; then
+            echo "WARNING: FIREBASE_CREDENTIALS_JSON secret is not set. Skipping Firebase injection."
+            exit 0
+          fi
+
+          echo "Injecting Firebase credentials into JAR..."
+          printf '%s\n' "${FIREBASE_CREDENTIALS_JSON}" > "/tmp/${FIREBASE_FILE}"
+
+          STAGING_DIR="/tmp/firebase-jar-staging/BOOT-INF/classes"
+          mkdir -p "${STAGING_DIR}"
+          cp "/tmp/${FIREBASE_FILE}" "${STAGING_DIR}/${FIREBASE_FILE}"
+
+          jar uf frc-central-server.jar \
+            -C /tmp/firebase-jar-staging \
+            "BOOT-INF/classes/${FIREBASE_FILE}"
+
+          rm -f "/tmp/${FIREBASE_FILE}"
+          rm -rf /tmp/firebase-jar-staging
+
+          if jar tf frc-central-server.jar | grep -q "${FIREBASE_FILE}"; then
+            echo "Firebase credentials injected successfully."
+          else
+            echo "ERROR: Firebase credentials were not found in JAR after injection."
+            exit 1
+          fi
+
       - name: Setup SSH
         run: |
           mkdir -p ~/.ssh


### PR DESCRIPTION
## Summary
- Inyecta `bodega-franco-frc-18e8c6ef35cf.json` en el JAR desde el secret `FIREBASE_CREDENTIALS_JSON` durante el workflow de Deploy.
- Valida en `deploy.sh` que el archivo quede presente en el artefacto antes de reiniciar el servicio.
- Corrige el fallo de push en producción causado porque el JSON está en `.gitignore` y no llegaba al JAR desplegado.

## Test plan
- [ ] Mergear PR y ejecutar Deploy manual hacia `bodega`.
- [ ] Verificar en servidor: `jar tf /opt/frc-backend-central/bodega/current/frc-central-server.jar | grep bodega-franco-frc`.
- [ ] Verificar logs: `journalctl -u frc-bodega.service | grep -i firebase` muestra inicialización exitosa.
- [ ] Enviar notificación de prueba y confirmar recepción en cliente con token FCM válido.


Made with [Cursor](https://cursor.com)