### PR TITLE
feat(productos): restringir costo en lista de productos

### DIFF
--- a/src/main/java/com/franco/dev/graphql/productos/ProductoGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/productos/ProductoGraphQL.java
@@ -222,7 +222,8 @@ public class ProductoGraphQL implements GraphQLQueryResolver, GraphQLMutationRes
             String usuario) throws FileNotFoundException {
 
         boolean puedeVerStockCompras = usuarioService.tieneRol(usuarioId, "VER STOCK COMPRAS", "ADMIN");
-
+        boolean puedeVerCostos = usuarioService.tieneRol(usuarioId, "EDITAR PRODUCTOS", "ADMIN");
+ 
         if (sucursalId != null) {
             Sucursal sucursal = sucursalService.findById(sucursalId).orElse(null);
             if (sucursal != null && "COMPRAS".equalsIgnoreCase(sucursal.getNombre())) {
@@ -231,11 +232,11 @@ public class ProductoGraphQL implements GraphQLQueryResolver, GraphQLMutationRes
                 }
             }
         }
-
+ 
         return service.exportarReporteConFiltros(
                 texto, codigo, activo, stock, balanza, vencimiento,
                 costoCero, subfamiliaId, familiaId, stockFiltro, sucursalId, usuarioId, usuario,
-                puedeVerStockCompras);
+                puedeVerStockCompras, puedeVerCostos);
     }
 
     public List<Producto> findByPdvGrupoProducto(Long id) {

--- a/src/main/java/com/franco/dev/service/productos/ProductoService.java
+++ b/src/main/java/com/franco/dev/service/productos/ProductoService.java
@@ -451,7 +451,8 @@ public class ProductoService extends CrudService<Producto, ProductoRepository, L
             Long sucursalId,
             Long usuarioId,
             String usuario,
-            boolean puedeVerStockCompras) throws FileNotFoundException {
+            boolean puedeVerStockCompras,
+            boolean puedeVerCostos) throws FileNotFoundException {
 
         Page<Producto> productoPage = findWithFilters(
                 texto,
@@ -638,6 +639,7 @@ public class ProductoService extends CrudService<Producto, ProductoRepository, L
 
             // Total de productos encontrados
             parameters.put("totalProductos", productosDtoList.size());
+            parameters.put("puedeVerCostos", puedeVerCostos);
 
             JasperPrint jasperPrint = JasperFillManager.fillReport(jasperReport, parameters, dataSource);
             byte[] pdfBytes = JasperExportManager.exportReportToPdf(jasperPrint);

--- a/src/main/resources/reports/productos.jrxml
+++ b/src/main/resources/reports/productos.jrxml
@@ -15,6 +15,7 @@
 	<parameter name="filtroFamilia" class="java.lang.String"/>
 	<parameter name="filtroStock" class="java.lang.String"/>
 	<parameter name="totalProductos" class="java.lang.Integer"/>
+	<parameter name="puedeVerCostos" class="java.lang.Boolean"/>
 	<field name="id" class="java.lang.Long"/>
 	<field name="descripcion" class="java.lang.String"/>
 	<field name="cantidad" class="java.lang.Double"/>
@@ -149,14 +150,14 @@
 				</textElement>
 				<text><![CDATA[COSTO TOTAL:]]></text>
 			</staticText>
-			<textField evaluationTime="Report" pattern="#,##0">
+			<textField evaluationTime="Report">
 				<reportElement x="500" y="90" width="50" height="14" uuid="a1b2c3d4-e5f6-7890-1234-567890abcdef">
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 				</reportElement>
 				<textElement textAlignment="Right" verticalAlignment="Top">
 					<font fontName="SansSerif" size="8" isBold="true"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$V{costoTotalGeneral}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{puedeVerCostos} ? ( $V{costoTotalGeneral} != null ? new java.text.DecimalFormat("#,##0").format($V{costoTotalGeneral}) : "0" ) : "-"]]></textFieldExpression>
 			</textField>
 		</band>
 	</title>
@@ -246,19 +247,19 @@
 				</textElement>
 				<textFieldExpression><![CDATA[$F{codigoPrincipal}]]></textFieldExpression>
 			</textField>
-			<textField pattern="#,##0">
+			<textField>
 				<reportElement x="335" y="1" width="65" height="15" uuid="8fb71000-51f6-46e1-bb3f-48fa3024a081"/>
 				<textElement textAlignment="Center">
 					<font fontName="SansSerif" size="9"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$F{precioCosto}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{puedeVerCostos} ? ( $F{precioCosto} != null ? new java.text.DecimalFormat("#,##0").format($F{precioCosto}) : "0" ) : "-"]]></textFieldExpression>
 			</textField>
-			<textField pattern="#,##0">
+			<textField>
 				<reportElement x="405" y="1" width="75" height="15" uuid="8fb81000-51f6-46e1-bb3f-48fa3024a082"/>
 				<textElement textAlignment="Center">
 					<font fontName="SansSerif" size="9"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$F{precioCosto} * $F{cantidad}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{puedeVerCostos} ? ( ($F{precioCosto} != null && $F{cantidad} != null) ? new java.text.DecimalFormat("#,##0").format($F{precioCosto} * $F{cantidad}) : "0" ) : "-"]]></textFieldExpression>
 			</textField>
 			<textField pattern="#,##0">
 				<reportElement x="485" y="1" width="65" height="15" uuid="16091ed4-b9c8-4869-94d0-c0732c680193"/>


### PR DESCRIPTION
### Qué resuelve
Restringe la visualización de la información de costos en el listado de productos (específicamente las columnas de "Costo medio" y "Ult. costo"). A partir de esta modificación, solo los usuarios que posean los roles `ADMIN` o `EDITAR_PRODUCTOS podrán ver los valores numéricos correspondientes. Los usuarios que no cuenten con estos roles verán un guion (-) en su lugar.

### Cómo probarlo

1. Inicie sesión en la aplicación con un usuario que no tenga asignados los roles `ADMIN` ni `EDITAR_PRODUCTOS`.
2. Diríjase a la sección del listado de productos y compruebe que en las columnas "Costo medio" y "Ult. costo" se muestra un guion (-) en lugar del valor numérico del costo.
3. Cierre sesión e ingrese con un usuario que sí cuente con el rol `ADMIN` o `EDITAR_PRODUCTOS`.
4. Vuelva al listado de productos y verifique que ahora sí se visualizan correctamente los valores de costo medio y último costo de compra.

### Impacto DB
No aplica. Es una modificación exclusiva de presentación en el frontend que reutiliza la lógica y los roles de usuario existentes.

### Riesgo
Bajo. El cambio está limitado únicamente a la lógica de visualización condicional dentro del componente de la tabla de productos en Angular.