### PR TITLE
feat(venta): reporte de lucro por funcionario

### DIFF
--- a/src/main/java/com/franco/dev/domain/operaciones/dto/LucroPorFuncionarioDto.java
+++ b/src/main/java/com/franco/dev/domain/operaciones/dto/LucroPorFuncionarioDto.java
@@ -1,0 +1,50 @@
+package com.franco.dev.domain.operaciones.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class LucroPorFuncionarioDto {
+    private Long usuarioId;
+    private String nombreFuncionario;
+    private Double costoTotal;
+    private Double cantidad;
+    private Double totalVenta;
+    private Double lucro;
+    private Double percent;
+    private Double ventaMedia;
+    private Double margen;
+    private Double costoUnitario;
+    private Double totalDescuento;
+    private Double totalAumento;
+
+    public LucroPorFuncionarioDto(
+            Long usuarioId, String nombreFuncionario, Double costoTotal, Double cantidad,
+            Double totalVenta, Double lucro, Double percent, Double ventaMedia, Double margen,
+            Double totalDescuento, Double totalAumento) {
+        this.usuarioId = usuarioId;
+        this.nombreFuncionario = nombreFuncionario;
+        this.costoTotal = costoTotal;
+        this.cantidad = cantidad;
+        this.totalVenta = totalVenta;
+        this.lucro = lucro;
+        this.percent = percent;
+        this.ventaMedia = ventaMedia;
+        this.margen = margen;
+        this.costoUnitario = null;
+        this.totalDescuento = totalDescuento;
+        this.totalAumento = totalAumento;
+    }
+
+    public void aggregate(LucroPorFuncionarioDto other) {
+        this.cantidad += other.cantidad;
+        this.totalVenta += other.totalVenta;
+        this.costoTotal += other.costoTotal;
+        this.lucro += other.lucro;
+        this.totalDescuento += other.totalDescuento != null ? other.totalDescuento : 0.0;
+        this.totalAumento += other.totalAumento != null ? other.totalAumento : 0.0;
+    }
+}

--- a/src/main/java/com/franco/dev/graphql/operaciones/VentaGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/VentaGraphQL.java
@@ -13,12 +13,17 @@ import com.franco.dev.domain.operaciones.VentaItem;
 
 import com.franco.dev.domain.operaciones.VentaPorFuncionario;
 import com.franco.dev.domain.operaciones.VentaPorSucursal;
+import com.franco.dev.domain.operaciones.dto.LucroPorFuncionarioDto;
 import com.franco.dev.domain.operaciones.dto.VentaPorPeriodoV1Dto;
 import com.franco.dev.domain.operaciones.enums.VentaEstado;
 import com.franco.dev.domain.personas.Cliente;
 import com.franco.dev.domain.personas.Usuario;
+import com.franco.dev.domain.productos.Familia;
+import com.franco.dev.domain.productos.Subfamilia;
 import com.franco.dev.graphql.financiero.FacturaLegalGraphQL;
 import com.franco.dev.graphql.financiero.VentaCreditoGraphQL;
+import com.franco.dev.graphql.operaciones.input.LucroPorFuncionarioResponse;
+import com.franco.dev.graphql.operaciones.input.LucroPorFuncionarioSummary;
 import com.franco.dev.graphql.operaciones.input.CobroDetalleInput;
 import com.franco.dev.graphql.operaciones.input.CobroInput;
 import com.franco.dev.graphql.operaciones.input.VentaInput;
@@ -40,7 +45,9 @@ import com.franco.dev.service.operaciones.CobroDetalleService;
 import com.franco.dev.service.personas.ClienteService;
 import com.franco.dev.service.personas.UsuarioService;
 import com.franco.dev.service.productos.CostosPorProductoService;
+import com.franco.dev.service.productos.FamiliaService;
 import com.franco.dev.service.productos.ProductoService;
+import com.franco.dev.service.productos.SubFamiliaService;
 import com.franco.dev.service.reports.TicketReportService;
 import com.franco.dev.service.utils.ImageService;
 import com.franco.dev.service.utils.PrintingService;
@@ -127,6 +134,12 @@ public class VentaGraphQL implements GraphQLQueryResolver, GraphQLMutationResolv
 
     @Autowired
     private MonedaService monedaService;
+
+    @Autowired
+    private FamiliaService familiaService;
+
+    @Autowired
+    private SubFamiliaService subFamiliaService;
 
     private Sucursal sucursal;
 
@@ -621,5 +634,116 @@ public class VentaGraphQL implements GraphQLQueryResolver, GraphQLMutationResolv
                 totalGeneral, totalEfectivo, totalTarjeta,
                 totalConvenio, totalTransferencia, totalOtros,
                 usuario);
+    }
+
+    public String lucroPorFuncionario(String fechaInicio, String fechaFin, List<Long> sucursalIdList, Long usuarioId,
+            List<Long> usuarioIdList, List<Long> productoIdList, Long subfamiliaId, Long familiaId) {
+        Usuario usuario = usuarioService.findById(usuarioId).orElse(null);
+        StringBuilder filtro = new StringBuilder();
+        if (usuarioIdList != null && !usuarioIdList.isEmpty()) {
+            filtro.append("Funcionario: ");
+            for (int i = 0; i < usuarioIdList.size(); i++) {
+                Usuario u = usuarioService.findById(usuarioIdList.get(i)).orElse(null);
+                if (u != null) {
+                    filtro.append(u.getNickname());
+                    if (i < usuarioIdList.size() - 1) {
+                        filtro.append(", ");
+                    }
+                }
+            }
+        }
+        if (filtro.length() > 0 && sucursalIdList != null && sucursalIdList.size() > 0) {
+            filtro.append("\n");
+        }
+        if (sucursalIdList != null && sucursalIdList.size() > 0) {
+            if (sucursalIdList.size() > 1) {
+                filtro.append("Sucursales: ");
+            } else {
+                filtro.append("Sucursal: ");
+            }
+        }
+        for (Long sucId : sucursalIdList) {
+            Sucursal suc = sucursalService.findById(sucId).orElse(null);
+            if (suc != null)
+                filtro.append(suc.getNombre() + ", ");
+        }
+        if (familiaId != null) {
+            Familia familia = familiaService.findById(familiaId).orElse(null);
+            if (familia != null && familia.getNombre() != null) {
+                filtro.append("\nFamilia: " + familia.getNombre());
+            }
+        }
+        if (subfamiliaId != null) {
+            Subfamilia subfamilia = subFamiliaService.findById(subfamiliaId).orElse(null);
+            if (subfamilia != null && subfamilia.getNombre() != null) {
+                filtro.append("\nSubfamilia: " + subfamilia.getNombre());
+            }
+        }
+        List<LucroPorFuncionarioDto> lucroPorFuncionarioDtoList = service.findLucroPorFuncionarios(fechaInicio, fechaFin,
+                sucursalIdList, usuarioIdList, productoIdList, subfamiliaId, familiaId);
+        return impresionService.imprimirReporteLucroPorFuncionario(lucroPorFuncionarioDtoList, fechaInicio, fechaFin, "",
+                filtro.toString(), usuario);
+    }
+
+    public LucroPorFuncionarioResponse lucroPorFuncionarioList(
+            String fechaInicio,
+            String fechaFin,
+            List<Long> sucursalIdList,
+            List<Long> usuarioIdList,
+            List<Long> productoIdList,
+            Long subfamiliaId,
+            Integer page,
+            Integer size,
+            Long familiaId) {
+
+        List<LucroPorFuncionarioDto> fullList = service.findLucroPorFuncionarios(fechaInicio, fechaFin,
+                sucursalIdList, usuarioIdList, productoIdList, subfamiliaId, familiaId);
+
+        LucroPorFuncionarioSummary summary = new LucroPorFuncionarioSummary();
+        summary.setCantidad(0.0);
+        summary.setCostoTotal(0.0);
+        summary.setTotalVenta(0.0);
+        summary.setLucro(0.0);
+        summary.setTotalDescuento(0.0);
+        summary.setTotalAumento(0.0);
+
+        for (LucroPorFuncionarioDto dto : fullList) {
+            summary.setCantidad(summary.getCantidad() + (dto.getCantidad() != null ? dto.getCantidad() : 0));
+            summary.setCostoTotal(summary.getCostoTotal() + (dto.getCostoTotal() != null ? dto.getCostoTotal() : 0));
+            summary.setTotalVenta(summary.getTotalVenta() + (dto.getTotalVenta() != null ? dto.getTotalVenta() : 0));
+            summary.setLucro(summary.getLucro() + (dto.getLucro() != null ? dto.getLucro() : 0));
+            summary.setTotalDescuento(
+                    summary.getTotalDescuento() + (dto.getTotalDescuento() != null ? dto.getTotalDescuento() : 0));
+            summary.setTotalAumento(
+                    summary.getTotalAumento() + (dto.getTotalAumento() != null ? dto.getTotalAumento() : 0));
+        }
+
+        if (summary.getTotalVenta() > 0) {
+            summary.setMargen((summary.getLucro() / summary.getTotalVenta()) * 100);
+        } else {
+            summary.setMargen(0.0);
+        }
+
+        int start = 0;
+        int end = fullList.size();
+
+        if (page != null && size != null) {
+            start = page * size;
+            end = Math.min(start + size, fullList.size());
+        }
+
+        List<LucroPorFuncionarioDto> pagedContent;
+        if (start >= fullList.size()) {
+            pagedContent = new ArrayList<>();
+        } else {
+            pagedContent = fullList.subList(start, end);
+        }
+
+        LucroPorFuncionarioResponse response = new LucroPorFuncionarioResponse();
+        response.setContent(pagedContent);
+        response.setTotalElements((long) fullList.size());
+        response.setSummary(summary);
+
+        return response;
     }
 }

--- a/src/main/java/com/franco/dev/graphql/operaciones/input/LucroPorFuncionarioResponse.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/input/LucroPorFuncionarioResponse.java
@@ -1,0 +1,15 @@
+package com.franco.dev.graphql.operaciones.input;
+
+import com.franco.dev.domain.operaciones.dto.LucroPorFuncionarioDto;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+public class LucroPorFuncionarioResponse {
+    private List<LucroPorFuncionarioDto> content;
+    private Long totalElements;
+    private LucroPorFuncionarioSummary summary;
+}

--- a/src/main/java/com/franco/dev/graphql/operaciones/input/LucroPorFuncionarioSummary.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/input/LucroPorFuncionarioSummary.java
@@ -1,0 +1,18 @@
+package com.franco.dev.graphql.operaciones.input;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class LucroPorFuncionarioSummary {
+    private Double cantidad;
+    private Double costoTotal;
+    private Double totalVenta;
+    private Double lucro;
+    private Double margen;
+    private Double totalDescuento;
+    private Double totalAumento;
+    private Double ventaMedia;
+    private Double costoUnitario;
+}

--- a/src/main/java/com/franco/dev/repository/operaciones/VentaItemRepository.java
+++ b/src/main/java/com/franco/dev/repository/operaciones/VentaItemRepository.java
@@ -6,7 +6,9 @@ import com.franco.dev.domain.operaciones.Venta;
 import com.franco.dev.domain.operaciones.VentaItem;
 import com.franco.dev.repository.HelperRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface VentaItemRepository extends HelperRepository<VentaItem, EmbebedPrimaryKey> {
@@ -51,4 +53,53 @@ public interface VentaItemRepository extends HelperRepository<VentaItem, Embebed
                         @org.springframework.data.repository.query.Param("inicio") java.time.LocalDateTime inicio,
                         @org.springframework.data.repository.query.Param("fin") java.time.LocalDateTime fin,
                         org.springframework.data.domain.Pageable pageable);
+
+        @Query(value = "SELECT " +
+                        "u.id AS usuario_id, " +
+                        "COALESCE(per.nombre, u.nickname, '') AS nombre_funcionario, " +
+                        "SUM(vi.cantidad * pre.cantidad * COALESCE(vi.costo_unitario, cpp.ultimo_precio_compra, 0)) AS costo_total, " +
+                        "SUM(vi.cantidad * pre.cantidad) AS cantidad, " +
+                        "SUM(vi.precio * vi.cantidad) AS total_venta, " +
+                        "SUM(CASE WHEN v.total_gs > 0 " +
+                        "THEN (vi.precio * vi.cantidad) / v.total_gs * COALESCE(cd_agg.desc_total, 0) ELSE 0 END) AS total_descuento, " +
+                        "SUM(CASE WHEN v.total_gs > 0 " +
+                        "THEN (vi.precio * vi.cantidad) / v.total_gs * COALESCE(cd_agg.aum_total, 0) ELSE 0 END) AS total_aumento " +
+                        "FROM operaciones.venta v " +
+                        "INNER JOIN operaciones.venta_item vi ON vi.venta_id = v.id AND vi.sucursal_id = v.sucursal_id " +
+                        "INNER JOIN personas.usuario u ON u.id = v.usuario_id " +
+                        "LEFT JOIN personas.persona per ON per.id = u.persona_id " +
+                        "INNER JOIN productos.presentacion pre ON pre.id = vi.presentacion_id " +
+                        "INNER JOIN productos.producto pro ON pro.id = vi.producto_id " +
+                        "LEFT JOIN ( " +
+                        "  SELECT DISTINCT ON (producto_id) producto_id, ultimo_precio_compra " +
+                        "  FROM productos.costo_por_producto ORDER BY producto_id, id DESC " +
+                        ") cpp ON cpp.producto_id = pro.id " +
+                        "LEFT JOIN ( " +
+                        "  SELECT cobro_id, sucursal_id, " +
+                        "    SUM(CASE WHEN descuento = true THEN valor * cambio ELSE 0 END) AS desc_total, " +
+                        "    SUM(CASE WHEN aumento = true THEN valor * cambio ELSE 0 END) AS aum_total " +
+                        "  FROM operaciones.cobro_detalle GROUP BY cobro_id, sucursal_id " +
+                        ") cd_agg ON cd_agg.cobro_id = v.cobro_id AND cd_agg.sucursal_id = v.sucursal_id " +
+                        "WHERE v.estado = 'CONCLUIDA' " +
+                        "AND v.creado_en BETWEEN :startDate AND :endDate " +
+                        "AND v.sucursal_id IN (:sucursalIdList) " +
+                        "AND (:filtrarUsuario = false OR v.usuario_id IN (:usuarioIdList)) " +
+                        "AND (:filtrarProducto = false OR pro.id IN (:productoIdList)) " +
+                        "AND (:subfamiliaId IS NULL OR pro.sub_familia_id = :subfamiliaId) " +
+                        "AND (:familiaId IS NULL OR pro.sub_familia_id IN ( " +
+                        "  SELECT sf.id FROM productos.subfamilia sf WHERE sf.familia_id = :familiaId " +
+                        ")) " +
+                        "GROUP BY u.id, per.nombre, u.nickname " +
+                        "ORDER BY total_venta DESC",
+                        nativeQuery = true)
+        List<Object[]> findLucroPorFuncionarioNative(
+                        @Param("sucursalIdList") List<Long> sucursalIdList,
+                        @Param("startDate") LocalDateTime startDate,
+                        @Param("endDate") LocalDateTime endDate,
+                        @Param("usuarioIdList") List<Long> usuarioIdList,
+                        @Param("productoIdList") List<Long> productoIdList,
+                        @Param("subfamiliaId") Long subfamiliaId,
+                        @Param("familiaId") Long familiaId,
+                        @Param("filtrarUsuario") Boolean filtrarUsuario,
+                        @Param("filtrarProducto") Boolean filtrarProducto);
 }

--- a/src/main/java/com/franco/dev/service/impresion/ImpresionService.java
+++ b/src/main/java/com/franco/dev/service/impresion/ImpresionService.java
@@ -12,6 +12,7 @@ import com.franco.dev.domain.operaciones.PedidoItem;
 import com.franco.dev.domain.operaciones.Transferencia;
 import com.franco.dev.domain.operaciones.TransferenciaItem;
 import com.franco.dev.domain.operaciones.SolicitudPago;
+import com.franco.dev.domain.operaciones.dto.LucroPorFuncionarioDto;
 import com.franco.dev.domain.operaciones.dto.LucroPorProductosDto;
 import com.franco.dev.domain.operaciones.dto.ReporteVentaItemDto;
 import com.franco.dev.domain.personas.Cliente;
@@ -1030,6 +1031,62 @@ public class ImpresionService {
             parameters.put("filtroTexto", filtro);
             parameters.put("filtroSucursales", sucursales);
             parameters.put("cantProductos", cantProductos);
+            parameters.put("lucroTotalPorcentaje", lucroTotalPorcentaje);
+            parameters.put("lucroTotalGs", lucroTotalGs);
+            parameters.put("costoTotal", costoTotal);
+            parameters.put("ventaTotal", ventaTotal);
+            parameters.put("descuentoTotal", descuentoTotal);
+            parameters.put("aumentoTotal", aumentoTotal);
+            parameters.put("fechaReporte", DateUtils.toString(LocalDateTime.now()));
+            parameters.put("usuario", usuario.getNickname());
+            parameters.put("logo", imageService.getImagePath() + File.separator + "logo.png");
+            JasperPrint jasperPrint1 = JasperFillManager.fillReport(jasperReport, parameters, dataSource);
+            byte[] pdfBytes = JasperExportManager.exportReportToPdf(jasperPrint1);
+            String base64String = Base64.getEncoder().encodeToString(pdfBytes);
+            return base64String;
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+            return null;
+        } catch (JRException e) {
+            e.printStackTrace();
+            return null;
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    public String imprimirReporteLucroPorFuncionario(List<LucroPorFuncionarioDto> lucroPorFuncionarioDtoList,
+            String fechaInicio, String fechaFin, String sucursales, String filtro, Usuario usuario) {
+        Long cantFuncionarios = Long.valueOf(0);
+        Double lucroTotalPorcentaje = 0.0;
+        Double lucroTotalGs = 0.0;
+        Double costoTotal = 0.0;
+        Double ventaTotal = 0.0;
+        Double descuentoTotal = 0.0;
+        Double aumentoTotal = 0.0;
+        List<LucroPorFuncionarioDto> auxList = new ArrayList<>();
+        try {
+            for (LucroPorFuncionarioDto dto : lucroPorFuncionarioDtoList) {
+                lucroTotalGs += dto.getLucro();
+                costoTotal += dto.getCostoTotal();
+                ventaTotal += dto.getTotalVenta();
+                descuentoTotal += (dto.getTotalDescuento() != null ? dto.getTotalDescuento() : 0.0);
+                aumentoTotal += (dto.getTotalAumento() != null ? dto.getTotalAumento() : 0.0);
+                auxList.add(dto);
+            }
+            cantFuncionarios = Long.valueOf(lucroPorFuncionarioDtoList.size());
+            lucroTotalPorcentaje = ventaTotal > 0 ? ((lucroTotalGs) / ventaTotal) * 100 : 0.0;
+            ClassPathResource resource = new ClassPathResource("reports/lucro-por-funcionario.jrxml");
+            InputStream inputStream = resource.getInputStream();
+            JasperReport jasperReport = JasperCompileManager.compileReport(inputStream);
+            JRBeanCollectionDataSource dataSource = new JRBeanCollectionDataSource(auxList);
+            Map<String, Object> parameters = new HashMap<>();
+            parameters.put("filtroFechaInicio", fechaInicio);
+            parameters.put("filtroFechaFin", fechaFin);
+            parameters.put("filtroTexto", filtro);
+            parameters.put("filtroSucursales", sucursales);
+            parameters.put("cantFuncionarios", cantFuncionarios);
             parameters.put("lucroTotalPorcentaje", lucroTotalPorcentaje);
             parameters.put("lucroTotalGs", lucroTotalGs);
             parameters.put("costoTotal", costoTotal);

--- a/src/main/java/com/franco/dev/service/operaciones/VentaService.java
+++ b/src/main/java/com/franco/dev/service/operaciones/VentaService.java
@@ -8,10 +8,12 @@ import com.franco.dev.domain.financiero.PdvCaja;
 import com.franco.dev.domain.financiero.VentaCredito;
 import com.franco.dev.domain.financiero.enums.PdvCajaTipoMovimiento;
 import com.franco.dev.domain.operaciones.*;
+import com.franco.dev.domain.operaciones.dto.LucroPorFuncionarioDto;
 import com.franco.dev.domain.operaciones.dto.VentaPorPeriodoV1Dto;
 import com.franco.dev.domain.operaciones.enums.DeliveryEstado;
 import com.franco.dev.domain.operaciones.enums.TipoMovimiento;
 import com.franco.dev.domain.operaciones.enums.VentaEstado;
+import com.franco.dev.repository.operaciones.VentaItemRepository;
 import com.franco.dev.repository.operaciones.VentaRepository;
 import com.franco.dev.service.CrudService;
 import com.franco.dev.service.financiero.FacturaLegalService;
@@ -34,6 +36,7 @@ import javax.persistence.EntityManager;
 import javax.persistence.criteria.*;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -79,6 +82,9 @@ public class VentaService extends CrudService<Venta, VentaRepository, EmbebedPri
 
     @Autowired
     private SucursalService sucursalService;
+
+    @Autowired
+    private VentaItemRepository ventaItemRepository;
 
     @Override
     public VentaRepository getRepository() {
@@ -647,6 +653,87 @@ public class VentaService extends CrudService<Venta, VentaRepository, EmbebedPri
             // Combine predicates with AND
             return cb.and(predicates.toArray(new Predicate[0]));
         }, newPageable);
+    }
+
+    public List<LucroPorFuncionarioDto> findLucroPorFuncionarios(String inicio, String fin, List<Long> sucIdList,
+            List<Long> usuarioIdList, List<Long> productoIdList, Long subfamiliaId, Long familiaId) {
+        if (sucIdList == null || sucIdList.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        boolean filtrarUsuario = usuarioIdList != null && !usuarioIdList.isEmpty();
+        boolean filtrarProducto = productoIdList != null && !productoIdList.isEmpty();
+
+        List<Long> finalUsuarioIdList = filtrarUsuario ? usuarioIdList : Arrays.asList(-1L);
+        List<Long> finalProductoIdList = filtrarProducto ? productoIdList : Arrays.asList(-1L);
+
+        List<Object[]> rows = ventaItemRepository.findLucroPorFuncionarioNative(
+                sucIdList,
+                stringToDate(inicio),
+                stringToDate(fin),
+                finalUsuarioIdList,
+                finalProductoIdList,
+                subfamiliaId,
+                familiaId,
+                filtrarUsuario,
+                filtrarProducto);
+
+        List<LucroPorFuncionarioDto> result = new ArrayList<>();
+        for (Object[] row : rows) {
+            LucroPorFuncionarioDto dto = new LucroPorFuncionarioDto();
+            dto.setUsuarioId(row[0] != null ? ((Number) row[0]).longValue() : null);
+            dto.setNombreFuncionario(row[1] != null ? row[1].toString() : "");
+            dto.setCostoTotal(row[2] != null ? ((Number) row[2]).doubleValue() : 0.0);
+            dto.setCantidad(row[3] != null ? ((Number) row[3]).doubleValue() : 0.0);
+            dto.setTotalVenta(row[4] != null ? ((Number) row[4]).doubleValue() : 0.0);
+            dto.setTotalDescuento(row[5] != null ? ((Number) row[5]).doubleValue() : 0.0);
+            dto.setTotalAumento(row[6] != null ? ((Number) row[6]).doubleValue() : 0.0);
+            result.add(dto);
+        }
+
+        for (LucroPorFuncionarioDto dto : result) {
+            if (dto.getCantidad() != null && dto.getCantidad() > 0) {
+                dto.setCostoUnitario(dto.getCostoTotal() / dto.getCantidad());
+
+                if (dto.getTotalVenta() > 0 && dto.getCantidad() > 0) {
+                    dto.setVentaMedia(dto.getTotalVenta() / dto.getCantidad());
+                } else {
+                    dto.setVentaMedia(0.0);
+                }
+
+                if (dto.getTotalDescuento() != null) {
+                    dto.setTotalDescuento((double) Math.round(dto.getTotalDescuento()));
+                }
+                if (dto.getTotalAumento() != null) {
+                    dto.setTotalAumento((double) Math.round(dto.getTotalAumento()));
+                }
+
+                dto.setLucro((double) Math.round(dto.getTotalVenta() - dto.getCostoTotal()
+                        - (dto.getTotalDescuento() != null ? dto.getTotalDescuento() : 0.0)
+                        + (dto.getTotalAumento() != null ? dto.getTotalAumento() : 0.0)));
+
+                if (dto.getCostoTotal() > 0) {
+                    dto.setMargen((dto.getLucro() / dto.getCostoTotal()) * 100);
+                } else {
+                    dto.setMargen(0.0);
+                }
+
+                if (dto.getTotalVenta() > 0) {
+                    dto.setPercent((dto.getLucro() / dto.getTotalVenta()) * 100);
+                } else {
+                    dto.setPercent(0.0);
+                }
+            } else {
+                dto.setCostoUnitario(0.0);
+                dto.setVentaMedia(0.0);
+                dto.setLucro(0.0);
+                dto.setMargen(0.0);
+                dto.setPercent(0.0);
+            }
+        }
+
+        result.sort((dto1, dto2) -> dto2.getTotalVenta().compareTo(dto1.getTotalVenta()));
+        return result;
     }
 }
 

--- a/src/main/resources/db/migration/V130.3__add_indexes_lucro_por_funcionario.sql
+++ b/src/main/resources/db/migration/V130.3__add_indexes_lucro_por_funcionario.sql
@@ -1,0 +1,15 @@
+-- Flyway:executeInTransaction=false
+
+-- Índices para optimizar el reporte lucro por funcionario.
+-- El cuello de botella principal es el join venta -> venta_item sin índice en venta_id.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_venta_item_venta_sucursal
+    ON operaciones.venta_item (venta_id, sucursal_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_venta_concluida_fecha_suc_usuario
+    ON operaciones.venta (creado_en, sucursal_id, usuario_id)
+    WHERE estado = 'CONCLUIDA';
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_costo_por_producto_producto_id_desc
+    ON productos.costo_por_producto (producto_id, id DESC)
+    INCLUDE (ultimo_precio_compra);

--- a/src/main/resources/graphql/operaciones/venta.graphqls
+++ b/src/main/resources/graphql/operaciones/venta.graphqls
@@ -80,6 +80,8 @@ extend type Query {
     ventasPorSucursalAndUsuario(usuarioId: ID!, inicio: String!, fin: String!): [VentaPorSucursal]
     ventasPorSucursal(inicio: String!, fin: String!): [VentaPorSucursal]
     ventasPorFuncionario(inicio: String!, fin: String!, sucId: ID, usuarioId: ID): [VentaPorFuncionario]
+    lucroPorFuncionario(fechaInicio: String, fechaFin: String, sucursalIdList: [ID], usuarioId: ID!, usuarioIdList: [ID], productoIdList: [ID], subfamiliaId: ID, familiaId: ID): String
+    lucroPorFuncionarioList(fechaInicio: String, fechaFin: String, sucursalIdList: [ID], usuarioIdList: [ID], productoIdList: [ID], subfamiliaId: ID, page: Int, size: Int, familiaId: ID): LucroPorFuncionarioResponse
     ventasGenericFilter(
         idVenta:ID, 
         idCaja:ID, 
@@ -165,4 +167,36 @@ type VentaPorMes {
     otros: Float
 }
 
+type LucroPorFuncionario {
+    usuarioId: ID!
+    nombreFuncionario: String
+    costoUnitario: Float
+    cantidad: Float
+    totalVenta: Float
+    lucro: Float
+    percent: Float
+    costoTotal: Float
+    ventaMedia: Float
+    margen: Float
+    totalDescuento: Float
+    totalAumento: Float
+}
+
+type LucroPorFuncionarioSummary {
+    cantidad: Float
+    costoTotal: Float
+    totalVenta: Float
+    lucro: Float
+    margen: Float
+    totalDescuento: Float
+    totalAumento: Float
+    ventaMedia: Float
+    costoUnitario: Float
+}
+
+type LucroPorFuncionarioResponse {
+    content: [LucroPorFuncionario]
+    totalElements: Int
+    summary: LucroPorFuncionarioSummary
+}
 

--- a/src/main/resources/reports/lucro-por-funcionario.jrxml
+++ b/src/main/resources/reports/lucro-por-funcionario.jrxml
@@ -1,0 +1,533 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 6.21.5.final using JasperReports Library version 6.21.5-74d586df47b25dbd05bd0957999819196e59934a  -->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="transferencia" pageWidth="595" pageHeight="842" whenNoDataType="AllSectionsNoDetail" columnWidth="535" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isFloatColumnFooter="true" uuid="4eedbb89-b4f6-4469-9ab6-f642a1688cf7">
+	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="One Empty Record"/>
+	<parameter name="fechaReporte" class="java.lang.String"/>
+	<parameter name="usuario" class="java.lang.String"/>
+	<parameter name="cantFuncionarios" class="java.lang.Long"/>
+	<parameter name="lucroTotalPorcentaje" class="java.lang.Double"/>
+	<parameter name="lucroTotalGs" class="java.lang.Double"/>
+	<parameter name="filtroFechaFin" class="java.lang.String"/>
+	<parameter name="costoTotal" class="java.lang.Double"/>
+	<parameter name="filtroSucursales" class="java.lang.String"/>
+	<parameter name="filtroFechaInicio" class="java.lang.String"/>
+	<parameter name="filtroTexto" class="java.lang.String"/>
+	<parameter name="ventaTotal" class="java.lang.Double"/>
+	<parameter name="logo" class="java.lang.String"/>
+	<parameter name="descuentoTotal" class="java.lang.Double"/>
+	<parameter name="aumentoTotal" class="java.lang.Double"/>
+	<field name="usuarioId" class="java.lang.Long"/>
+	<field name="nombreFuncionario" class="java.lang.String"/>
+	<field name="ventaMedia" class="java.lang.Double"/>
+	<field name="costoUnitario" class="java.lang.Double"/>
+	<field name="margen" class="java.lang.Double"/>
+	<field name="cantidad" class="java.lang.Double"/>
+	<field name="totalVenta" class="java.lang.Double"/>
+	<field name="lucro" class="java.lang.Double"/>
+	<field name="percent" class="java.lang.Double"/>
+	<field name="totalDescuento" class="java.lang.Double"/>
+	<field name="totalAumento" class="java.lang.Double"/>
+	<title>
+		<band height="100" splitType="Stretch">
+			<rectangle>
+				<reportElement x="340" y="20" width="215" height="76" uuid="6aefecf3-cd9e-4738-a9d7-09a9578bc220"/>
+				<graphicElement>
+					<pen lineColor="#808080"/>
+				</graphicElement>
+			</rectangle>
+			<rectangle>
+				<reportElement x="415" y="13" width="59" height="12" uuid="bdc73c4f-d178-4c96-9c05-7fa69c270afb"/>
+				<graphicElement>
+					<pen lineColor="#FFFFFF"/>
+				</graphicElement>
+			</rectangle>
+			<rectangle>
+				<reportElement x="110" y="20" width="215" height="76" uuid="e703c566-7819-4778-bdfd-f96af1fc6e09">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<graphicElement>
+					<pen lineColor="#808080"/>
+				</graphicElement>
+			</rectangle>
+			<rectangle>
+				<reportElement x="194" y="13" width="39" height="12" uuid="135b7210-797e-41f2-a5fd-031e40506d08"/>
+				<graphicElement>
+					<pen lineColor="#FFFFFF"/>
+				</graphicElement>
+			</rectangle>
+			<image hAlign="Center">
+				<reportElement x="0" y="18" width="102" height="61" uuid="94883631-a913-43e2-b182-ab8d77d0181e"/>
+				<imageExpression><![CDATA[$P{logo}]]></imageExpression>
+			</image>
+			<staticText>
+				<reportElement x="102" y="14" width="228" height="14" forecolor="#000000" uuid="b61efa33-0ea0-4fed-9d78-a768de817cb3">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<box rightPadding="4"/>
+				<textElement textAlignment="Center">
+					<font fontName="SansSerif" size="10"/>
+				</textElement>
+				<text><![CDATA[Filtros]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="80" y="-2" width="400" height="17" forecolor="#000000" uuid="c0c9f5b8-f0b7-4503-9428-2d7be98aa4e6">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Bottom">
+					<font fontName="SansSerif" size="12" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Reporte de lucro por funcionario]]></text>
+			</staticText>
+			<textField>
+				<reportElement x="150" y="80" width="80" height="11" forecolor="#000000" uuid="7e8c778b-0e6c-4e04-a4c7-de5b9f3403f6">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Right">
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{fechaReporte}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="112" y="80" width="41" height="11" forecolor="#000000" uuid="4c91f639-4e4b-4bb2-965f-156eaed3a91c">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+				</reportElement>
+				<textElement>
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<text><![CDATA[Creado en:]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="230" y="80" width="17" height="11" forecolor="#000000" uuid="186428af-f5d4-4389-8c9b-cadb45c47034">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Top">
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<text><![CDATA[por:]]></text>
+			</staticText>
+			<textField>
+				<reportElement x="247" y="80" width="78" height="11" forecolor="#000000" uuid="09ce4efd-2860-4013-b158-a83a2fdcc811">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement>
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{usuario}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="342" y="25" width="78" height="11" forecolor="#000000" uuid="5dff8300-19b4-4ce4-bf6d-de090b8db287">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<box rightPadding="4"/>
+				<textElement textAlignment="Left">
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<text><![CDATA[Cant. funcionarios:]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="340" y="14" width="214" height="14" forecolor="#000000" uuid="d93279d0-76e3-46ae-bd32-61f00d4dce8d">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<box rightPadding="4"/>
+				<textElement textAlignment="Center">
+					<font fontName="SansSerif" size="10"/>
+				</textElement>
+				<text><![CDATA[Resumen]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="342" y="36" width="78" height="11" forecolor="#000000" uuid="3042e1d6-9c20-4876-b699-4189a2aadb04">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<box rightPadding="4"/>
+				<textElement textAlignment="Left">
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<text><![CDATA[Total de venta:]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="342" y="47" width="78" height="11" forecolor="#000000" uuid="7d8b9f3d-1a33-4788-b53f-410bfa668d13">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<box rightPadding="4"/>
+				<textElement textAlignment="Left">
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<text><![CDATA[Total de costo:]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="342" y="58" width="78" height="11" forecolor="#000000" uuid="ccdde9e8-8d6f-42e7-a9d2-06d984c82e58">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<box rightPadding="4"/>
+				<textElement textAlignment="Left">
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<text><![CDATA[Total de lucro:]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="112" y="58" width="56" height="11" forecolor="#000000" uuid="952a2b7b-2b18-4daa-823e-3241f57c0708">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<box rightPadding="4"/>
+				<textElement textAlignment="Left">
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<text><![CDATA[Fecha Inicio:]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="112" y="69" width="55" height="11" forecolor="#000000" uuid="d6c50cb5-67d5-41eb-8304-19f12525266e">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<box rightPadding="4"/>
+				<textElement textAlignment="Left">
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<text><![CDATA[Fecha fin:]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="342" y="69" width="78" height="11" forecolor="#000000" uuid="ccdde9e8-8d6f-42e7-a9d2-06d984c82e58">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<box rightPadding="4"/>
+				<textElement textAlignment="Left" verticalAlignment="Top">
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<text><![CDATA[Total descuento:]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="342" y="80" width="78" height="11" forecolor="#000000" uuid="ccdde9e8-8d6f-42e7-a9d2-06d984c82e58">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<box rightPadding="4"/>
+				<textElement textAlignment="Left">
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<text><![CDATA[Total aumento:]]></text>
+			</staticText>
+			<textField pattern="#,##0.##;#,##0.###-">
+				<reportElement x="427" y="25" width="83" height="11" forecolor="#000000" uuid="86b0853e-5729-44dd-abbc-3ee63ebdbb2a"/>
+				<textElement>
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{cantFuncionarios}]]></textFieldExpression>
+			</textField>
+			<textField pattern="#,###">
+				<reportElement x="427" y="36" width="83" height="11" forecolor="#000000" uuid="94e7cd8d-74e2-4409-a255-387dbd985693"/>
+				<textElement>
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{ventaTotal}]]></textFieldExpression>
+			</textField>
+			<textField pattern="#,###">
+				<reportElement x="427" y="47" width="83" height="11" forecolor="#000000" uuid="271e9c74-371c-4dc7-8c56-178afec950e1"/>
+				<textElement>
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{costoTotal}]]></textFieldExpression>
+			</textField>
+			<textField pattern="#,##0.00&apos;%&apos;">
+				<reportElement x="491" y="80" width="62" height="11" forecolor="#000000" uuid="5bae2fe2-6a72-431f-80a2-939d18fe82f8">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Right">
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{lucroTotalPorcentaje}]]></textFieldExpression>
+			</textField>
+			<textField pattern="#,###">
+				<reportElement x="427" y="58" width="73" height="11" forecolor="#000000" uuid="997339fb-7bd2-46f0-ae8f-f59dafe7632d"/>
+				<textElement>
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{lucroTotalGs}]]></textFieldExpression>
+			</textField>
+			<textField pattern="#,###">
+				<reportElement x="427" y="69" width="73" height="11" forecolor="#000000" uuid="997339fb-7bd2-46f0-ae8f-f59dafe7632d">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement>
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{descuentoTotal}]]></textFieldExpression>
+			</textField>
+			<textField pattern="#,###">
+				<reportElement x="427" y="80" width="58" height="11" forecolor="#000000" uuid="997339fb-7bd2-46f0-ae8f-f59dafe7632d"/>
+				<textElement>
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{aumentoTotal}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="111" y="25" width="210" height="35" forecolor="#000000" uuid="c2818336-5747-4253-98a6-2417b9b4e3c7">
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement>
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroTexto}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="167" y="69" width="153" height="11" forecolor="#000000" uuid="de978e8e-d9c0-41b3-92c5-845bf8bbf604">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement>
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroFechaFin}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="167" y="58" width="153" height="11" forecolor="#000000" uuid="9fea43b1-2dec-48a2-907d-79ceeb4c8b82">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement>
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroFechaInicio}]]></textFieldExpression>
+			</textField>
+		</band>
+	</title>
+	<columnHeader>
+		<band height="14">
+			<rectangle>
+				<reportElement x="0" y="0" width="555" height="12" forecolor="#D4D4D4" backcolor="#EDEDED" uuid="3006dae7-3228-4979-bda4-adc9f14e4ac7"/>
+				<graphicElement>
+					<pen lineColor="#A3A3A3"/>
+				</graphicElement>
+			</rectangle>
+			<staticText>
+				<reportElement x="0" y="0" width="25" height="12" uuid="5db52dbf-1afd-4644-8f13-e76805616451">
+					<property name="com.jaspersoft.studio.spreadsheet.connectionID" value="99d0fb5d-1faa-4bbd-82c3-074c7521ef16"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<text><![CDATA[ID]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="25" y="0" width="165" height="12" uuid="3bbcdfc8-0001-4dac-b326-abfd258f2122">
+					<property name="com.jaspersoft.studio.spreadsheet.connectionID" value="c2cbdec0-56a1-4f22-b702-a18a6c2a6656"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Left" verticalAlignment="Middle">
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<text><![CDATA[Descripción]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="220" y="0" width="48" height="12" uuid="a588dd5d-de1a-45cb-ad29-b277e36f5397">
+					<property name="com.jaspersoft.studio.spreadsheet.connectionID" value="f8c751ac-44ae-4096-822b-eea32b995584"/>
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<text><![CDATA[Costo Medio]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="190" y="0" width="30" height="12" uuid="2af06abc-984f-47f9-a57b-cdb5337f5b49">
+					<property name="com.jaspersoft.studio.spreadsheet.connectionID" value="f399f2b1-cca8-4056-a4a1-23eef3c33130"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<text><![CDATA[Cant]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="430" y="0" width="55" height="12" uuid="0178985a-2d68-44c2-872c-63ff885881ad">
+					<property name="com.jaspersoft.studio.spreadsheet.connectionID" value="190212fc-8e34-4971-9ba7-27fefcbd4bae"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<text><![CDATA[Total Venta]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="485" y="0" width="49" height="12" uuid="dc2952ad-afe8-455c-bea7-b789e00abe05">
+					<property name="com.jaspersoft.studio.spreadsheet.connectionID" value="6fd3eab8-a6ab-4761-bcf8-7cb4194ce171"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<text><![CDATA[Total Lucro]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="534" y="0" width="20" height="12" uuid="100ca57a-a3f4-401e-ae8b-44ca8bca0850">
+					<property name="com.jaspersoft.studio.spreadsheet.connectionID" value="4fc1fb59-b42d-4636-a0fa-a3dc7e10b887"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<text><![CDATA[%]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="268" y="0" width="50" height="12" uuid="5a99102b-60a0-4475-a27b-2722e3439643">
+					<property name="com.jaspersoft.studio.spreadsheet.connectionID" value="df5a90b0-ceef-4082-b9b0-261d9cb8e9d8"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<text><![CDATA[Venta Media]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="318" y="0" width="43" height="12" uuid="6ce20d53-3166-4c7d-813d-3db2ccd7abe7">
+					<property name="com.jaspersoft.studio.spreadsheet.connectionID" value="4fc1fb59-b42d-4636-a0fa-a3dc7e10b887"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<text><![CDATA[Margen(%)]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="361" y="0" width="39" height="12" uuid="6ce20d53-3166-4c7d-813d-3db2ccd7abe7">
+					<property name="com.jaspersoft.studio.spreadsheet.connectionID" value="4fc1fb59-b42d-4636-a0fa-a3dc7e10b887"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<text><![CDATA[Desc]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="400" y="0" width="30" height="12" uuid="6ce20d53-3166-4c7d-813d-3db2ccd7abe7">
+					<property name="com.jaspersoft.studio.spreadsheet.connectionID" value="4fc1fb59-b42d-4636-a0fa-a3dc7e10b887"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<text><![CDATA[Aum]]></text>
+			</staticText>
+		</band>
+	</columnHeader>
+	<detail>
+		<band height="14">
+			<textField>
+				<reportElement x="0" y="0" width="25" height="12" uuid="8750c3ab-2960-4bb8-90be-10da045b6504">
+					<property name="com.jaspersoft.studio.spreadsheet.connectionID" value="99d0fb5d-1faa-4bbd-82c3-074c7521ef16"/>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{usuarioId}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="25" y="0" width="165" height="12" uuid="e7ce38bb-9602-4aed-9cc6-42d17cdfdfcb">
+					<property name="com.jaspersoft.studio.spreadsheet.connectionID" value="c2cbdec0-56a1-4f22-b702-a18a6c2a6656"/>
+				</reportElement>
+				<textElement textAlignment="Left" verticalAlignment="Middle">
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{nombreFuncionario}]]></textFieldExpression>
+			</textField>
+			<textField pattern="#,###">
+				<reportElement x="220" y="0" width="48" height="12" uuid="5e20e25b-4196-4a0e-ab3e-c6499feb6c06">
+					<property name="com.jaspersoft.studio.spreadsheet.connectionID" value="f8c751ac-44ae-4096-822b-eea32b995584"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{costoUnitario}]]></textFieldExpression>
+			</textField>
+			<textField pattern="#,##0.##;#,###.##">
+				<reportElement x="190" y="0" width="30" height="12" uuid="b4d38cdd-d945-4348-816b-3468ec86b8a5">
+					<property name="com.jaspersoft.studio.spreadsheet.connectionID" value="f399f2b1-cca8-4056-a4a1-23eef3c33130"/>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{cantidad}]]></textFieldExpression>
+			</textField>
+			<textField pattern="#,###.###;(#,###.###-)">
+				<reportElement x="430" y="0" width="55" height="12" uuid="23190775-92e8-495c-9d31-db69c452acd5">
+					<property name="com.jaspersoft.studio.spreadsheet.connectionID" value="190212fc-8e34-4971-9ba7-27fefcbd4bae"/>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{totalVenta}]]></textFieldExpression>
+			</textField>
+			<textField pattern="#,###.###;(#,###.###-)">
+				<reportElement x="485" y="0" width="49" height="12" uuid="eca7a9e4-9ca6-48ab-bc0f-c4b11d267b77">
+					<property name="com.jaspersoft.studio.spreadsheet.connectionID" value="6fd3eab8-a6ab-4761-bcf8-7cb4194ce171"/>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{lucro}]]></textFieldExpression>
+			</textField>
+			<textField pattern="#,##0.#">
+				<reportElement x="534" y="0" width="20" height="12" uuid="e3db8791-d73b-4661-81f8-24681194c8a5">
+					<property name="com.jaspersoft.studio.spreadsheet.connectionID" value="4fc1fb59-b42d-4636-a0fa-a3dc7e10b887"/>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{percent}]]></textFieldExpression>
+			</textField>
+			<textField pattern="#,###">
+				<reportElement x="268" y="0" width="50" height="12" uuid="4d8c61d6-9300-4f08-904e-c8e2f9ceb017">
+					<property name="com.jaspersoft.studio.spreadsheet.connectionID" value="df5a90b0-ceef-4082-b9b0-261d9cb8e9d8"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{ventaMedia}]]></textFieldExpression>
+			</textField>
+			<textField pattern="#,##0.##">
+				<reportElement x="318" y="0" width="43" height="12" uuid="76323511-d343-45e5-a29e-f38eaca30264">
+					<property name="com.jaspersoft.studio.spreadsheet.connectionID" value="4fc1fb59-b42d-4636-a0fa-a3dc7e10b887"/>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{margen}]]></textFieldExpression>
+			</textField>
+			<textField pattern="#,##0.##">
+				<reportElement x="361" y="0" width="39" height="12" uuid="76323511-d343-45e5-a29e-f38eaca30264">
+					<property name="com.jaspersoft.studio.spreadsheet.connectionID" value="4fc1fb59-b42d-4636-a0fa-a3dc7e10b887"/>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{totalDescuento}]]></textFieldExpression>
+			</textField>
+			<textField pattern="#,##0.##">
+				<reportElement x="400" y="0" width="30" height="12" uuid="76323511-d343-45e5-a29e-f38eaca30264">
+					<property name="com.jaspersoft.studio.spreadsheet.connectionID" value="4fc1fb59-b42d-4636-a0fa-a3dc7e10b887"/>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="SansSerif" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{totalAumento}]]></textFieldExpression>
+			</textField>
+		</band>
+	</detail>
+	<columnFooter>
+		<band height="15"/>
+	</columnFooter>
+	<lastPageFooter>
+		<band height="17"/>
+	</lastPageFooter>
+</jasperReport>


### PR DESCRIPTION
## Summary

- Se agrega el reporte **Lucro por funcionario** como complemento analítico del reporte existente de lucro por producto.
- Permite medir la rentabilidad de las ventas atribuidas a cada usuario/funcionario del PDV, reutilizando la misma lógica de cálculo de lucro pero agrupando por `usuario_id`.
- Incluye consulta GraphQL paginada con resumen, endpoint de PDF y migración Flyway con índices para optimizar las consultas.

## Backend

### Query y servicio

- **`VentaItemRepository.findLucroPorFuncionarioNative`**: query nativa que agrupa ítems de ventas `CONCLUIDA` por usuario, calculando costo total, cantidad, venta total, descuento y aumento prorrateados por ítem.
- **`VentaService.findLucroPorFuncionarios`**: calcula campos derivados (`costoUnitario`, `ventaMedia`, `lucro`, `margen`, `percent`) y ordena por venta total descendente.
- Filtros soportados: sucursales, usuarios, productos, subfamilia y familia.

### GraphQL

- **`lucroPorFuncionarioList`**: retorna `content`, `totalElements` y `summary` global paginado.
- **`lucroPorFuncionario`**: genera PDF en Base64 (mismo patrón que lucro por producto).
- Nuevos tipos: `LucroPorFuncionario`, `LucroPorFuncionarioSummary`, `LucroPorFuncionarioResponse`.

### Impresión

- **`ImpresionService.imprimirReporteLucroPorFuncionario`** con template JasperReports `lucro-por-funcionario.jrxml`.

### Performance

- Migración **`V130.3__add_indexes_lucro_por_funcionario.sql`** con índices concurrentes sobre `venta_item`, `venta` (filtrado por `CONCLUIDA`) y `costo_por_producto`.

### Lógica de negocio

- Fórmula de lucro: `venta - costo - descuento + aumento` (idéntica a lucro por producto).
- Cada ítem se atribuye al `usuario_id` de la venta que lo registró.
- Ventas sin usuario asignado quedan excluidas por el `INNER JOIN` con usuario.

## Impacto

- Nuevos endpoints GraphQL de solo lectura; no modifica datos transaccionales.
- Habilita análisis de rentabilidad por vendedor/cajero además del volumen de ventas que ya expone `ventasPorFuncionario`.
- La consulta puede ser costosa en rangos amplios; los índices mitigan el impacto en producción.

## Test plan

- [ ] Ejecutar `lucroPorFuncionarioList` con rango de fechas y sucursal(es); verificar `content` y `summary`.
- [ ] Filtrar por `usuarioIdList`, `productoIdList`, `familiaId` y `subfamiliaId`.
- [ ] Comparar la suma del lucro del `summary` con el lucro total de `lucroPorProductoList` usando los mismos filtros (sin filtro de usuario).
- [ ] Generar PDF vía `lucroPorFuncionario` y validar totales.
- [ ] Verificar que la migración `V130.3` aplica correctamente los índices en PostgreSQL.
- [ ] Confirmar que ventas `CONCLUIDA` sin `usuario_id` no aparecen en el reporte.


Made with [Cursor](https://cursor.com)