### PR TITLE
refactor(facturacion): centralizar parciales + fix print Gs lee parciales persistidos

### DIFF
--- a/src/main/java/com/franco/dev/graphql/financiero/FacturaLegalGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/FacturaLegalGraphQL.java
@@ -497,19 +497,21 @@ public class FacturaLegalGraphQL implements GraphQLQueryResolver, GraphQLMutatio
             }
 
             escpos.writeLF("--------Liquidación IVA---------");
-            Double porcentajeDescuento = (facturaLegal.getDescuento() != null
-                    && facturaLegal.getDescuento().compareTo(0.0) != 0) ? (facturaLegal.getDescuento() / totalFinal)
-                            : null;
+            // Leer los parciales persistidos en la factura (ya tienen el descuento
+            // aplicado proporcionalmente por el builder). Antes este bloque
+            // recalculaba desde los items locales y aplicaba descuento extra,
+            // generando inconsistencia con PDF/KUDE que leen los parciales
+            // persistidos.
+            Double ivaParcial10Persist = facturaLegal.getIvaParcial10() != null ? facturaLegal.getIvaParcial10() : 0.0;
+            Double ivaParcial5Persist = facturaLegal.getIvaParcial5() != null ? facturaLegal.getIvaParcial5() : 0.0;
             escpos.write("Gravadas 10%:");
-            Double desc10 = porcentajeDescuento != null ? (totalIva10 - (totalIva10 * porcentajeDescuento)) : null;
-            String totalIva10S = df.format(desc10 == null ? totalIva10.intValue() : desc10.intValue());
+            String totalIva10S = df.format(ivaParcial10Persist.intValue());
             for (int i = 19; i > totalIva10S.length(); i--) {
                 escpos.write(" ");
             }
             escpos.writeLF(totalIva10S);
             escpos.write("Gravadas 5%: ");
-            Double desc5 = porcentajeDescuento != null ? (totalIva5 - (totalIva5 * porcentajeDescuento)) : null;
-            String totalIva5S = df.format(desc5 == null ? totalIva5.intValue() : desc5.intValue());
+            String totalIva5S = df.format(ivaParcial5Persist.intValue());
             for (int i = 19; i > totalIva5S.length(); i--) {
                 escpos.write(" ");
             }
@@ -519,10 +521,8 @@ public class FacturaLegalGraphQL implements GraphQLQueryResolver, GraphQLMutatio
                 escpos.write(" ");
             }
             escpos.writeLF("0");
-            Double totalFinalIva = totalIva10 + totalIva5;
-            Double descFinal = porcentajeDescuento != null ? (totalFinalIva - (totalFinalIva * porcentajeDescuento))
-                    : null;
-            String totalFinalIvaS = df.format(descFinal == null ? totalFinalIva.intValue() : descFinal.intValue());
+            Double totalFinalIvaPersist = ivaParcial10Persist + ivaParcial5Persist;
+            String totalFinalIvaS = df.format(totalFinalIvaPersist.intValue());
             escpos.write("Total IVA:   ");
             for (int i = 19; i > totalFinalIvaS.length(); i--) {
                 escpos.write(" ");

--- a/src/main/java/com/franco/dev/service/financiero/FacturaLegalFilialService.java
+++ b/src/main/java/com/franco/dev/service/financiero/FacturaLegalFilialService.java
@@ -181,68 +181,46 @@ public class FacturaLegalFilialService {
                 .collect(Collectors.toList());
         request.setItems(itemsRequest);
         
-        // Calcular totales de IVA basándose en los items
-        Double totalParcial0 = 0.0;
-        Double totalParcial5 = 0.0;
-        Double totalParcial10 = 0.0;
-        Double ivaParcial0 = 0.0;
-        Double ivaParcial5 = 0.0;
-        Double ivaParcial10 = 0.0;
-        
+        // Calcular parciales con descuento distribuido proporcional usando
+        // ParcialesCalculator centralizado. Fix del bug: el codigo viejo restaba
+        // el descuento del total_final sin distribuirlo a los parciales,
+        // generando sum(parciales) > total_final.
+        java.util.List<com.franco.dev.service.financiero.builder.ParcialesCalculator.ItemIvaTuple> tuples =
+                new java.util.ArrayList<>();
         for (FacturaLegalItemFilialRequest item : itemsRequest) {
             if (item.getTotal() == null || item.getIva() == null) {
                 continue;
             }
-            
-            Double totalItem = item.getTotal();
-            Integer ivaItem = item.getIva();
-            
-            if (ivaItem == 0) {
-                // Item exento de IVA
-                totalParcial0 += totalItem;
-            } else if (ivaItem == 5) {
-                // Item con IVA 5%
-                totalParcial5 += totalItem;
-                // IVA 5%: iva = total / 21.0
-                ivaParcial5 += totalItem / 21.0;
-            } else if (ivaItem == 10) {
-                // Item con IVA 10%
-                totalParcial10 += totalItem;
-                // IVA 10%: iva = total / 11.0
-                ivaParcial10 += totalItem / 11.0;
-            }
+            tuples.add(new com.franco.dev.service.financiero.builder.ParcialesCalculator.ItemIvaTuple(
+                    item.getIva(), item.getTotal()));
         }
-        
+        Double descuento = facturaInput.getDescuento() != null ? facturaInput.getDescuento().doubleValue() : 0.0;
+        com.franco.dev.service.financiero.builder.ParcialesCalculator.Resultado calc =
+                com.franco.dev.service.financiero.builder.ParcialesCalculator.calcular(tuples, descuento);
+
         // Redondear los valores de IVA a 2 decimales
-        ivaParcial0 = Math.round(ivaParcial0 * 100.0) / 100.0;
-        ivaParcial5 = Math.round(ivaParcial5 * 100.0) / 100.0;
-        ivaParcial10 = Math.round(ivaParcial10 * 100.0) / 100.0;
-        
-        // Asignar los totales calculados
-        request.setIvaParcial0(ivaParcial0);
+        double ivaParcial5 = Math.round(calc.getIvaParcial5() * 100.0) / 100.0;
+        double ivaParcial10 = Math.round(calc.getIvaParcial10() * 100.0) / 100.0;
+
+        request.setIvaParcial0(0.0);
         request.setIvaParcial5(ivaParcial5);
         request.setIvaParcial10(ivaParcial10);
-        request.setTotalParcial0(totalParcial0);
-        request.setTotalParcial5(totalParcial5);
-        request.setTotalParcial10(totalParcial10);
-        
-        // Calcular totalFinal (suma de totales parciales - descuento)
-        Double descuento = facturaInput.getDescuento() != null ? facturaInput.getDescuento().doubleValue() : 0.0;
-        Double totalFinalCalculado = (totalParcial0 + totalParcial5 + totalParcial10) - descuento;
-        
-        // Usar siempre el totalFinal calculado para garantizar consistencia
-        // Si el totalFinal viene en el input, validar que sea consistente
+        request.setTotalParcial0(calc.getTotalParcial0());
+        request.setTotalParcial5(calc.getTotalParcial5());
+        request.setTotalParcial10(calc.getTotalParcial10());
+
+        double totalFinalCalculado = calc.getTotalFinal();
         Double totalFinalInput = facturaInput.getTotalFinal() != null ? facturaInput.getTotalFinal().doubleValue() : null;
         if (totalFinalInput != null) {
             double diferencia = Math.abs(totalFinalInput - totalFinalCalculado);
             if (diferencia > 0.01) {
-                log.warn("Diferencia entre totalFinal calculado ({}) e input ({}): {}. Se usará el calculado.", 
+                log.warn("Diferencia entre totalFinal calculado ({}) e input ({}): {}. Se usará el calculado.",
                         totalFinalCalculado, totalFinalInput, diferencia);
             }
         }
-        
+
         request.setTotalFinal(totalFinalCalculado);
-        request.setDescuento(facturaInput.getDescuento() != null ? facturaInput.getDescuento().doubleValue() : 0.0);
+        request.setDescuento(descuento);
         
         // Mapear moneda extranjera a código SIFEN (ISO 4217)
         String monedaExtranjera = facturaInput.getMonedaExtranjera();

--- a/src/main/java/com/franco/dev/service/financiero/builder/IvaResolver.java
+++ b/src/main/java/com/franco/dev/service/financiero/builder/IvaResolver.java
@@ -1,0 +1,86 @@
+package com.franco.dev.service.financiero.builder;
+
+import com.franco.dev.domain.operaciones.VentaItem;
+import com.franco.dev.domain.productos.Presentacion;
+import com.franco.dev.domain.productos.Producto;
+import org.slf4j.Logger;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Resolucion del IVA de un item de factura legal segun una unica politica
+ * (centralizada). Reemplaza los defaults divergentes que existian en
+ * FacturaLegalGraphQL, FacturaLegalApiService, FacturaService y los paths de
+ * print de ticket.
+ *
+ * Prioridad de resolucion:
+ *   1. iva explicito en el input (frontend nuevo)
+ *   2. producto.iva si producto fue resuelto via productoId
+ *   3. ventaItem.producto.iva si ventaItemId fue resuelto
+ *   4. presentacion.producto.iva si presentacionId fue resuelto
+ *   5. match por descripcion (UPPER+TRIM contra producto.descripcion / descripcionFactura).
+ *      Si todos los matches comparten el mismo iva -> usar ese iva.
+ *      Si difieren -> log warn (no asignar).
+ *   6. log.warn + default 10 (legacy-friendly, nunca rechaza la factura)
+ *
+ * Sin strictMode. El backend es safety net del frontend: si llega null igual
+ * factura, pero deja log para detectar regresiones del frontend.
+ */
+public final class IvaResolver {
+
+    private IvaResolver() {
+    }
+
+    public static Integer resolveIva(
+            Integer ivaInput,
+            Producto producto,
+            VentaItem ventaItem,
+            Presentacion presentacion,
+            String descripcion,
+            List<Producto> descMatches,
+            Logger log) {
+
+        if (ivaInput != null) {
+            return ivaInput;
+        }
+
+        if (producto != null && producto.getIva() != null) {
+            return producto.getIva();
+        }
+
+        if (ventaItem != null && ventaItem.getProducto() != null && ventaItem.getProducto().getIva() != null) {
+            return ventaItem.getProducto().getIva();
+        }
+
+        if (presentacion != null && presentacion.getProducto() != null && presentacion.getProducto().getIva() != null) {
+            return presentacion.getProducto().getIva();
+        }
+
+        if (descMatches != null && !descMatches.isEmpty()) {
+            Set<Integer> ivasDistintos = new HashSet<>();
+            for (Producto p : descMatches) {
+                if (p.getIva() != null) {
+                    ivasDistintos.add(p.getIva());
+                }
+            }
+            if (ivasDistintos.size() == 1) {
+                Integer iva = ivasDistintos.iterator().next();
+                log.warn("IVA resuelto por descripcion para item desc='{}' (consensus {} match): iva={}",
+                        descripcion, descMatches.size(), iva);
+                return iva;
+            } else if (ivasDistintos.size() > 1) {
+                log.warn("IVA ambiguo por descripcion para item desc='{}' ({} matches con ivas distintos: {}), default 10",
+                        descripcion, descMatches.size(), ivasDistintos);
+            }
+        }
+
+        log.warn("IVA no resoluble para item desc='{}' productoId={} ventaItemId={} presentacionId={}, default 10",
+                descripcion,
+                producto != null ? producto.getId() : null,
+                ventaItem != null ? ventaItem.getId() : null,
+                presentacion != null ? presentacion.getId() : null);
+        return 10;
+    }
+}

--- a/src/main/java/com/franco/dev/service/financiero/builder/ParcialesCalculator.java
+++ b/src/main/java/com/franco/dev/service/financiero/builder/ParcialesCalculator.java
@@ -1,0 +1,108 @@
+package com.franco.dev.service.financiero.builder;
+
+import java.util.List;
+
+/**
+ * Calculo de parciales (total_parcial_0/5/10), iva_parcial_5/10 y total_final
+ * para FacturaLegal segun la fórmula correcta:
+ *
+ *   sumaBruta = sum(item.total) por banda IVA (sin descuento)
+ *   porcentajeDescuento = descuento / totalBruto
+ *   total_parcial_X = sumaBruta_X * (1 - porcentajeDescuento)
+ *   iva_parcial_5  = total_parcial_5  / 21.0   (IVA incluido)
+ *   iva_parcial_10 = total_parcial_10 / 11.0
+ *   total_final = total_parcial_0 + total_parcial_5 + total_parcial_10
+ *
+ * Reemplaza las 3 implementaciones divergentes que existian en
+ * FacturaLegalGraphQL, FacturaLegalApiService y FacturaService (la ultima
+ * distribuia descuento; las otras dos no).
+ */
+public final class ParcialesCalculator {
+
+    private ParcialesCalculator() {
+    }
+
+    public static class ItemIvaTuple {
+        private final int iva;
+        private final double total;
+
+        public ItemIvaTuple(int iva, double total) {
+            this.iva = iva;
+            this.total = total;
+        }
+
+        public int getIva() {
+            return iva;
+        }
+
+        public double getTotal() {
+            return total;
+        }
+    }
+
+    public static class Resultado {
+        private final double totalParcial0;
+        private final double totalParcial5;
+        private final double totalParcial10;
+        private final double ivaParcial5;
+        private final double ivaParcial10;
+        private final double totalFinal;
+
+        public Resultado(double totalParcial0, double totalParcial5, double totalParcial10,
+                         double ivaParcial5, double ivaParcial10, double totalFinal) {
+            this.totalParcial0 = totalParcial0;
+            this.totalParcial5 = totalParcial5;
+            this.totalParcial10 = totalParcial10;
+            this.ivaParcial5 = ivaParcial5;
+            this.ivaParcial10 = ivaParcial10;
+            this.totalFinal = totalFinal;
+        }
+
+        public double getTotalParcial0() { return totalParcial0; }
+        public double getTotalParcial5() { return totalParcial5; }
+        public double getTotalParcial10() { return totalParcial10; }
+        public double getIvaParcial5() { return ivaParcial5; }
+        public double getIvaParcial10() { return ivaParcial10; }
+        public double getTotalFinal() { return totalFinal; }
+    }
+
+    public static Resultado calcular(List<ItemIvaTuple> items, double descuento) {
+        double bruto0 = 0.0, bruto5 = 0.0, bruto10 = 0.0;
+        for (ItemIvaTuple t : items) {
+            switch (t.getIva()) {
+                case 5:
+                    bruto5 += t.getTotal();
+                    break;
+                case 10:
+                    bruto10 += t.getTotal();
+                    break;
+                case 0:
+                default:
+                    // iva 0 o cualquier valor no soportado cae en exento
+                    bruto0 += t.getTotal();
+                    break;
+            }
+        }
+        double brutoTotal = bruto0 + bruto5 + bruto10;
+
+        double p0 = bruto0, p5 = bruto5, p10 = bruto10;
+        // descuento puede ser positivo (descuento) o negativo (aumento, ej. recargo).
+        if (descuento != 0.0 && brutoTotal > 0) {
+            double porcentaje = Math.abs(descuento) / brutoTotal;
+            // si descuento positivo >= brutoTotal, no devolver negativos
+            if (descuento > 0 && porcentaje > 1.0) {
+                porcentaje = 1.0;
+            }
+            double factor = descuento > 0 ? (1.0 - porcentaje) : (1.0 + porcentaje);
+            p0 = bruto0 * factor;
+            p5 = bruto5 * factor;
+            p10 = bruto10 * factor;
+        }
+
+        double iva5 = p5 / 21.0;
+        double iva10 = p10 / 11.0;
+        double totalFinal = p0 + p5 + p10;
+
+        return new Resultado(p0, p5, p10, iva5, iva10, totalFinal);
+    }
+}

--- a/src/test/java/com/franco/dev/service/financiero/builder/IvaResolverTest.java
+++ b/src/test/java/com/franco/dev/service/financiero/builder/IvaResolverTest.java
@@ -1,0 +1,123 @@
+package com.franco.dev.service.financiero.builder;
+
+import com.franco.dev.domain.operaciones.VentaItem;
+import com.franco.dev.domain.productos.Presentacion;
+import com.franco.dev.domain.productos.Producto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+
+class IvaResolverTest {
+
+    private Logger log;
+
+    @BeforeEach
+    void setUp() {
+        log = mock(Logger.class);
+    }
+
+    private Producto producto(Long id, Integer iva) {
+        Producto p = new Producto();
+        p.setId(id);
+        p.setIva(iva);
+        return p;
+    }
+
+    private VentaItem ventaItem(Long id, Producto p) {
+        VentaItem vi = new VentaItem();
+        vi.setId(id);
+        vi.setProducto(p);
+        return vi;
+    }
+
+    private Presentacion presentacion(Long id, Producto p) {
+        Presentacion pr = new Presentacion();
+        pr.setId(id);
+        pr.setProducto(p);
+        return pr;
+    }
+
+    private boolean huboWarn(Logger log) {
+        return Mockito.mockingDetails(log).getInvocations().stream()
+                .anyMatch(inv -> inv.getMethod().getName().equals("warn"));
+    }
+
+    @Test
+    void resuelveDesdeInput_siNoNull() {
+        Integer iva = IvaResolver.resolveIva(5, producto(1L, 10), null, null, "X", null, log);
+        assertEquals(Integer.valueOf(5), iva);
+        assertFalse(huboWarn(log));
+    }
+
+    @Test
+    void priorizaProductoSobreVentaItem() {
+        Integer iva = IvaResolver.resolveIva(null, producto(1L, 0), ventaItem(99L, producto(99L, 10)), null, "X", null, log);
+        assertEquals(Integer.valueOf(0), iva);
+        assertFalse(huboWarn(log));
+    }
+
+    @Test
+    void fallbackVentaItemProducto() {
+        Integer iva = IvaResolver.resolveIva(null, null, ventaItem(99L, producto(99L, 5)), null, "X", null, log);
+        assertEquals(Integer.valueOf(5), iva);
+        assertFalse(huboWarn(log));
+    }
+
+    @Test
+    void fallbackPresentacionProducto() {
+        Integer iva = IvaResolver.resolveIva(null, null, null, presentacion(1L, producto(2L, 0)), "X", null, log);
+        assertEquals(Integer.valueOf(0), iva);
+        assertFalse(huboWarn(log));
+    }
+
+    @Test
+    void descMatchUnico_resuelve() {
+        List<Producto> matches = Collections.singletonList(producto(1L, 5));
+        Integer iva = IvaResolver.resolveIva(null, null, null, null, "PROD", matches, log);
+        assertEquals(Integer.valueOf(5), iva);
+        assertTrue(huboWarn(log));
+    }
+
+    @Test
+    void descMatchMultipleMismoIva_resuelve() {
+        // Caso DURACELL AA X 4: dos productos con misma desc (uno con trailing space), ambos iva 10
+        List<Producto> matches = Arrays.asList(producto(1L, 10), producto(2L, 10));
+        Integer iva = IvaResolver.resolveIva(null, null, null, null, "DURACELL AA X 4", matches, log);
+        assertEquals(Integer.valueOf(10), iva);
+        // hay warn porque se resolvio por descripcion (consensus)
+        assertTrue(huboWarn(log));
+    }
+
+    @Test
+    void descMatchMultipleIvaDistinto_default10_warn() {
+        List<Producto> matches = Arrays.asList(producto(1L, 5), producto(2L, 10));
+        Integer iva = IvaResolver.resolveIva(null, null, null, null, "AMBIGUO", matches, log);
+        assertEquals(Integer.valueOf(10), iva);
+        assertTrue(huboWarn(log));
+    }
+
+    @Test
+    void sinMatch_default10_warn_legacyFriendly() {
+        Integer iva = IvaResolver.resolveIva(null, null, null, null, "INVENTADO XYZ", Collections.emptyList(), log);
+        assertEquals(Integer.valueOf(10), iva);
+        assertTrue(huboWarn(log));
+    }
+
+    @Test
+    void productoSinIva_caeABuscarDescripcion() {
+        Producto pSinIva = producto(1L, null);
+        List<Producto> matches = Collections.singletonList(producto(99L, 5));
+        Integer iva = IvaResolver.resolveIva(null, pSinIva, null, null, "X", matches, log);
+        assertEquals(Integer.valueOf(5), iva);
+    }
+}

--- a/src/test/java/com/franco/dev/service/financiero/builder/ParcialesCalculatorTest.java
+++ b/src/test/java/com/franco/dev/service/financiero/builder/ParcialesCalculatorTest.java
@@ -1,0 +1,107 @@
+package com.franco.dev.service.financiero.builder;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ParcialesCalculatorTest {
+
+    private static final double DELTA = 0.01;
+
+    @Test
+    void calculaSinDescuento_unicaBanda10() {
+        List<ParcialesCalculator.ItemIvaTuple> items = Collections.singletonList(
+                new ParcialesCalculator.ItemIvaTuple(10, 11000.0));
+        ParcialesCalculator.Resultado r = ParcialesCalculator.calcular(items, 0.0);
+        assertEquals(0.0, r.getTotalParcial0(), DELTA);
+        assertEquals(0.0, r.getTotalParcial5(), DELTA);
+        assertEquals(11000.0, r.getTotalParcial10(), DELTA);
+        assertEquals(1000.0, r.getIvaParcial10(), DELTA);
+        assertEquals(0.0, r.getIvaParcial5(), DELTA);
+        assertEquals(11000.0, r.getTotalFinal(), DELTA);
+    }
+
+    @Test
+    void distribuyeDescuentoProporcional_mixBandas() {
+        // p0=10000, p10=11000, p5=2100, total=23100, descuento=2310 (10%)
+        // post: p0=9000, p10=9900, p5=1890, total=20790
+        List<ParcialesCalculator.ItemIvaTuple> items = Arrays.asList(
+                new ParcialesCalculator.ItemIvaTuple(0, 10000.0),
+                new ParcialesCalculator.ItemIvaTuple(10, 11000.0),
+                new ParcialesCalculator.ItemIvaTuple(5, 2100.0));
+        ParcialesCalculator.Resultado r = ParcialesCalculator.calcular(items, 2310.0);
+        assertEquals(9000.0, r.getTotalParcial0(), DELTA);
+        assertEquals(1890.0, r.getTotalParcial5(), DELTA);
+        assertEquals(9900.0, r.getTotalParcial10(), DELTA);
+        assertEquals(20790.0, r.getTotalFinal(), DELTA);
+        // iva proporcional al parcial post-descuento
+        assertEquals(9900.0 / 11.0, r.getIvaParcial10(), DELTA);
+        assertEquals(1890.0 / 21.0, r.getIvaParcial5(), DELTA);
+    }
+
+    @Test
+    void ivaParcialDesdeNeto_noBruto() {
+        // verify formula iva10 = parcial_neto_10 / 11, no bruto / 11
+        List<ParcialesCalculator.ItemIvaTuple> items = Collections.singletonList(
+                new ParcialesCalculator.ItemIvaTuple(10, 11000.0));
+        ParcialesCalculator.Resultado r = ParcialesCalculator.calcular(items, 1100.0);
+        // bruto 11000 - descuento 1100 = 9900 → iva10 = 9900/11 = 900
+        assertEquals(9900.0, r.getTotalParcial10(), DELTA);
+        assertEquals(900.0, r.getIvaParcial10(), DELTA);
+    }
+
+    @Test
+    void totalFinalIgualSumaParciales() {
+        List<ParcialesCalculator.ItemIvaTuple> items = Arrays.asList(
+                new ParcialesCalculator.ItemIvaTuple(0, 50000.0),
+                new ParcialesCalculator.ItemIvaTuple(5, 21000.0),
+                new ParcialesCalculator.ItemIvaTuple(10, 11000.0));
+        ParcialesCalculator.Resultado r = ParcialesCalculator.calcular(items, 8200.0);
+        double suma = r.getTotalParcial0() + r.getTotalParcial5() + r.getTotalParcial10();
+        assertEquals(r.getTotalFinal(), suma, DELTA);
+    }
+
+    @Test
+    void todosItems0_parcialesCorrectos() {
+        List<ParcialesCalculator.ItemIvaTuple> items = Arrays.asList(
+                new ParcialesCalculator.ItemIvaTuple(0, 10000.0),
+                new ParcialesCalculator.ItemIvaTuple(0, 5000.0));
+        ParcialesCalculator.Resultado r = ParcialesCalculator.calcular(items, 0.0);
+        assertEquals(15000.0, r.getTotalParcial0(), DELTA);
+        assertEquals(0.0, r.getTotalParcial5(), DELTA);
+        assertEquals(0.0, r.getTotalParcial10(), DELTA);
+        assertEquals(15000.0, r.getTotalFinal(), DELTA);
+    }
+
+    @Test
+    void sinItems_parcialesCero() {
+        ParcialesCalculator.Resultado r = ParcialesCalculator.calcular(Collections.emptyList(), 0.0);
+        assertEquals(0.0, r.getTotalFinal(), DELTA);
+    }
+
+    @Test
+    void descuentoNegativo_aumentaProporcional() {
+        // ajusteNeto < 0 = aumento (recargo). Ej. recargo 10% sobre 10000 → +1000
+        List<ParcialesCalculator.ItemIvaTuple> items = Collections.singletonList(
+                new ParcialesCalculator.ItemIvaTuple(10, 11000.0));
+        ParcialesCalculator.Resultado r = ParcialesCalculator.calcular(items, -1100.0);
+        // 11000 * 1.1 = 12100
+        assertEquals(12100.0, r.getTotalParcial10(), DELTA);
+        assertEquals(12100.0 / 11.0, r.getIvaParcial10(), DELTA);
+        assertEquals(12100.0, r.getTotalFinal(), DELTA);
+    }
+
+    @Test
+    void descuentoMayorQueBruto_noNegativos() {
+        List<ParcialesCalculator.ItemIvaTuple> items = Collections.singletonList(
+                new ParcialesCalculator.ItemIvaTuple(10, 11000.0));
+        ParcialesCalculator.Resultado r = ParcialesCalculator.calcular(items, 99999.0);
+        assertTrue(r.getTotalParcial10() >= 0.0);
+        assertTrue(r.getTotalFinal() >= 0.0);
+    }
+}


### PR DESCRIPTION
## Summary

Copia los helpers `IvaResolver` y `ParcialesCalculator` desde filial. Reemplaza el calculo manual de parciales en `FacturaLegalFilialService` (que tenia el bug de descuento no distribuido) y fix del print 58mm Gs para que lea los parciales persistidos.

## Cambios

### Nuevas clases (`com.franco.dev.service.financiero.builder`)

| Clase | Notas |
|---|---|
| `IvaResolver` | Copia de filial. Politica unica de resolucion iva |
| `ParcialesCalculator` | Copia de filial. Distribuye descuento proporcional |

### Bugs corregidos

- `FacturaLegalFilialService.mapearRequest` (saveFacturaLegalToFilial proxy central → filial): el codigo viejo restaba descuento del `total_final` sin distribuirlo a parciales. Resultado: `sum(parciales) > total_final` en el payload REST → filial recibia inconsistencia. Ahora usa `ParcialesCalculator.calcular()`.
- `FacturaLegalGraphQL.printTicket58mmFactura` (ticket Gs HQ): bloque "Liquidacion IVA" recalculaba iva desde items + descuento extra, mientras que ticket moneda extranjera y PDF KUDE leen los parciales persistidos. Inconsistencia entre los 3 outputs. Ahora ticket Gs tambien lee `fl.getIvaParcial10()`/`fl.getIvaParcial5()`.

### Tests (17 copiados de filial, todos pasando)

- `IvaResolverTest` (9)
- `ParcialesCalculatorTest` (8)

## Out of scope

`FacturaLegalBuilder` centralizado en central. La mutation `saveFacturaLegal` HQ sigue con su flow propio. `saveFacturaLegalToFilial` es solo proxy a filial donde el builder ya esta. Si el bug aparece en HQ, proximo PR.

## Relacionado

- PR filial: https://github.com/GabFrank/franco-system-backend-filial/pull/47

## Test plan

- [ ] `./mvnw compile -Dflyway.skip=true` OK
- [ ] `./mvnw test -Dtest='com.franco.dev.service.financiero.builder.*Test'` OK (17 tests)
- [ ] Deploy alpha central (manual via workflow Deploy)
- [ ] Verificar saveFacturaLegalToFilial: emitir factura desde frontend que dispare flow central → filial. El payload REST debe tener sum(parciales) = total_final.
- [ ] Imprimir ticket 58mm Gs de una factura con descuento: liquidacion IVA debe coincidir con PDF KUDE