### PR TITLE
fix(deploy): asegurar Firebase por entorno e inicializacion

### DIFF
--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -8,9 +8,10 @@ set -euo pipefail
 # Example: ./deploy.sh 3.1.0-alpha.1 alpha
 # ============================================================
 
-VERSION="${1:?Usage: deploy.sh <version> <instance> [firebase_json_path]}"
-INSTANCE="${2:?Usage: deploy.sh <version> <instance> [firebase_json_path]}"
+VERSION="${1:?Usage: deploy.sh <version> <instance> [firebase_json_path] [firebase_target_path]}"
+INSTANCE="${2:?Usage: deploy.sh <version> <instance> [firebase_json_path] [firebase_target_path]}"
 FIREBASE_JSON_SOURCE="${3:-}"
+FIREBASE_TARGET_OVERRIDE="${4:-}"
 
 BASE_DIR="/opt/frc-backend-central"
 INSTANCE_DIR="${BASE_DIR}/${INSTANCE}"
@@ -21,9 +22,16 @@ SERVICE_NAME="frc-${INSTANCE}.service"
 HEALTH_URL="http://localhost:$(grep SERVER_PORT "${INSTANCE_DIR}/.env" | cut -d= -f2)/actuator/health"
 HEALTH_TIMEOUT=500
 HEALTH_INTERVAL=5
-FIREBASE_FILE="bodega-franco-frc-18e8c6ef35cf.json"
+DEFAULT_FIREBASE_FILE="bodega-franco-frc-18e8c6ef35cf.json"
 FIREBASE_DIR="${INSTANCE_DIR}/secrets"
-FIREBASE_TARGET="${FIREBASE_DIR}/${FIREBASE_FILE}"
+FIREBASE_TARGET="${FIREBASE_DIR}/${DEFAULT_FIREBASE_FILE}"
+
+if [[ -n "${FIREBASE_TARGET_OVERRIDE}" ]]; then
+  FIREBASE_TARGET="${FIREBASE_TARGET_OVERRIDE}"
+elif [[ -n "${FIREBASE_JSON_SOURCE}" ]]; then
+  SOURCE_BASENAME=$(basename "${FIREBASE_JSON_SOURCE}")
+  FIREBASE_TARGET="${FIREBASE_DIR}/${SOURCE_BASENAME}"
+fi
 
 # --- Validations ---
 if [[ ! -d "${INSTANCE_DIR}" ]]; then
@@ -38,7 +46,7 @@ fi
 
 if [[ -n "${FIREBASE_JSON_SOURCE}" && -f "${FIREBASE_JSON_SOURCE}" ]]; then
   echo "Installing Firebase credentials for ${INSTANCE}..."
-  mkdir -p "${FIREBASE_DIR}"
+  mkdir -p "$(dirname "${FIREBASE_TARGET}")"
   cp "${FIREBASE_JSON_SOURCE}" "${FIREBASE_TARGET}"
   chmod 600 "${FIREBASE_TARGET}"
   rm -f "${FIREBASE_JSON_SOURCE}"

--- a/.github/workflows/deploy-auto.yml
+++ b/.github/workflows/deploy-auto.yml
@@ -1,0 +1,18 @@
+name: Deploy Auto
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    name: Deploy ${{ matrix.instance }}
+    strategy:
+      fail-fast: false
+      matrix:
+        instance: [alpha, farmacia, bodega]
+    uses: ./.github/workflows/deploy.yml
+    with:
+      instance: ${{ matrix.instance }}
+      version: ${{ github.event.release.tag_name }}
+    secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,16 @@ on:
         description: 'Version override (leave empty for latest of the channel)'
         required: false
         type: string
+  workflow_call:
+    inputs:
+      instance:
+        description: 'Target instance'
+        required: true
+        type: string
+      version:
+        description: 'Version override (leave empty for latest of the channel)'
+        required: false
+        type: string
 
 jobs:
   deploy:
@@ -37,8 +47,9 @@ jobs:
           OVERRIDE="${{ inputs.version }}"
 
           if [[ -n "${OVERRIDE}" ]]; then
-            echo "Using manual version: ${OVERRIDE}"
-            echo "version=${OVERRIDE}" >> $GITHUB_OUTPUT
+            NORMALIZED_VERSION="${OVERRIDE#v}"
+            echo "Using manual version: ${NORMALIZED_VERSION}"
+            echo "version=${NORMALIZED_VERSION}" >> $GITHUB_OUTPUT
           else
             echo "Resolving latest version for instance: ${INSTANCE}"
             if [[ "${INSTANCE}" == "bodega" ]]; then
@@ -68,6 +79,57 @@ jobs:
             echo "version=${VERSION}" >> $GITHUB_OUTPUT
           fi
 
+      - name: Resolve Firebase credentials by instance
+        id: firebase
+        env:
+          INSTANCE: ${{ inputs.instance }}
+          FIREBASE_CREDENTIALS_JSON: ${{ secrets.FIREBASE_CREDENTIALS_JSON }}
+          FIREBASE_CREDENTIALS_JSON_ALPHA: ${{ secrets.FIREBASE_CREDENTIALS_JSON_ALPHA }}
+          FIREBASE_CREDENTIALS_JSON_BETA: ${{ secrets.FIREBASE_CREDENTIALS_JSON_BETA }}
+          FIREBASE_CREDENTIALS_JSON_PROD: ${{ secrets.FIREBASE_CREDENTIALS_JSON_PROD }}
+          FIREBASE_TARGET_PATH: ${{ secrets.FIREBASE_TARGET_PATH }}
+          FIREBASE_TARGET_PATH_ALPHA: ${{ secrets.FIREBASE_TARGET_PATH_ALPHA }}
+          FIREBASE_TARGET_PATH_BETA: ${{ secrets.FIREBASE_TARGET_PATH_BETA }}
+          FIREBASE_TARGET_PATH_PROD: ${{ secrets.FIREBASE_TARGET_PATH_PROD }}
+        run: |
+          CREDENTIALS_JSON=""
+          TARGET_PATH=""
+          CHANNEL="alpha"
+
+          if [[ "${INSTANCE}" == "bodega" ]]; then
+            CHANNEL="prod"
+            CREDENTIALS_JSON="${FIREBASE_CREDENTIALS_JSON_PROD:-}"
+            TARGET_PATH="${FIREBASE_TARGET_PATH_PROD:-}"
+          elif [[ "${INSTANCE}" == "farmacia" || "${INSTANCE}" == "beta" ]]; then
+            CHANNEL="beta"
+            CREDENTIALS_JSON="${FIREBASE_CREDENTIALS_JSON_BETA:-}"
+            TARGET_PATH="${FIREBASE_TARGET_PATH_BETA:-}"
+          else
+            CREDENTIALS_JSON="${FIREBASE_CREDENTIALS_JSON_ALPHA:-}"
+            TARGET_PATH="${FIREBASE_TARGET_PATH_ALPHA:-}"
+          fi
+
+          if [[ -z "${CREDENTIALS_JSON}" ]]; then
+            CREDENTIALS_JSON="${FIREBASE_CREDENTIALS_JSON:-}"
+          fi
+          if [[ -z "${TARGET_PATH}" ]]; then
+            TARGET_PATH="${FIREBASE_TARGET_PATH:-}"
+          fi
+
+          if [[ -n "${CREDENTIALS_JSON}" ]]; then
+            {
+              echo "credentials_json<<EOF"
+              echo "${CREDENTIALS_JSON}"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "target_path=${TARGET_PATH}" >> "$GITHUB_OUTPUT"
+          echo "channel=${CHANNEL}" >> "$GITHUB_OUTPUT"
+
       - name: Download JAR from GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -94,7 +156,7 @@ jobs:
 
       - name: Upload Firebase credentials
         env:
-          FIREBASE_CREDENTIALS_JSON: ${{ secrets.FIREBASE_CREDENTIALS_JSON }}
+          FIREBASE_CREDENTIALS_JSON: ${{ steps.firebase.outputs.credentials_json }}
           VERSION: ${{ steps.resolve.outputs.version }}
         run: |
           if [[ -z "${FIREBASE_CREDENTIALS_JSON}" ]]; then
@@ -129,10 +191,11 @@ jobs:
       - name: Execute deploy
         env:
           VERSION: ${{ steps.resolve.outputs.version }}
+          FIREBASE_TARGET_PATH: ${{ steps.firebase.outputs.target_path }}
         run: |
           FIREBASE_REMOTE_PATH="/tmp/firebase-${{ inputs.instance }}-${VERSION}.json"
           ssh -i ~/.ssh/deploy_key deploy@${{ secrets.DEPLOY_HOST }} \
-            "chmod +x /tmp/deploy.sh && /tmp/deploy.sh '${VERSION}' '${{ inputs.instance }}' '${FIREBASE_REMOTE_PATH}'"
+            "chmod +x /tmp/deploy.sh && /tmp/deploy.sh '${VERSION}' '${{ inputs.instance }}' '${FIREBASE_REMOTE_PATH}' '${FIREBASE_TARGET_PATH}'"
 
       - name: Summary
         if: always()
@@ -142,4 +205,5 @@ jobs:
           echo "## Deploy Summary" >> $GITHUB_STEP_SUMMARY
           echo "- **Version:** ${VERSION}" >> $GITHUB_STEP_SUMMARY
           echo "- **Instance:** ${{ inputs.instance }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Firebase channel:** ${{ steps.firebase.outputs.channel }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Status:** ${{ job.status }}" >> $GITHUB_STEP_SUMMARY

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ informacion.txt
 src/main/resources/application-dev.properties
 src/main/resources/application-user-dev.properties
 bodega-franco-frc-18e8c6ef35cf.json
+secrets/bodega-franco-frc-18e8c6ef35cf.json
 src/main/resources/bodega-franco-frc-18e8c6ef35cf.json
 src/main/resources/bodega-franco-frc-firebase-admin.json
 .m2/

--- a/src/main/java/com/franco/dev/fmc/service/FCMInitializer.java
+++ b/src/main/java/com/franco/dev/fmc/service/FCMInitializer.java
@@ -1,6 +1,5 @@
 package com.franco.dev.fmc.service;
 
-import java.io.IOException;
 import javax.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -11,14 +10,14 @@ import org.springframework.stereotype.Service;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 @Service
-@ConditionalOnProperty(name = "app.firebase-enabled", havingValue = "true", matchIfMissing = false)
 public class FCMInitializer {
 
     @Value("${app.firebase-configuration-file}")
     private String firebaseConfigPath;
+    @Value("${app.firebase-enabled:true}")
+    private boolean firebaseEnabled;
     private final ResourceLoader resourceLoader;
     Logger logger = LoggerFactory.getLogger(FCMInitializer.class);
 
@@ -28,7 +27,12 @@ public class FCMInitializer {
 
     @PostConstruct
     public void initialize() {
+        if (!firebaseEnabled) {
+            logger.info("Firebase initialization skipped because app.firebase-enabled=false");
+            return;
+        }
         try {
+            logger.info("Initializing Firebase using config path: {}", firebaseConfigPath);
             Resource configResource = resolveFirebaseConfigResource();
             if (!configResource.exists()) {
                 logger.error("Error initializing Firebase: config file not found at {}", firebaseConfigPath);
@@ -42,8 +46,10 @@ public class FCMInitializer {
                 FirebaseApp.initializeApp(options);
                 logger.info("Firebase application has been initialized with project: bodega-franco-frc");
                 logger.info("Firebase Sender ID: 170136643206");
+            } else {
+                logger.info("Firebase already initialized. Apps loaded: {}", FirebaseApp.getApps().size());
             }
-        } catch (IOException e) {
+        } catch (Exception e) {
             logger.error("Error initializing Firebase: " + e.getMessage());
         }
     }

--- a/src/main/java/com/franco/dev/fmc/service/FCMService.java
+++ b/src/main/java/com/franco/dev/fmc/service/FCMService.java
@@ -26,9 +26,12 @@ public class FCMService {
     private static final String DEFAULT_DATA_PATH = "/";
     private final Logger logger = LoggerFactory.getLogger(FCMService.class);
     private final Gson gson;
+    @SuppressWarnings("unused")
+    private final FCMInitializer fcmInitializer;
 
-    public FCMService(Gson gson) {
+    public FCMService(Gson gson, FCMInitializer fcmInitializer) {
         this.gson = gson;
+        this.fcmInitializer = fcmInitializer;
     }
 
     public DeliveryResult sendToToken(String token, PushNotificationRequest request) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -108,7 +108,9 @@ homepath=${user.home}
 # ----------------------------------------------------------------------------
 # Firebase Configuration
 # ----------------------------------------------------------------------------
-app.firebase-configuration-file=bodega-franco-frc-18e8c6ef35cf.json
+# Deploy: APP_FIREBASE_CONFIGURATION_FILE se inyecta en /opt/frc-backend-central/<instancia>/.env
+# Fallback por defecto si no existe variable de entorno (útil fuera de deploy automático).
+app.firebase-configuration-file=${APP_FIREBASE_CONFIGURATION_FILE:file:/opt/frc-backend-central/${APP_INSTANCE:central}/secrets/bodega-franco-frc-18e8c6ef35cf.json}
 app.firebase-enabled=true
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- alinea el deploy para resolver credenciales Firebase por entorno/instancia y soportar `workflow_call`/`deploy-auto`
- permite inyectar ruta destino del JSON en el servidor y actualizar `.env` con la ruta final usada por cada instancia
- fuerza la inicializacion de Firebase antes del primer envio y configura `application.properties` para priorizar `APP_FIREBASE_CONFIGURATION_FILE` con fallback por instancia

## Test plan
- [x] `./mvnw -q -DskipFlyway=true -DskipTests compile`
- [x] validar que el backend inicia y ya no arroja `FirebaseApp with name [DEFAULT] doesn't exist.` en envios push
- [x] validar en DB que los envios nuevos dejan de quedar en `FALLO_ENVIO` por app Firebase no inicializada

Made with [Cursor](https://cursor.com)