### PR TITLE
fix(deploy): usar credenciales Firebase externas sin mutar el JAR

### DIFF
--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -8,8 +8,9 @@ set -euo pipefail
 # Example: ./deploy.sh 3.1.0-alpha.1 alpha
 # ============================================================
 
-VERSION="${1:?Usage: deploy.sh <version> <instance>}"
-INSTANCE="${2:?Usage: deploy.sh <version> <instance>}"
+VERSION="${1:?Usage: deploy.sh <version> <instance> [firebase_json_path]}"
+INSTANCE="${2:?Usage: deploy.sh <version> <instance> [firebase_json_path]}"
+FIREBASE_JSON_SOURCE="${3:-}"
 
 BASE_DIR="/opt/frc-backend-central"
 INSTANCE_DIR="${BASE_DIR}/${INSTANCE}"
@@ -20,6 +21,9 @@ SERVICE_NAME="frc-${INSTANCE}.service"
 HEALTH_URL="http://localhost:$(grep SERVER_PORT "${INSTANCE_DIR}/.env" | cut -d= -f2)/actuator/health"
 HEALTH_TIMEOUT=500
 HEALTH_INTERVAL=5
+FIREBASE_FILE="bodega-franco-frc-18e8c6ef35cf.json"
+FIREBASE_DIR="${INSTANCE_DIR}/secrets"
+FIREBASE_TARGET="${FIREBASE_DIR}/${FIREBASE_FILE}"
 
 # --- Validations ---
 if [[ ! -d "${INSTANCE_DIR}" ]]; then
@@ -32,11 +36,26 @@ if [[ ! -f "${RELEASE_DIR}/${JAR_NAME}" ]]; then
   exit 1
 fi
 
-FIREBASE_FILE="bodega-franco-frc-18e8c6ef35cf.json"
-if jar tf "${RELEASE_DIR}/${JAR_NAME}" | grep -q "${FIREBASE_FILE}"; then
-  echo "Firebase credentials found in JAR"
+if [[ -n "${FIREBASE_JSON_SOURCE}" && -f "${FIREBASE_JSON_SOURCE}" ]]; then
+  echo "Installing Firebase credentials for ${INSTANCE}..."
+  mkdir -p "${FIREBASE_DIR}"
+  cp "${FIREBASE_JSON_SOURCE}" "${FIREBASE_TARGET}"
+  chmod 600 "${FIREBASE_TARGET}"
+  rm -f "${FIREBASE_JSON_SOURCE}"
+  echo "Firebase credentials installed at ${FIREBASE_TARGET}"
 else
-  echo "WARNING: Firebase credentials not found in JAR (${FIREBASE_FILE}). Push notifications will fail."
+  echo "WARNING: Firebase credentials source file not provided. Reusing existing credentials if present."
+fi
+
+if [[ -f "${FIREBASE_TARGET}" ]]; then
+  if grep -q '^APP_FIREBASE_CONFIGURATION_FILE=' "${INSTANCE_DIR}/.env"; then
+    sed -i "s|^APP_FIREBASE_CONFIGURATION_FILE=.*|APP_FIREBASE_CONFIGURATION_FILE=${FIREBASE_TARGET}|" "${INSTANCE_DIR}/.env"
+  else
+    echo "APP_FIREBASE_CONFIGURATION_FILE=${FIREBASE_TARGET}" >> "${INSTANCE_DIR}/.env"
+  fi
+  echo "Firebase config path set in ${INSTANCE_DIR}/.env"
+else
+  echo "WARNING: Firebase credentials not found at ${FIREBASE_TARGET}. Push notifications will fail."
 fi
 
 # --- Save current version for rollback ---

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,44 +85,25 @@ jobs:
               | jq -r '.assets[] | select(.name == "frc-central-server.jar") | .url')"
           ls -lh frc-central-server.jar
 
-      - name: Inject Firebase credentials into JAR
-        env:
-          FIREBASE_CREDENTIALS_JSON: ${{ secrets.FIREBASE_CREDENTIALS_JSON }}
-        run: |
-          FIREBASE_FILE="bodega-franco-frc-18e8c6ef35cf.json"
-
-          if [[ -z "${FIREBASE_CREDENTIALS_JSON}" ]]; then
-            echo "WARNING: FIREBASE_CREDENTIALS_JSON secret is not set. Skipping Firebase injection."
-            exit 0
-          fi
-
-          echo "Injecting Firebase credentials into JAR..."
-          printf '%s\n' "${FIREBASE_CREDENTIALS_JSON}" > "/tmp/${FIREBASE_FILE}"
-
-          STAGING_DIR="/tmp/firebase-jar-staging/BOOT-INF/classes"
-          mkdir -p "${STAGING_DIR}"
-          cp "/tmp/${FIREBASE_FILE}" "${STAGING_DIR}/${FIREBASE_FILE}"
-
-          jar uf frc-central-server.jar \
-            -C /tmp/firebase-jar-staging \
-            "BOOT-INF/classes/${FIREBASE_FILE}"
-
-          rm -f "/tmp/${FIREBASE_FILE}"
-          rm -rf /tmp/firebase-jar-staging
-
-          if jar tf frc-central-server.jar | grep -q "${FIREBASE_FILE}"; then
-            echo "Firebase credentials injected successfully."
-          else
-            echo "ERROR: Firebase credentials were not found in JAR after injection."
-            exit 1
-          fi
-
       - name: Setup SSH
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -H ${{ secrets.DEPLOY_HOST }} >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Upload Firebase credentials
+        if: ${{ secrets.FIREBASE_CREDENTIALS_JSON != '' }}
+        env:
+          FIREBASE_CREDENTIALS_JSON: ${{ secrets.FIREBASE_CREDENTIALS_JSON }}
+          VERSION: ${{ steps.resolve.outputs.version }}
+        run: |
+          FIREBASE_REMOTE_PATH="/tmp/firebase-${{ inputs.instance }}-${VERSION}.json"
+          printf '%s\n' "${FIREBASE_CREDENTIALS_JSON}" > firebase-credentials.json
+          scp -i ~/.ssh/deploy_key \
+            firebase-credentials.json \
+            deploy@${{ secrets.DEPLOY_HOST }}:${FIREBASE_REMOTE_PATH}
+          rm -f firebase-credentials.json
 
       - name: Upload JAR to server
         env:
@@ -146,8 +127,9 @@ jobs:
         env:
           VERSION: ${{ steps.resolve.outputs.version }}
         run: |
+          FIREBASE_REMOTE_PATH="/tmp/firebase-${{ inputs.instance }}-${VERSION}.json"
           ssh -i ~/.ssh/deploy_key deploy@${{ secrets.DEPLOY_HOST }} \
-            "chmod +x /tmp/deploy.sh && /tmp/deploy.sh '${VERSION}' '${{ inputs.instance }}'"
+            "chmod +x /tmp/deploy.sh && /tmp/deploy.sh '${VERSION}' '${{ inputs.instance }}' '${FIREBASE_REMOTE_PATH}'"
 
       - name: Summary
         if: always()

--- a/src/main/java/com/franco/dev/fmc/health/NotificationHealthIndicator.java
+++ b/src/main/java/com/franco/dev/fmc/health/NotificationHealthIndicator.java
@@ -26,7 +26,7 @@ public class NotificationHealthIndicator implements HealthIndicator {
     @Override
     public Health health() {
         try {
-            Resource resource = resourceLoader.getResource("classpath:" + firebaseConfigFile);
+            Resource resource = resolveFirebaseConfigResource();
             if (!resource.exists()) {
                 return Health.down().withDetail("firebaseConfig", "Archivo no encontrado").build();
             }
@@ -38,6 +38,23 @@ public class NotificationHealthIndicator implements HealthIndicator {
         } catch (IOException e) {
             return Health.down(e).build();
         }
+    }
+
+    private Resource resolveFirebaseConfigResource() {
+        if (firebaseConfigFile == null || firebaseConfigFile.trim().isEmpty()) {
+            return resourceLoader.getResource("classpath:missing-firebase-config");
+        }
+
+        if (firebaseConfigFile.startsWith("classpath:") || firebaseConfigFile.startsWith("file:")) {
+            return resourceLoader.getResource(firebaseConfigFile);
+        }
+
+        Resource fileResource = resourceLoader.getResource("file:" + firebaseConfigFile);
+        if (fileResource.exists()) {
+            return fileResource;
+        }
+
+        return resourceLoader.getResource("classpath:" + firebaseConfigFile);
     }
 }
 

--- a/src/main/java/com/franco/dev/fmc/service/FCMInitializer.java
+++ b/src/main/java/com/franco/dev/fmc/service/FCMInitializer.java
@@ -5,7 +5,8 @@ import javax.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Service;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
@@ -17,12 +18,23 @@ public class FCMInitializer {
 
     @Value("${app.firebase-configuration-file}")
     private String firebaseConfigPath;
+    private final ResourceLoader resourceLoader;
     Logger logger = LoggerFactory.getLogger(FCMInitializer.class);
+
+    public FCMInitializer(ResourceLoader resourceLoader) {
+        this.resourceLoader = resourceLoader;
+    }
+
     @PostConstruct
     public void initialize() {
         try {
+            Resource configResource = resolveFirebaseConfigResource();
+            if (!configResource.exists()) {
+                logger.error("Error initializing Firebase: config file not found at {}", firebaseConfigPath);
+                return;
+            }
             FirebaseOptions options = new FirebaseOptions.Builder()
-                    .setCredentials(GoogleCredentials.fromStream(new ClassPathResource(firebaseConfigPath).getInputStream()))
+                    .setCredentials(GoogleCredentials.fromStream(configResource.getInputStream()))
                     .setProjectId("bodega-franco-frc")
                     .build();
             if (FirebaseApp.getApps().isEmpty()) {
@@ -33,5 +45,22 @@ public class FCMInitializer {
         } catch (IOException e) {
             logger.error("Error initializing Firebase: " + e.getMessage());
         }
+    }
+
+    private Resource resolveFirebaseConfigResource() {
+        if (firebaseConfigPath == null || firebaseConfigPath.trim().isEmpty()) {
+            return resourceLoader.getResource("classpath:missing-firebase-config");
+        }
+
+        if (firebaseConfigPath.startsWith("classpath:") || firebaseConfigPath.startsWith("file:")) {
+            return resourceLoader.getResource(firebaseConfigPath);
+        }
+
+        Resource fileResource = resourceLoader.getResource("file:" + firebaseConfigPath);
+        if (fileResource.exists()) {
+            return fileResource;
+        }
+
+        return resourceLoader.getResource("classpath:" + firebaseConfigPath);
     }
 }


### PR DESCRIPTION
## Summary
- Reemplaza la estrategia de inyección en JAR por carga de credenciales Firebase como archivo externo por instancia durante deploy.
- Actualiza `deploy.sh` para instalar el JSON en `/opt/frc-backend-central/<instancia>/secrets/` y configurar `APP_FIREBASE_CONFIGURATION_FILE` en `.env`.
- Ajusta `FCMInitializer` y `NotificationHealthIndicator` para resolver credenciales desde filesystem o classpath (fallback compatible).

## Test plan
- [ ] Ejecutar workflow Deploy para `alpha` o `bodega` con `FIREBASE_CREDENTIALS_JSON` configurado.
- [ ] Verificar que exista `/opt/frc-backend-central/<instancia>/secrets/bodega-franco-frc-18e8c6ef35cf.json` con permisos `600`.
- [ ] Confirmar en logs de servicio: inicialización Firebase exitosa.
- [ ] Enviar notificación de prueba y validar recepción.


Made with [Cursor](https://cursor.com)