### PR TITLE
feat(transferencias): add configuracion de transferencia stock negativo

### DIFF
--- a/src/main/java/com/franco/dev/domain/operaciones/ConfiguracionTransferencia.java
+++ b/src/main/java/com/franco/dev/domain/operaciones/ConfiguracionTransferencia.java
@@ -1,0 +1,37 @@
+package com.franco.dev.domain.operaciones;
+
+import com.franco.dev.config.Identifiable;
+import com.franco.dev.domain.personas.Usuario;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "configuracion_transferencia", schema = "operaciones")
+public class ConfiguracionTransferencia implements Identifiable<Long> {
+
+    @Id
+    @GenericGenerator(name = "assigned-identity", strategy = "com.franco.dev.config.AssignedIdentityGenerator")
+    @GeneratedValue(generator = "assigned-identity", strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "permitir_stock_negativo", nullable = false)
+    private Boolean permitirStockNegativo = false;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "usuario_id", nullable = true)
+    private Usuario usuario;
+
+    @Column(name = "creado_en")
+    private LocalDateTime creadoEn;
+
+    @Column(name = "modificado_en")
+    private LocalDateTime modificadoEn;
+}

--- a/src/main/java/com/franco/dev/graphql/operaciones/ConfiguracionTransferenciaGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/ConfiguracionTransferenciaGraphQL.java
@@ -1,0 +1,36 @@
+package com.franco.dev.graphql.operaciones;
+
+import com.franco.dev.domain.operaciones.ConfiguracionTransferencia;
+import com.franco.dev.graphql.operaciones.input.ConfiguracionTransferenciaInput;
+import com.franco.dev.service.operaciones.ConfiguracionTransferenciaService;
+import com.franco.dev.service.personas.UsuarioService;
+import graphql.kickstart.tools.GraphQLMutationResolver;
+import graphql.kickstart.tools.GraphQLQueryResolver;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+@AllArgsConstructor
+public class ConfiguracionTransferenciaGraphQL implements GraphQLQueryResolver, GraphQLMutationResolver {
+
+    private final ConfiguracionTransferenciaService service;
+    private final UsuarioService usuarioService;
+
+    public ConfiguracionTransferencia configuracionTransferencia() {
+        return service.findOrCreate();
+    }
+
+    public ConfiguracionTransferencia saveConfiguracionTransferencia(ConfiguracionTransferenciaInput input) {
+        ConfiguracionTransferencia config = service.findOrCreate();
+        if (input.getPermitirStockNegativo() != null) {
+            config.setPermitirStockNegativo(input.getPermitirStockNegativo());
+        }
+        if (input.getUsuarioId() != null) {
+            config.setUsuario(usuarioService.findById(input.getUsuarioId()).orElse(null));
+        }
+        config.setModificadoEn(LocalDateTime.now());
+        return service.save(config);
+    }
+}

--- a/src/main/java/com/franco/dev/graphql/operaciones/input/ConfiguracionTransferenciaInput.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/input/ConfiguracionTransferenciaInput.java
@@ -1,0 +1,10 @@
+package com.franco.dev.graphql.operaciones.input;
+
+import lombok.Data;
+
+@Data
+public class ConfiguracionTransferenciaInput {
+    private Long id;
+    private Boolean permitirStockNegativo;
+    private Long usuarioId;
+}

--- a/src/main/java/com/franco/dev/repository/operaciones/ConfiguracionTransferenciaRepository.java
+++ b/src/main/java/com/franco/dev/repository/operaciones/ConfiguracionTransferenciaRepository.java
@@ -1,0 +1,13 @@
+package com.franco.dev.repository.operaciones;
+
+import com.franco.dev.domain.operaciones.ConfiguracionTransferencia;
+import com.franco.dev.repository.HelperRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ConfiguracionTransferenciaRepository extends HelperRepository<ConfiguracionTransferencia, Long> {
+
+    default Class<ConfiguracionTransferencia> getEntityClass() {
+        return ConfiguracionTransferencia.class;
+    }
+}

--- a/src/main/java/com/franco/dev/service/operaciones/ConfiguracionTransferenciaService.java
+++ b/src/main/java/com/franco/dev/service/operaciones/ConfiguracionTransferenciaService.java
@@ -1,0 +1,37 @@
+package com.franco.dev.service.operaciones;
+
+import com.franco.dev.domain.operaciones.ConfiguracionTransferencia;
+import com.franco.dev.repository.operaciones.ConfiguracionTransferenciaRepository;
+import com.franco.dev.service.CrudService;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@AllArgsConstructor
+public class ConfiguracionTransferenciaService extends CrudService<ConfiguracionTransferencia, ConfiguracionTransferenciaRepository, Long> {
+
+    private final ConfiguracionTransferenciaRepository repository;
+
+    @Override
+    public ConfiguracionTransferenciaRepository getRepository() {
+        return repository;
+    }
+
+    /**
+     * Devuelve el registro único de configuración. Si no existe, lo crea con valores por defecto.
+     */
+    public ConfiguracionTransferencia findOrCreate() {
+        List<ConfiguracionTransferencia> list = repository.findAllByOrderByIdAsc();
+        if (!list.isEmpty()) {
+            return list.get(0);
+        }
+        ConfiguracionTransferencia config = new ConfiguracionTransferencia();
+        config.setPermitirStockNegativo(false);
+        config.setCreadoEn(LocalDateTime.now());
+        config.setModificadoEn(LocalDateTime.now());
+        return repository.save(config);
+    }
+}

--- a/src/main/resources/db/migration/V129.1__add_configuracion_transferencia_table.sql
+++ b/src/main/resources/db/migration/V129.1__add_configuracion_transferencia_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS operaciones.configuracion_transferencia (
+    id BIGSERIAL PRIMARY KEY,
+    permitir_stock_negativo BOOLEAN NOT NULL DEFAULT FALSE,
+    usuario_id BIGINT,
+    creado_en TIMESTAMP DEFAULT NOW(),
+    modificado_en TIMESTAMP DEFAULT NOW(),
+    CONSTRAINT fk_configuracion_transferencia_usuario FOREIGN KEY (usuario_id) REFERENCES personas.usuario(id)
+);
+
+INSERT INTO operaciones.configuracion_transferencia (permitir_stock_negativo, creado_en, modificado_en)
+SELECT FALSE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM operaciones.configuracion_transferencia);

--- a/src/main/resources/graphql/operaciones/configuracion-transferencia.graphqls
+++ b/src/main/resources/graphql/operaciones/configuracion-transferencia.graphqls
@@ -1,0 +1,21 @@
+type ConfiguracionTransferencia {
+    id: ID!
+    permitirStockNegativo: Boolean!
+    usuario: Usuario
+    creadoEn: Date
+    modificadoEn: Date
+}
+
+input ConfiguracionTransferenciaInput {
+    id: ID
+    permitirStockNegativo: Boolean
+    usuarioId: ID
+}
+
+extend type Query {
+    configuracionTransferencia: ConfiguracionTransferencia!
+}
+
+extend type Mutation {
+    saveConfiguracionTransferencia(input: ConfiguracionTransferenciaInput!): ConfiguracionTransferencia!
+}


### PR DESCRIPTION
## Qué resuelve
Este PR migra la configuración de la restricción de stock negativo en las transferencias de un estado local a uno global y persistente. 

Anteriormente, el sistema bloqueaba por defecto el ingreso de productos con stock negativo o dependía de configuraciones locales. Con este desarrollo, se ha introducido una tabla en la base de datos para manejar esta restricción como una configuración global de la aplicación. Desde el frontend, los usuarios con permisos de administrador pueden activar o desactivar esta restricción mediante un nuevo diálogo de configuración accesible desde el panel de transferencias. Además, se guarda un registro del `usuario_id` correspondiente a la persona que realizó la última modificación en la configuración.

## Cómo probarlo
1. Ingresar a la aplicación con un usuario que posea el rol de Administrador.
2. Navegar hacia el módulo de Transferencias.
3. Hacer clic en el botón "Configurar Transferencias".
4. En el diálogo que aparece, alternar el estado de "Permitir transferencias con stock negativo" y guardar.
5. Iniciar la creación o edición de una transferencia.
6. Intentar agregar un ítem a la transferencia cuyo producto posea actualmente un stock negativo en la sucursal de origen.
7. Verificar que el sistema permite o bloquea el registro del producto respetando estrictamente el valor configurado en el paso 4.
8. (Opcional) Consultar la tabla `operaciones.configuracion_transferencia` en la base de datos para verificar que el campo `usuario_id` fue actualizado con el ID del usuario que realizó la acción.

## Impacto DB
Aplica. 

Se introduce el script de migración Flyway correspondiente (`V129.1`) que realiza lo siguiente:
- Crea la tabla `operaciones.configuracion_transferencia` con los campos `id`, `permitir_stock_negativo`, `usuario_id`, `creado_en` y `modificado_en`.
- Establece una Foreign Key (`fk_configuracion_transferencia_usuario`) que referencia a `personas.usuario(id)`.
- Ejecuta una sentencia `INSERT` inicial para crear un registro único (Singleton) con valores por defecto y evitar nulos al arrancar el sistema.

## Riesgo
Bajo. 

La tabla, la entidad JPA, los servicios y los esquemas GraphQL creados son totalmente nuevos e independientes, por lo cual no modifican la estructura de los datos actuales. En cuanto al frontend, la intervención en el flujo principal (`edit-transferencia`) consiste únicamente en una consulta preventiva (vía HTTP/GraphQL) antes del guardado del ítem, la cual además cuenta con una regla de seguridad (fail-safe) que bloquea la transferencia del producto si la consulta a la configuración llegase a fallar.
