### PR TITLE
feat(notificaciones): preferencias y alerta por venta con stock crítico

### DIFF
--- a/src/main/java/com/franco/dev/fmc/controller/PushNotificationController.java
+++ b/src/main/java/com/franco/dev/fmc/controller/PushNotificationController.java
@@ -6,6 +6,7 @@ import com.franco.dev.domain.operaciones.Venta;
 import com.franco.dev.domain.personas.Usuario;
 import com.franco.dev.fmc.model.PushNotificationRequest;
 import com.franco.dev.fmc.model.PushNotificationResponse;
+import com.franco.dev.fmc.model.VentaStockCriticoNotificationRequest;
 import com.franco.dev.fmc.service.NotificationRoleService;
 import com.franco.dev.fmc.service.NotificationTemplateService;
 import com.franco.dev.fmc.service.PushNotificationService;
@@ -23,6 +24,7 @@ import javax.validation.Valid;
 import java.text.DecimalFormat;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 public class PushNotificationController {
@@ -261,6 +263,46 @@ public class PushNotificationController {
                                                 HttpStatus.NOT_FOUND);
                         }
 
+                } catch (Exception e) {
+                        return new ResponseEntity<>(
+                                        new PushNotificationResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                                                        "Error al enviar notificación: " + e.getMessage()),
+                                        HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+        }
+
+        @PostMapping("/notification/venta-stock-critico")
+        public ResponseEntity<PushNotificationResponse> sendVentaStockCriticoNotification(
+                        @RequestBody VentaStockCriticoNotificationRequest body) {
+                try {
+                        if (body == null || body.getVentaId() == null || body.getSucursalId() == null
+                                        || body.getItems() == null || body.getItems().isEmpty()) {
+                                return new ResponseEntity<>(new PushNotificationResponse(HttpStatus.BAD_REQUEST.value(),
+                                                "Parámetros insuficientes para notificación de stock crítico"),
+                                                HttpStatus.BAD_REQUEST);
+                        }
+
+                        List<String> rolesRelevantes = notificationRoleService.getRolesForVentaStockCritico();
+                        List<Long> usuariosRelevantes = notificationRoleService.getUserIdsByRoles(rolesRelevantes);
+
+                        if (!usuariosRelevantes.isEmpty()) {
+                                PushNotificationRequest request = notificationTemplateService.ventaStockCritico(
+                                                body.getVentaId(),
+                                                body.getSucursalId(),
+                                                body.getSucursalNombre(),
+                                                body.getUsuarioNombre(),
+                                                body.getItems(),
+                                                df);
+                                request.setUsuarioIds(usuariosRelevantes.stream().distinct().collect(Collectors.toList()));
+                                pushNotificationService.sendPushNotificationToToken(request);
+                                return new ResponseEntity<>(new PushNotificationResponse(HttpStatus.ACCEPTED.value(),
+                                                "Notificación de stock crítico enviada exitosamente"),
+                                                HttpStatus.ACCEPTED);
+                        } else {
+                                return new ResponseEntity<>(new PushNotificationResponse(HttpStatus.NOT_FOUND.value(),
+                                                "No se encontraron usuarios con roles relevantes"),
+                                                HttpStatus.NOT_FOUND);
+                        }
                 } catch (Exception e) {
                         return new ResponseEntity<>(
                                         new PushNotificationResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(),

--- a/src/main/java/com/franco/dev/fmc/model/VentaStockCriticoNotificationRequest.java
+++ b/src/main/java/com/franco/dev/fmc/model/VentaStockCriticoNotificationRequest.java
@@ -1,0 +1,28 @@
+package com.franco.dev.fmc.model;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class VentaStockCriticoNotificationRequest {
+    private Long ventaId;
+    private Long sucursalId;
+    private String usuarioNombre;
+    private String sucursalNombre;
+    private List<VentaStockCriticoItem> items;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class VentaStockCriticoItem {
+        private Long productoId;
+        private String productoDescripcion;
+        private Double stockActual;
+        private Double cantidadVendida;
+        private Double stockResultante;
+    }
+}

--- a/src/main/java/com/franco/dev/fmc/service/NotificationRoleService.java
+++ b/src/main/java/com/franco/dev/fmc/service/NotificationRoleService.java
@@ -164,4 +164,14 @@ public class NotificationRoleService {
                 "ANALISIS DE CAJA",
                 "ANALISIS DE VENTA");
     }
+
+    public List<String> getRolesForVentaStockCritico() {
+        return Arrays.asList(
+                "ADMIN",
+                "SOPORTE",
+                "ANALISIS DE VENTA",
+                "ANALISIS DE CAJA",
+                "VER MOVIMIENTO DE STOCK",
+                "VER PRODUCTOS");
+    }
 }

--- a/src/main/java/com/franco/dev/fmc/service/NotificationTemplateService.java
+++ b/src/main/java/com/franco/dev/fmc/service/NotificationTemplateService.java
@@ -12,7 +12,9 @@ import com.franco.dev.domain.productos.Producto;
 import com.franco.dev.domain.productos.TipoPrecio;
 import com.franco.dev.domain.personas.Usuario;
 import com.franco.dev.fmc.model.PushNotificationRequest;
+import com.franco.dev.fmc.model.VentaStockCriticoNotificationRequest;
 import java.text.DecimalFormat;
+import java.util.List;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -457,6 +459,41 @@ public class NotificationTemplateService {
 
         PushNotificationRequest request = base("PAGO CON TRANSFERENCIA REGISTRADO", builder.toString());
         request.setType("VENTA_TRANSFERENCIA");
+        request.setData("/operaciones/ventas/" + ventaId + "/" + sucursalId);
+        return request;
+    }
+
+    public PushNotificationRequest ventaStockCritico(
+            Long ventaId,
+            Long sucursalId,
+            String sucursalNombre,
+            String usuarioNombre,
+            List<VentaStockCriticoNotificationRequest.VentaStockCriticoItem> items,
+            DecimalFormat decimalFormat) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("SE DETECTÓ UNA VENTA CON UN PRODUCTO CON STOCK CERO O NEGATIVO");
+        if (sucursalNombre != null && !sucursalNombre.isEmpty()) {
+            builder.append(" EN LA SUCURSAL ").append(sucursalNombre);
+        }
+        builder.append(". VENTA ID: ").append(ventaId);
+        if (usuarioNombre != null && !usuarioNombre.isEmpty()) {
+            builder.append(". REALIZADO POR: ").append(usuarioNombre.toUpperCase());
+        }
+
+        int maxItems = Math.min(items != null ? items.size() : 0, 3);
+        for (int i = 0; i < maxItems; i++) {
+            VentaStockCriticoNotificationRequest.VentaStockCriticoItem item = items.get(i);
+            builder.append(" | ")
+                    .append(item.getProductoDescripcion() != null ? item.getProductoDescripcion() : "PRODUCTO")
+                    .append(": ")
+                    .append(decimalFormat.format(item.getStockResultante() != null ? item.getStockResultante() : 0));
+        }
+        if (items != null && items.size() > maxItems) {
+            builder.append(" | +").append(items.size() - maxItems).append(" productos más");
+        }
+
+        PushNotificationRequest request = base("ALERTA DE STOCK CRÍTICO", builder.toString());
+        request.setType("VENTA_STOCK_CRITICO");
         request.setData("/operaciones/ventas/" + ventaId + "/" + sucursalId);
         return request;
     }

--- a/src/main/resources/db/migration/V127.3__add_notification_types_retiro_venta_transferencia.sql
+++ b/src/main/resources/db/migration/V127.3__add_notification_types_retiro_venta_transferencia.sql
@@ -1,0 +1,7 @@
+INSERT INTO configuraciones.notificacion_tipo_role (role_id, tipo_notificacion, descripcion, es_obligatorio, creado_en)
+VALUES
+    (1, 'RETIRO', 'Notificación de retiro realizado en sucursal', false, NOW()),
+    (5, 'RETIRO', 'Notificación de retiro realizado en sucursal', false, NOW()),
+    (1, 'VENTA_TRANSFERENCIA', 'Notificación de venta con pago por transferencia', false, NOW()),
+    (5, 'VENTA_TRANSFERENCIA', 'Notificación de venta con pago por transferencia', false, NOW())
+ON CONFLICT (role_id, tipo_notificacion) DO NOTHING;

--- a/src/main/resources/db/migration/V128.3__add_notification_type_venta_stock_critico.sql
+++ b/src/main/resources/db/migration/V128.3__add_notification_type_venta_stock_critico.sql
@@ -1,0 +1,5 @@
+INSERT INTO configuraciones.notificacion_tipo_role (role_id, tipo_notificacion, descripcion, es_obligatorio, creado_en)
+VALUES
+    (1, 'VENTA_STOCK_CRITICO', 'Alerta de venta con stock resultante cero o negativo', false, NOW()),
+    (5, 'VENTA_STOCK_CRITICO', 'Alerta de venta con stock resultante cero o negativo', false, NOW())
+ON CONFLICT (role_id, tipo_notificacion) DO NOTHING;


### PR DESCRIPTION
## Summary
- Registra tipos de notificación `RETIRO`, `VENTA_TRANSFERENCIA` y `VENTA_STOCK_CRITICO` en preferencias por rol (migraciones Flyway).
- Expone `POST /notification/venta-stock-critico` para enviar push cuando una venta deja productos con stock cero o negativo.
- Agrega plantilla, roles destinatarios y DTO de solicitud para la alerta de stock crítico.

## Test plan
- [ ] Ejecutar migraciones V127.3 y V128.3 y verificar filas en `configuraciones.notificacion_tipo_role`.
- [ ] Llamar `POST /notification/venta-stock-critico` con venta, sucursal e ítems válidos y confirmar push a usuarios con roles configurados.
- [ ] Validar respuesta 400 con payload incompleto y 404 sin usuarios con roles relevantes.
- [ ] Confirmar que el deep link apunta a `/operaciones/ventas/{ventaId}/{sucursalId}`.


Made with [Cursor](https://cursor.com)