### PR TITLE
fix(deploy): corregir validacion de secret en workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,11 +93,14 @@ jobs:
           ssh-keyscan -H ${{ secrets.DEPLOY_HOST }} >> ~/.ssh/known_hosts 2>/dev/null
 
       - name: Upload Firebase credentials
-        if: ${{ secrets.FIREBASE_CREDENTIALS_JSON != '' }}
         env:
           FIREBASE_CREDENTIALS_JSON: ${{ secrets.FIREBASE_CREDENTIALS_JSON }}
           VERSION: ${{ steps.resolve.outputs.version }}
         run: |
+          if [[ -z "${FIREBASE_CREDENTIALS_JSON}" ]]; then
+            echo "WARNING: FIREBASE_CREDENTIALS_JSON secret is not set. Skipping Firebase credentials upload."
+            exit 0
+          fi
           FIREBASE_REMOTE_PATH="/tmp/firebase-${{ inputs.instance }}-${VERSION}.json"
           printf '%s\n' "${FIREBASE_CREDENTIALS_JSON}" > firebase-credentials.json
           scp -i ~/.ssh/deploy_key \

--- a/src/main/java/com/franco/dev/fmc/health/NotificationHealthIndicator.java
+++ b/src/main/java/com/franco/dev/fmc/health/NotificationHealthIndicator.java
@@ -42,21 +42,11 @@ public class NotificationHealthIndicator implements HealthIndicator {
 
     private Resource resolveFirebaseConfigResource() {
         if (firebaseConfigFile == null || firebaseConfigFile.trim().isEmpty()) {
-            return resourceLoader.getResource("classpath:missing-firebase-config");
+            return resourceLoader.getResource("file:/dev/null");
         }
-
-        if (firebaseConfigFile.startsWith("classpath:") || firebaseConfigFile.startsWith("file:")) {
+        if (firebaseConfigFile.startsWith("file:")) {
             return resourceLoader.getResource(firebaseConfigFile);
         }
-
-        Resource fileResource = resourceLoader.getResource("file:" + firebaseConfigFile);
-        if (fileResource.exists()) {
-            return fileResource;
-        }
-
-        return resourceLoader.getResource("classpath:" + firebaseConfigFile);
+        return resourceLoader.getResource("file:" + firebaseConfigFile);
     }
 }
-
-
-

--- a/src/main/java/com/franco/dev/fmc/service/FCMInitializer.java
+++ b/src/main/java/com/franco/dev/fmc/service/FCMInitializer.java
@@ -12,6 +12,7 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
 @Service
 @ConditionalOnProperty(name = "app.firebase-enabled", havingValue = "true", matchIfMissing = false)
 public class FCMInitializer {
@@ -49,18 +50,11 @@ public class FCMInitializer {
 
     private Resource resolveFirebaseConfigResource() {
         if (firebaseConfigPath == null || firebaseConfigPath.trim().isEmpty()) {
-            return resourceLoader.getResource("classpath:missing-firebase-config");
+            return resourceLoader.getResource("file:/dev/null");
         }
-
-        if (firebaseConfigPath.startsWith("classpath:") || firebaseConfigPath.startsWith("file:")) {
+        if (firebaseConfigPath.startsWith("file:")) {
             return resourceLoader.getResource(firebaseConfigPath);
         }
-
-        Resource fileResource = resourceLoader.getResource("file:" + firebaseConfigPath);
-        if (fileResource.exists()) {
-            return fileResource;
-        }
-
-        return resourceLoader.getResource("classpath:" + firebaseConfigPath);
+        return resourceLoader.getResource("file:" + firebaseConfigPath);
     }
 }


### PR DESCRIPTION
## Summary
- Corrige el workflow de deploy eliminando el uso de `secrets` en `if`, que invalida el parseo en GitHub Actions.
- Mantiene la validación del secret dentro del script del step para evitar fallos de cola del workflow.
- Ajusta la carga de Firebase para usar archivo externo sin fallback a classpath.

## Test plan
- [ ] Ejecutar workflow `Deploy` y confirmar que ya no aparece `Unrecognized named-value: 'secrets'`.
- [ ] Verificar que el paso de credenciales Firebase se salte con warning si el secret no existe.
- [ ] Ejecutar deploy con secret presente y validar arranque exitoso.

Made with [Cursor](https://cursor.com)