### PR TITLE
feat(productos): mejora accesiblidad ui y seguridad

### DIFF
--- a/src/main/java/com/franco/dev/graphql/productos/ProductoGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/productos/ProductoGraphQL.java
@@ -220,9 +220,22 @@ public class ProductoGraphQL implements GraphQLQueryResolver, GraphQLMutationRes
             Long sucursalId,
             Long usuarioId,
             String usuario) throws FileNotFoundException {
+
+        boolean puedeVerStockCompras = usuarioService.tieneRol(usuarioId, "VER STOCK COMPRAS", "ADMIN");
+
+        if (sucursalId != null) {
+            Sucursal sucursal = sucursalService.findById(sucursalId).orElse(null);
+            if (sucursal != null && "COMPRAS".equalsIgnoreCase(sucursal.getNombre())) {
+                if (!puedeVerStockCompras) {
+                    sucursalId = null;
+                }
+            }
+        }
+
         return service.exportarReporteConFiltros(
                 texto, codigo, activo, stock, balanza, vencimiento,
-                costoCero, subfamiliaId, familiaId, stockFiltro, sucursalId, usuarioId, usuario);
+                costoCero, subfamiliaId, familiaId, stockFiltro, sucursalId, usuarioId, usuario,
+                puedeVerStockCompras);
     }
 
     public List<Producto> findByPdvGrupoProducto(Long id) {

--- a/src/main/java/com/franco/dev/service/operaciones/MovimientoStockService.java
+++ b/src/main/java/com/franco/dev/service/operaciones/MovimientoStockService.java
@@ -57,6 +57,19 @@ public class MovimientoStockService extends CrudService<MovimientoStock, Movimie
         return finalStock;
     }
 
+    public Double stockByProductoIdExcluyendoNombresSucursal(Long proId, List<String> nombresExcluidos) {
+        Double finalStock = 0.0;
+        List<Sucursal> sucursalList = sucursalService.findAll2();
+        for (Sucursal s : sucursalList) {
+            if (nombresExcluidos != null && nombresExcluidos.stream()
+                    .anyMatch(nombre -> nombre.equalsIgnoreCase(s.getNombre()))) {
+                continue;
+            }
+            finalStock += stockByProductoIdAndSucursalId(proId, s.getId());
+        }
+        return finalStock;
+    }
+
     public Double stockByProductoIdExecptMovStockId(Long proId, Long movId, Long sucId) {
         Float stock = repository.stockByProductoIdExeptMovimientoId(proId, movId, sucId);
         return Double.valueOf(stock != null ? stock : 0);

--- a/src/main/java/com/franco/dev/service/personas/UsuarioService.java
+++ b/src/main/java/com/franco/dev/service/personas/UsuarioService.java
@@ -87,13 +87,22 @@ public class UsuarioService extends CrudService<Usuario, UsuarioRepository, Long
         List<Role> roleList = new ArrayList<Role>();
         if (!usuarioRoleList.isEmpty()) {
             usuarioRoleList.forEach(usuarioRole -> {
-                Role role = roleService.findById(usuarioRole.getUser().getId()).orElse(null);
+                Role role = usuarioRole.getRole();
                 if (role != null) {
                     roleList.add(role);
                 }
             });
         }
         return roleList;
+    }
+
+    public boolean tieneRol(Long usuarioId, String... nombresRol) {
+        if (usuarioId == null || nombresRol == null || nombresRol.length == 0) return false;
+        List<Role> roles = getRoles(usuarioId);
+        return roles.stream().anyMatch(r ->
+            java.util.Arrays.stream(nombresRol)
+                .anyMatch(nombre -> nombre.equalsIgnoreCase(r.getNombre()))
+        );
     }
 
     public Usuario findByEmail(String email) {

--- a/src/main/java/com/franco/dev/service/productos/ProductoService.java
+++ b/src/main/java/com/franco/dev/service/productos/ProductoService.java
@@ -450,7 +450,8 @@ public class ProductoService extends CrudService<Producto, ProductoRepository, L
             String stockFiltro,
             Long sucursalId,
             Long usuarioId,
-            String usuario) throws FileNotFoundException {
+            String usuario,
+            boolean puedeVerStockCompras) throws FileNotFoundException {
 
         Page<Producto> productoPage = findWithFilters(
                 texto,
@@ -521,38 +522,39 @@ public class ProductoService extends CrudService<Producto, ProductoRepository, L
 
         // Filtro de Stock (columna 4 del template - separado)
         StringBuilder filtroStock = new StringBuilder();
-        if (stockFiltro != null && !stockFiltro.equals("todos")) {
-            filtroStock.append("STOCK: ").append(stockFiltro.toUpperCase());
-            if (sucursalId != null) {
-                try {
-                    Sucursal sucursal = sucursalService.findById(sucursalId).orElse(null);
-                    if (sucursal != null) {
-                        // Mostrar nombre completo de sucursal, truncar solo si es muy largo
-                        String nombreSucursal = sucursal.getNombre().length() > 35
-                                ? sucursal.getNombre().substring(0, 32) + "..."
-                                : sucursal.getNombre();
-                        filtroStock.append(" (").append(nombreSucursal.toUpperCase()).append(")");
-                    } else {
-                        filtroStock.append(" (ID: ").append(sucursalId).append(")");
-                    }
-                } catch (Exception e) {
-                    filtroStock.append(" (ID: ").append(sucursalId).append(")");
+        String stockFiltroLabel = (stockFiltro != null && !stockFiltro.equals("todos"))
+                ? stockFiltro.toUpperCase() : "TODOS";
+        filtroStock.append("STOCK: ").append(stockFiltroLabel);
+        if (sucursalId != null) {
+            try {
+                Sucursal sucursal = sucursalService.findById(sucursalId).orElse(null);
+                if (sucursal != null) {
+                    String nombreSucursal = sucursal.getNombre().length() > 35
+                            ? sucursal.getNombre().substring(0, 32) + "..."
+                            : sucursal.getNombre();
+                    filtroStock.append(" | SUCURSAL: ").append(nombreSucursal.toUpperCase());
+                } else {
+                    filtroStock.append(" | SUCURSAL ID: ").append(sucursalId);
                 }
+            } catch (Exception e) {
+                filtroStock.append(" | SUCURSAL ID: ").append(sucursalId);
             }
-        } else {
-            filtroStock.append("STOCK: TODOS");
         }
 
         // Crear la lista de DTOs para el reporte
         List<ProductoReportDto> productosDtoList = new ArrayList<>();
 
         for (Producto p : productoList) {
-            // Obtener stock real - usar stock por sucursal si se filtró por sucursal
-            // específica
+            // Obtener stock real
             Double stockCantidad;
-            if (sucursalId != null && (stockFiltro != null && !stockFiltro.equals("todos"))) {
-                // Si hay filtro de sucursal y stock específico, usar stock de esa sucursal
+            if (sucursalId != null) {
+                // Hay sucursal seleccionada: mostrar solo esa sucursal
                 stockCantidad = movimientoStockService.stockByProductoIdAndSucursalId(p.getId(), sucursalId);
+            } else if (!puedeVerStockCompras) {
+                // Sin permiso de ver COMPRAS: excluir esa sucursal del total para
+                // evitar que pueda deducir el stock de COMPRAS por diferencia matemática
+                stockCantidad = movimientoStockService.stockByProductoIdExcluyendoNombresSucursal(
+                        p.getId(), java.util.Arrays.asList("COMPRAS"));
             } else {
                 // Usar stock total (todas las sucursales)
                 stockCantidad = movimientoStockService.stockByProductoId(p.getId());


### PR DESCRIPTION
## Que resuelve

Este cambio implementa una mejora de accesibilidad y usabilidad en la interfaz de listado de productos, y resuelve una brecha de seguridad relacionada con la visibilidad del stock de la sucursal de compras (COMPRAS) para usuarios sin los permisos adecuados.

### Correcciones y Seguridad (Backend)
* Se soluciono un error heredado en UsuarioService.getRoles() donde se utilizaba incorrectamente el ID de usuario en lugar del ID de rol para resolver la entidad.
* Se agrego el metodo tieneRol() en el backend para una verificacion de permisos centralizada.
* Se implemento un control en el resolver de GraphQL para que, si un usuario sin permisos intenta inyectar el ID de la sucursal COMPRAS, el backend lo ignore silenciosamente.
* Se evito el calculo indirecto del stock de COMPRAS. Anteriormente, si un usuario sin permisos generaba el reporte general de todas las sucursales, la sumatoria total del stock incluia la sucursal de compras. Ahora, si el usuario no tiene los roles ADMIN o VER STOCK COMPRAS, el reporte general se genera excluyendo de manera transparente el stock de COMPRAS en el calculo de las columnas de cantidad total.

---

## Como probarlo

### Requisitos previos
Tener dos usuarios de prueba:
1. Usuario A: Posee el rol ADMIN o VER STOCK COMPRAS.
2. Usuario B: Un usuario con permisos basicos (sin los roles mencionados).

### Prueba 1: Visualizacion y filtros de sucursal
1. Iniciar sesion con el Usuario B.
2. Ir a la lista de productos. El campo Sucursal debe estar siempre visible, sin importar que el campo Stock figure en Todos.
3. Desplegar el selector de Sucursal y verificar que la sucursal COMPRAS no este disponible en el listado.
4. Seleccionar una sucursal visible (ej. Sucursal Central con ID 1) y filtrar. Deberia mostrar el stock tanto positivo como negativo solo para esa sucursal en el panel expandido del producto.

### Prueba 2: Generacion de Reportes y exclusion de stock
1. Con el Usuario B, realizar una busqueda general y hacer clic en Generar Pdf.
2. Comprobar el PDF generado: las cantidades de stock del listado y el stock total consolidado no deben sumar los movimientos ni el stock de la sucursal COMPRAS.
3. Repetir el proceso con el Usuario A. Verificar que este usuario si puede ver la sucursal COMPRAS en el desplegable de filtros y que, al generar el reporte general, las cantidades consolidadas si sumen la sucursal COMPRAS.

---

## Impacto DB
No aplica. No se modifico la estructura de la base de datos, solo se realizaron ajustes en las consultas logicamente controladas a nivel de servicio.

---

## Riesgo
Bajo. Las modificaciones estan acotadas a la consulta de busqueda filtrada de productos y al metodo de exportacion de reportes de stock. La correccion del metodo getRoles() reactiva la consulta correcta de roles asociados a los usuarios, la cual fallaba previamente.
