### PR TITLE
fix(marcacion): ajustar umbral de similitud facial al 55 por ciento

### DIFF
--- a/src/main/java/com/franco/dev/graphql/administrativo/MarcacionGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/administrativo/MarcacionGraphQL.java
@@ -85,7 +85,7 @@ public class MarcacionGraphQL implements GraphQLQueryResolver, GraphQLMutationRe
                                 });
 
                         double similarity = cosineSimilarity(marcacion.getEmbedding(), storedEmbedding);
-                        if (similarity < 0.6) {
+                        if (similarity < 0.55) {
                             throw new graphql.GraphQLException("Verificación facial fallida: El rostro no coincide ("
                                     + String.format("%.2f", similarity * 100) + "% similitud)");
                         }

--- a/src/main/java/com/franco/dev/service/personas/UsuarioEmbeddingCacheService.java
+++ b/src/main/java/com/franco/dev/service/personas/UsuarioEmbeddingCacheService.java
@@ -22,7 +22,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 @Slf4j
 public class UsuarioEmbeddingCacheService {
 
-    private static final double MATCH_THRESHOLD = 0.75;
+    private static final double MATCH_THRESHOLD = 0.55;
 
     private final UsuarioRepository usuarioRepository;
     private final ObjectMapper objectMapper;


### PR DESCRIPTION
## Summary
- Reduce el umbral de match en la caché de embeddings faciales de 75% a 55%.
- Ajusta la verificación facial al guardar marcación para usar el mismo umbral del frontend.

## Test plan
- [ ] Reiniciar backend y confirmar carga de caché de embeddings al arrancar.
- [ ] Probar `usuarioPorEmbedding` con un usuario registrado y similitud >= 55%.
- [ ] Guardar una marcación con verificación facial y confirmar que rechaza similitud < 55%.
- [ ] Validar que usuarios sin embedding registrado siguen sin ser identificados.


Made with [Cursor](https://cursor.com)