### PR TITLE
fix(graficos): entradas y rotación por movimiento_stock en análisis de productos

### DIFF
--- a/src/main/java/com/franco/dev/graphql/operaciones/dto/ProductoVendidoEstadistica.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/dto/ProductoVendidoEstadistica.java
@@ -15,4 +15,10 @@ public class ProductoVendidoEstadistica {
     private Double cantidad;
     private Double totalMonto;
     private Double porcentaje;
+    /** Entradas por COMPRA + TRANSFERENCIA (movimiento_stock, cantidad > 0) */
+    private Double cantidadEntrada;
+    /** Ventas según movimiento_stock tipo VENTA */
+    private Double cantidadVentaMovimiento;
+    /** ventaMovimiento / cantidadEntrada cuando hay entradas en el período */
+    private Double indiceRotacion;
 }

--- a/src/main/java/com/franco/dev/repository/operaciones/VentaRepository.java
+++ b/src/main/java/com/franco/dev/repository/operaciones/VentaRepository.java
@@ -185,16 +185,21 @@ public interface VentaRepository extends HelperRepository<Venta, EmbebedPrimaryK
         // public Page<Venta> findWithFilters(Long id, Long sucId, Long formaPagoId,
         // VentaEstado estado, Pageable pageable, Boolean isDelivery, Long monedaId);
 
-        @Query(value = "SELECT s.id, s.nombre, " +
-                        "SUM((CASE WHEN cd.pago = true THEN cd.valor * cd.cambio ELSE 0 END) - (CASE WHEN cd.vuelto = true THEN cd.valor * cd.cambio ELSE 0 END)) " +
+        // Excluye ventas con cobro_detalle corrupto (pagos/vueltos >= 2.000.000.000 Gs).
+        // Filtrar solo cd.valor < 2e9 por fila no alcanza: vueltos negativos enormes pasan el filtro
+        // y al restarlos en la suma inflan el total del reporte.
+        @Query(value = "SELECT s.id, s.nombre, SUM(v.total_gs) " +
                         "FROM operaciones.venta v " +
                         "JOIN empresarial.sucursal s ON v.sucursal_id = s.id " +
-                        "JOIN operaciones.cobro_detalle cd ON cd.cobro_id = v.cobro_id AND cd.sucursal_id = v.sucursal_id " +
                         "WHERE v.creado_en BETWEEN :inicio AND :fin " +
                         "AND v.estado = 'CONCLUIDA' " +
-                        "AND cd.valor < 2000000000 " +
+                        "AND NOT EXISTS ( " +
+                        "  SELECT 1 FROM operaciones.cobro_detalle cd_bad " +
+                        "  WHERE cd_bad.cobro_id = v.cobro_id AND cd_bad.sucursal_id = v.sucursal_id " +
+                        "  AND ABS(cd_bad.valor * COALESCE(cd_bad.cambio, 1)) >= 2000000000 " +
+                        ") " +
                         "GROUP BY s.id, s.nombre " +
-                        "ORDER BY SUM((CASE WHEN cd.pago = true THEN cd.valor * cd.cambio ELSE 0 END) - (CASE WHEN cd.vuelto = true THEN cd.valor * cd.cambio ELSE 0 END)) DESC", nativeQuery = true)
+                        "ORDER BY SUM(v.total_gs) DESC", nativeQuery = true)
         List<Object[]> getVentasPorSucursal(@Param("inicio") LocalDateTime inicio,
                         @Param("fin") LocalDateTime fin);
 
@@ -233,7 +238,11 @@ public interface VentaRepository extends HelperRepository<Venta, EmbebedPrimaryK
                         "AND v.sucursal_id = :sucId " +
                         "AND v.estado = 'CONCLUIDA' " +
                         "AND cd.pago = true " +
-                        "AND cd.valor < 2000000000 " +
+                        "AND NOT EXISTS ( " +
+                        "  SELECT 1 FROM operaciones.cobro_detalle cd_bad " +
+                        "  WHERE cd_bad.cobro_id = v.cobro_id AND cd_bad.sucursal_id = v.sucursal_id " +
+                        "  AND ABS(cd_bad.valor * COALESCE(cd_bad.cambio, 1)) >= 2000000000 " +
+                        ") " +
                         "GROUP BY extract(month from v.creado_en) " +
                         "ORDER BY extract(month from v.creado_en)", nativeQuery = true)
         List<Object[]> ventasPorMes(@Param("inicio") LocalDateTime inicio,
@@ -251,7 +260,11 @@ public interface VentaRepository extends HelperRepository<Venta, EmbebedPrimaryK
                         "WHERE v.creado_en BETWEEN :inicio AND :fin " +
                         "AND v.estado = 'CONCLUIDA' " +
                         "AND cd.pago = true " +
-                        "AND cd.valor < 2000000000 " +
+                        "AND NOT EXISTS ( " +
+                        "  SELECT 1 FROM operaciones.cobro_detalle cd_bad " +
+                        "  WHERE cd_bad.cobro_id = v.cobro_id AND cd_bad.sucursal_id = v.sucursal_id " +
+                        "  AND ABS(cd_bad.valor * COALESCE(cd_bad.cambio, 1)) >= 2000000000 " +
+                        ") " +
                         "GROUP BY extract(month from v.creado_en) " +
                         "ORDER BY extract(month from v.creado_en)", nativeQuery = true)
         List<Object[]> ventasPorMesSinSucursal(@Param("inicio") LocalDateTime inicio,

--- a/src/main/java/com/franco/dev/service/operaciones/VentaItemService.java
+++ b/src/main/java/com/franco/dev/service/operaciones/VentaItemService.java
@@ -65,18 +65,56 @@ public class VentaItemService extends CrudService<VentaItem, VentaItemRepository
     }
 
     /**
+     * Entradas de stock para análisis: recepciones (COMPRA) y transferencias desde
+     * sucursal COMPRAS hacia cualquier destino (movimiento positivo en destino).
+     */
+    private String sqlCondicionEntradasStock() {
+        return "ms.estado = true AND ms.cantidad > 0 AND ("
+                + "ms.tipo_movimiento = 'COMPRA' OR ("
+                + "ms.tipo_movimiento = 'TRANSFERENCIA' AND EXISTS ("
+                + "  SELECT 1 FROM operaciones.transferencia_item ti "
+                + "  JOIN operaciones.transferencia t ON t.id = ti.transferencia_id "
+                + "  WHERE ti.id = ms.referencia "
+                + "  AND t.sucursal_origen_id IN ("
+                + "    SELECT s.id FROM empresarial.sucursal s WHERE UPPER(s.nombre) LIKE '%COMPRAS%'"
+                + "  )"
+                + ")))";
+    }
+
+    /**
      * Obtiene estadísticas de productos más vendidos con filtros usando
      * CriteriaBuilder
      */
     public List<ProductoVendidoEstadistica> obtenerProductosMasVendidos(LocalDateTime inicio, LocalDateTime fin,
             Integer limit, Long sucursalId, Long familiaId, Boolean ascendente, Long productoId,
             List<Long> productoIds) {
+        String filtroFechaMs = "";
+        if (inicio != null) filtroFechaMs += "AND ms.creado_en >= :inicio ";
+        if (fin != null) filtroFechaMs += "AND ms.creado_en < :fin ";
+        String filtroSucursalMs = (sucursalId != null && sucursalId > 0) ? "AND ms.sucursal_id = :sucursalId " : "";
+
         String sql = "SELECT p.id, p.descripcion, SUM(vi.cantidad) as cantidad, " +
-                "SUM((vi.precio * vi.cantidad) - COALESCE(vi.descuento_unitario * vi.cantidad, 0)) as total_monto " +
+                "SUM((vi.precio * vi.cantidad) - COALESCE(vi.descuento_unitario * vi.cantidad, 0)) as total_monto, " +
+                "COALESCE(ent.cantidad_entrada, 0) as cantidad_entrada, " +
+                "COALESCE(ven.cantidad_venta_mov, 0) as cantidad_venta_mov " +
                 "FROM operaciones.venta_item vi " +
                 "JOIN productos.producto p ON vi.producto_id = p.id " +
                 "JOIN operaciones.venta v ON vi.venta_id = v.id AND vi.sucursal_id = v.sucursal_id " +
                 "LEFT JOIN productos.subfamilia sf ON p.sub_familia_id = sf.id " +
+                "LEFT JOIN ( " +
+                "  SELECT ms.producto_id, SUM(ms.cantidad) AS cantidad_entrada " +
+                "  FROM operaciones.movimiento_stock ms " +
+                "  WHERE " + sqlCondicionEntradasStock() + " " +
+                filtroFechaMs + filtroSucursalMs +
+                "  GROUP BY ms.producto_id " +
+                ") ent ON ent.producto_id = p.id " +
+                "LEFT JOIN ( " +
+                "  SELECT ms.producto_id, SUM(ABS(ms.cantidad)) AS cantidad_venta_mov " +
+                "  FROM operaciones.movimiento_stock ms " +
+                "  WHERE ms.estado = true AND ms.tipo_movimiento = 'VENTA' AND ms.cantidad < 0 " +
+                filtroFechaMs + filtroSucursalMs +
+                "  GROUP BY ms.producto_id " +
+                ") ven ON ven.producto_id = p.id " +
                 "WHERE v.estado = 'CONCLUIDA' AND vi.activo = true ";
 
         if (inicio != null) sql += "AND vi.creado_en >= :inicio ";
@@ -90,7 +128,8 @@ public class VentaItemService extends CrudService<VentaItem, VentaItemRepository
         }
 
         boolean ordenAsc = Boolean.TRUE.equals(ascendente);
-        sql += "GROUP BY p.id, p.descripcion ORDER BY cantidad " + (ordenAsc ? "ASC" : "DESC");
+        sql += "GROUP BY p.id, p.descripcion, ent.cantidad_entrada, ven.cantidad_venta_mov " +
+                "ORDER BY cantidad " + (ordenAsc ? "ASC" : "DESC");
 
         javax.persistence.Query query = em.createNativeQuery(sql);
         if (inicio != null) query.setParameter("inicio", inicio);
@@ -163,17 +202,17 @@ public class VentaItemService extends CrudService<VentaItem, VentaItemRepository
 
     public List<ProductoCompraPorPeriodo> obtenerComprasProductoPorDia(LocalDateTime inicio, LocalDateTime fin,
             Long productoId, Long sucursalId) {
-        String sql = "SELECT CAST(rm.fecha AS DATE) as periodo, SUM(rmi.cantidad_recibida) as cantidad, " +
-                "COUNT(DISTINCT rm.id) as cantidad_compras " +
-                "FROM operaciones.recepcion_mercaderia_item rmi " +
-                "JOIN operaciones.recepcion_mercaderia rm ON rmi.recepcion_mercaderia_id = rm.id " +
-                "WHERE rm.estado = 'FINALIZADA' AND rmi.producto_id = :productoId ";
+        String sql = "SELECT CAST(ms.creado_en AS DATE) as periodo, SUM(ms.cantidad) as cantidad, " +
+                "COUNT(*) as cantidad_compras " +
+                "FROM operaciones.movimiento_stock ms " +
+                "WHERE " + sqlCondicionEntradasStock() + " " +
+                "AND ms.producto_id = :productoId ";
 
-        if (inicio != null) sql += "AND rm.fecha >= :inicio ";
-        if (fin != null) sql += "AND rm.fecha < :fin ";
-        if (sucursalId != null && sucursalId > 0) sql += "AND rmi.sucursal_entrega_id = :sucursalId ";
+        if (inicio != null) sql += "AND ms.creado_en >= :inicio ";
+        if (fin != null) sql += "AND ms.creado_en < :fin ";
+        if (sucursalId != null && sucursalId > 0) sql += "AND ms.sucursal_id = :sucursalId ";
 
-        sql += "GROUP BY CAST(rm.fecha AS DATE) ORDER BY periodo ASC";
+        sql += "GROUP BY CAST(ms.creado_en AS DATE) ORDER BY periodo ASC";
 
         javax.persistence.Query query = em.createNativeQuery(sql);
         query.setParameter("productoId", productoId);
@@ -188,17 +227,17 @@ public class VentaItemService extends CrudService<VentaItem, VentaItemRepository
 
     public List<ProductoCompraPorPeriodo> obtenerComprasProductoPorMes(LocalDateTime inicio, LocalDateTime fin,
             Long productoId, Long sucursalId) {
-        String sql = "SELECT TO_CHAR(rm.fecha, 'YYYY-MM') as periodo, SUM(rmi.cantidad_recibida) as cantidad, " +
-                "COUNT(DISTINCT rm.id) as cantidad_compras " +
-                "FROM operaciones.recepcion_mercaderia_item rmi " +
-                "JOIN operaciones.recepcion_mercaderia rm ON rmi.recepcion_mercaderia_id = rm.id " +
-                "WHERE rm.estado = 'FINALIZADA' AND rmi.producto_id = :productoId ";
+        String sql = "SELECT TO_CHAR(ms.creado_en, 'YYYY-MM') as periodo, SUM(ms.cantidad) as cantidad, " +
+                "COUNT(*) as cantidad_compras " +
+                "FROM operaciones.movimiento_stock ms " +
+                "WHERE " + sqlCondicionEntradasStock() + " " +
+                "AND ms.producto_id = :productoId ";
 
-        if (inicio != null) sql += "AND rm.fecha >= :inicio ";
-        if (fin != null) sql += "AND rm.fecha < :fin ";
-        if (sucursalId != null && sucursalId > 0) sql += "AND rmi.sucursal_entrega_id = :sucursalId ";
+        if (inicio != null) sql += "AND ms.creado_en >= :inicio ";
+        if (fin != null) sql += "AND ms.creado_en < :fin ";
+        if (sucursalId != null && sucursalId > 0) sql += "AND ms.sucursal_id = :sucursalId ";
 
-        sql += "GROUP BY TO_CHAR(rm.fecha, 'YYYY-MM') ORDER BY periodo ASC";
+        sql += "GROUP BY TO_CHAR(ms.creado_en, 'YYYY-MM') ORDER BY periodo ASC";
 
         javax.persistence.Query query = em.createNativeQuery(sql);
         query.setParameter("productoId", productoId);
@@ -250,6 +289,8 @@ public class VentaItemService extends CrudService<VentaItem, VentaItemRepository
             String descripcion = fila[1] != null ? fila[1].toString() : "";
             Double cantidad = fila[2] != null ? ((Number) fila[2]).doubleValue() : 0.0;
             Double totalMonto = fila[3] != null ? ((Number) fila[3]).doubleValue() : 0.0;
+            Double cantidadEntrada = fila[4] != null ? ((Number) fila[4]).doubleValue() : 0.0;
+            Double cantidadVentaMovimiento = fila[5] != null ? ((Number) fila[5]).doubleValue() : 0.0;
 
             Double porcentaje = 0.0;
             if (montoTotalGeneral > 0) {
@@ -257,14 +298,36 @@ public class VentaItemService extends CrudService<VentaItem, VentaItemRepository
                 porcentaje = Math.round(porcentaje * 100.0) / 100.0;
             }
 
+            Double indiceRotacion = calcularIndiceRotacion(cantidadEntrada, cantidadVentaMovimiento);
+
             estadisticas.add(new ProductoVendidoEstadistica(
                     productoId,
                     descripcion,
                     cantidad,
                     totalMonto,
-                    porcentaje));
+                    porcentaje,
+                    cantidadEntrada,
+                    cantidadVentaMovimiento,
+                    indiceRotacion));
         }
 
         return estadisticas;
+    }
+
+    /**
+     * Índice de rotación: unidades vendidas (mov. VENTA) / unidades que entraron (COMPRA + TRANSFERENCIA).
+     * Sin entradas en el período pero con ventas: 1.0 (rota stock previo).
+     */
+    private Double calcularIndiceRotacion(Double cantidadEntrada, Double cantidadVentaMovimiento) {
+        double entradas = cantidadEntrada != null ? cantidadEntrada : 0.0;
+        double ventas = cantidadVentaMovimiento != null ? cantidadVentaMovimiento : 0.0;
+        if (entradas > 0) {
+            double indice = ventas / entradas;
+            return Math.round(indice * 1000.0) / 1000.0;
+        }
+        if (ventas > 0) {
+            return 1.0;
+        }
+        return 0.0;
     }
 }

--- a/src/main/resources/graphql/operaciones/venta-item.graphqls
+++ b/src/main/resources/graphql/operaciones/venta-item.graphqls
@@ -37,6 +37,9 @@ type ProductoVendidoEstadistica {
     cantidad: Float
     totalMonto: Float
     porcentaje: Float
+    cantidadEntrada: Float
+    cantidadVentaMovimiento: Float
+    indiceRotacion: Float
 }
 
 type ProductoVentaPorPeriodo {


### PR DESCRIPTION
## Summary

- Unifica las **entradas** del análisis de productos en `movimiento_stock`: movimientos `COMPRA` (módulo de recepción) y `TRANSFERENCIA` solo cuando el origen es la sucursal **COMPRAS** (cualquier destino), evitando duplicar recepciones y contar transferencias internas depósito → sucursal.
- Agrega a `productosMasVendidos` los campos `cantidadEntrada`, `cantidadVentaMovimiento` e `indiceRotacion` (ventas mov. / entradas) para calcular rotación Alta/Media/Baja en el frontend.
- Corrige reportes de ventas por sucursal y por mes excluyendo ventas con `cobro_detalle` corrupto (montos >= 2.000.000.000 Gs), usando `v.total_gs` y `NOT EXISTS` en lugar de filtrar fila a fila.

## Test plan

- [ ] Reiniciar backend y abrir Análisis de Productos: verificar entradas de un producto con transfer desde COMPRAS (ej. Coca Cola 2LTS, mayo 2026).
- [ ] Confirmar que productos solo abastecidos por depósito → sucursal **no** inflan entradas (ej. Hielo Mediano: entradas menores que antes del fix de origen).
- [ ] Validar badges de rotación según `indiceRotacion` (producto con ventas ≈ entradas → Alta rotación).
- [ ] Gráfico ventas por mes / por sucursal: totales coherentes sin ventas con cobros corruptos.


Made with [Cursor](https://cursor.com)