### PR TITLE
feat(productos): add sucursal compras en reporte de productos

### DIFF
--- a/src/main/java/com/franco/dev/service/operaciones/MovimientoStockService.java
+++ b/src/main/java/com/franco/dev/service/operaciones/MovimientoStockService.java
@@ -50,8 +50,7 @@ public class MovimientoStockService extends CrudService<MovimientoStock, Movimie
 
     public Double stockByProductoId(Long proId) {
         Double finalStock = 0.0;
-        List<Sucursal> sucursalList = sucursalService.findAll2().stream()
-                .filter(s -> s.getNombre().equals("COMPRAS") == false).collect(Collectors.toList());
+        List<Sucursal> sucursalList = sucursalService.findAll2();
         for (Sucursal s : sucursalList) {
             finalStock += stockByProductoIdAndSucursalId(proId, s.getId());
         }


### PR DESCRIPTION
## Qué resuelve
Corrige una discrepancia en el stock total consolidado de productos que afectaba al reporte general (PDF) y a las consultas GraphQL generales. El método encargado de consolidar el stock total (stockByProductoId en MovimientoStockService) excluía explícitamente a la sucursal "COMPRAS" mediante un filtro por nombre. Dado que esta sucursal posee movimientos de inventario legítimos (de tipo transferencia), omitirla causaba que el cálculo de stock total general no coincidiera con la sumatoria individual de las sucursales mostrada en la interfaz del usuario.

## Cómo probarlo
1. Ubicar un producto que tenga stock en la sucursal "Compras" (por ejemplo, el producto con ID 120 u otro que cuente con existencias en dicha sucursal).
2. En la pantalla de lista de productos, expandir la fila de dicho producto para visualizar el desglose por sucursal y calcular la sumatoria manual (la cual incluye a la sucursal Compras).
3. Generar el reporte de productos (PDF) sin filtrar por sucursal ni por stock.
4. Verificar que la columna "Cantidad" del producto en el PDF coincida exactamente con la sumatoria manual obtenida en el paso 2 (incluyendo la cantidad de la sucursal Compras).
5. Adicionalmente, se puede validar que el campo consolidado de stock retornado por consultas GraphQL generales para el producto incluya ahora el stock de la sucursal Compras.

## Impacto DB
No aplica. Este cambio no modifica esquemas, tablas ni requiere nuevas migraciones de base de datos.

## Riesgo
Bajo. La modificación únicamente remueve el filtro de exclusión de la sucursal "COMPRAS" al momento de consolidar stocks, sin alterar la lógica de inserción, actualización de movimientos o integridad de inventario.
