### PR TITLE
feat(pre-gasto): validar y vincular ente segun modulo padre del tipo de gasto

### DIFF
--- a/src/main/java/com/franco/dev/graphql/financiero/PreGastoGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/PreGastoGraphQL.java
@@ -5,6 +5,9 @@ import com.franco.dev.domain.financiero.enums.EstadoPreGasto;
 import com.franco.dev.graphql.financiero.input.PreGastoInput;
 import com.franco.dev.service.empresarial.SucursalService;
 import com.franco.dev.service.financiero.MonedaService;
+import com.franco.dev.domain.activos.Ente;
+import com.franco.dev.domain.financiero.TipoGasto;
+import com.franco.dev.service.financiero.PreGastoEnteValidationService;
 import com.franco.dev.service.financiero.PreGastoService;
 import com.franco.dev.service.financiero.TipoGastoService;
 import com.franco.dev.domain.personas.Persona;
@@ -64,6 +67,9 @@ public class PreGastoGraphQL implements GraphQLQueryResolver, GraphQLMutationRes
 
     @Autowired
     private com.franco.dev.service.impresion.ImpresionService impresionService;
+
+    @Autowired
+    private PreGastoEnteValidationService preGastoEnteValidationService;
 
     public PreGasto preGasto(Long id, Long sucId) {
         return service.findByIdAndSucursalId(id, sucId);
@@ -147,9 +153,13 @@ public class PreGastoGraphQL implements GraphQLQueryResolver, GraphQLMutationRes
         if (input.getFuncionarioId() != null) {
             e.setFuncionario(personaService.findById(input.getFuncionarioId()).orElse(null));
         }
+        TipoGasto tipoGasto = null;
         if (input.getTipoGastoId() != null) {
-            e.setTipoGasto(tipoGastoService.findById(input.getTipoGastoId()).orElse(null));
+            tipoGasto = tipoGastoService.findById(input.getTipoGastoId()).orElse(null);
+            e.setTipoGasto(tipoGasto);
         }
+        Ente ente = preGastoEnteValidationService.validarYResolverEnte(tipoGasto, input.getEnteId());
+        e.setEnte(ente);
         if (input.getMonedaId() != null) {
             e.setMoneda(monedaService.findById(input.getMonedaId()).orElse(null));
         }

--- a/src/main/java/com/franco/dev/service/financiero/PreGastoEnteValidationService.java
+++ b/src/main/java/com/franco/dev/service/financiero/PreGastoEnteValidationService.java
@@ -1,0 +1,92 @@
+package com.franco.dev.service.financiero;
+
+import com.franco.dev.domain.activos.Ente;
+import com.franco.dev.domain.activos.enums.TipoEnte;
+import com.franco.dev.domain.financiero.TipoGasto;
+import com.franco.dev.domain.financiero.enums.TipoPadreGastoModulo;
+import com.franco.dev.service.activos.EnteService;
+import graphql.GraphQLException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PreGastoEnteValidationService {
+
+    private final EnteService enteService;
+
+    /**
+     * Valida y resuelve el ente según el módulo padre del tipo de gasto.
+     * Para VEHICULO, MUEBLE e INMUEBLE el ente es obligatorio y debe coincidir en tipo.
+     */
+    public Ente validarYResolverEnte(TipoGasto tipoGasto, Long enteId) {
+        if (tipoGasto == null) {
+            if (enteId != null) {
+                throw new GraphQLException("No se puede vincular un activo sin un tipo de gasto válido.");
+            }
+            return null;
+        }
+
+        TipoPadreGastoModulo modulo = tipoGasto.getModuloPadre();
+        TipoEnte tipoEnteRequerido = tipoEnteEsperado(modulo);
+
+        if (tipoEnteRequerido == null) {
+            if (enteId != null) {
+                throw new GraphQLException(
+                        "El tipo de gasto \"" + tipoGasto.getDescripcion()
+                                + "\" no admite vinculación a un activo (inmueble, vehículo o mueble).");
+            }
+            return null;
+        }
+
+        if (enteId == null) {
+            throw new GraphQLException(
+                    "Debe seleccionar " + etiquetaActivo(tipoEnteRequerido)
+                            + " para el tipo de gasto \"" + tipoGasto.getDescripcion() + "\".");
+        }
+
+        Ente ente = enteService.findById(enteId)
+                .orElseThrow(() -> new GraphQLException("El activo seleccionado no existe."));
+
+        if (Boolean.FALSE.equals(ente.getActivo())) {
+            throw new GraphQLException("El activo seleccionado no está activo.");
+        }
+
+        if (ente.getTipoEnte() != tipoEnteRequerido) {
+            throw new GraphQLException(
+                    "El activo seleccionado no corresponde al módulo del tipo de gasto. Se esperaba "
+                            + etiquetaActivo(tipoEnteRequerido) + ".");
+        }
+
+        return ente;
+    }
+
+    private TipoEnte tipoEnteEsperado(TipoPadreGastoModulo modulo) {
+        if (modulo == null) {
+            return null;
+        }
+        switch (modulo) {
+            case VEHICULO:
+                return TipoEnte.VEHICULO;
+            case MUEBLE:
+                return TipoEnte.MUEBLE;
+            case INMUEBLE:
+                return TipoEnte.INMUEBLE;
+            default:
+                return null;
+        }
+    }
+
+    private String etiquetaActivo(TipoEnte tipo) {
+        switch (tipo) {
+            case VEHICULO:
+                return "un vehículo";
+            case MUEBLE:
+                return "un mueble";
+            case INMUEBLE:
+                return "un inmueble";
+            default:
+                return "un activo";
+        }
+    }
+}

--- a/src/main/resources/db/migration/V129.3__pre_gasto_ente_fk.sql
+++ b/src/main/resources/db/migration/V129.3__pre_gasto_ente_fk.sql
@@ -1,0 +1,24 @@
+-- Integridad referencial: pre_gasto.ente_id -> activos.ente(id)
+
+UPDATE financiero.pre_gasto pg
+SET ente_id = NULL
+WHERE ente_id IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM activos.ente e WHERE e.id = pg.ente_id
+  );
+
+CREATE INDEX IF NOT EXISTS idx_pre_gasto_ente_id
+    ON financiero.pre_gasto USING btree (ente_id);
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'pre_gasto_ente_id_fkey'
+    ) THEN
+        ALTER TABLE financiero.pre_gasto
+            ADD CONSTRAINT pre_gasto_ente_id_fkey
+            FOREIGN KEY (ente_id) REFERENCES activos.ente (id);
+    END IF;
+END$$;


### PR DESCRIPTION
## Summary
- Valida que el ente sea obligatorio y coherente cuando el tipo de gasto tiene modulo padre VEHICULO, MUEBLE o INMUEBLE.
- Vincula el ente al guardar pre-gasto desde GraphQL.
- Agrega FK e indice de integridad referencial en `pre_gasto.ente_id`.

## Test plan
- [ ] Guardar pre-gasto con tipo sin modulo padre activo (sin enteId).
- [ ] Rechazar pre-gasto con tipo de modulo padre activo sin enteId.
- [ ] Rechazar enteId de tipo incorrecto para el modulo padre.
- [ ] Guardar pre-gasto valido con enteId correcto.
- [ ] Verificar migracion V129.3 en base local.


Made with [Cursor](https://cursor.com)