### PR TITLE
feat(marcacion): galería de embeddings y reglas de jornada centralizadas

### DIFF
--- a/src/main/java/com/franco/dev/domain/administrativo/EstadoMarcacionUsuario.java
+++ b/src/main/java/com/franco/dev/domain/administrativo/EstadoMarcacionUsuario.java
@@ -1,0 +1,16 @@
+package com.franco.dev.domain.administrativo;
+
+import com.franco.dev.domain.administrativo.enums.AccionMarcacionPendiente;
+import lombok.Data;
+
+@Data
+public class EstadoMarcacionUsuario {
+
+    private Jornada jornadaRelevante;
+    private AccionMarcacionPendiente accionPendiente;
+    private boolean puedeMarcarEntrada;
+    private boolean puedeMarcarSalida;
+    private boolean puedeMarcarSalidaAlmuerzo;
+    private boolean puedeMarcarEntradaAlmuerzo;
+    private boolean estaEnJornada;
+}

--- a/src/main/java/com/franco/dev/domain/administrativo/enums/AccionMarcacionPendiente.java
+++ b/src/main/java/com/franco/dev/domain/administrativo/enums/AccionMarcacionPendiente.java
@@ -1,0 +1,8 @@
+package com.franco.dev.domain.administrativo.enums;
+
+public enum AccionMarcacionPendiente {
+    ENTRADA,
+    SALIDA,
+    RETORNO_ALMUERZO,
+    SALIDA_DEFINITIVA
+}

--- a/src/main/java/com/franco/dev/domain/personas/enums/ResultadoIncorporacionEmbedding.java
+++ b/src/main/java/com/franco/dev/domain/personas/enums/ResultadoIncorporacionEmbedding.java
@@ -1,0 +1,7 @@
+package com.franco.dev.domain.personas.enums;
+
+public enum ResultadoIncorporacionEmbedding {
+    OK,
+    RECHAZADO_SCORE,
+    RECHAZADO_SIMILITUD
+}

--- a/src/main/java/com/franco/dev/graphql/administrativo/JornadaGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/administrativo/JornadaGraphQL.java
@@ -1,7 +1,9 @@
 package com.franco.dev.graphql.administrativo;
 
+import com.franco.dev.domain.administrativo.EstadoMarcacionUsuario;
 import com.franco.dev.domain.administrativo.Jornada;
 import com.franco.dev.domain.EmbebedPrimaryKey;
+import com.franco.dev.service.administrativo.EstadoMarcacionService;
 import com.franco.dev.service.administrativo.JornadaService;
 import com.franco.dev.service.personas.UsuarioService;
 import graphql.kickstart.tools.GraphQLMutationResolver;
@@ -19,6 +21,9 @@ public class JornadaGraphQL implements GraphQLQueryResolver, GraphQLMutationReso
 
     @Autowired
     private JornadaService service;
+
+    @Autowired
+    private EstadoMarcacionService estadoMarcacionService;
 
     @Autowired
     private UsuarioService usuarioService;
@@ -44,6 +49,10 @@ public class JornadaGraphQL implements GraphQLQueryResolver, GraphQLMutationReso
             return service.findByUsuarioIdAndFechaRange(usuarioId, fechaInicio, fechaFin);
         }
         return service.findByUsuarioId(usuarioId);
+    }
+
+    public EstadoMarcacionUsuario estadoMarcacionUsuario(Long usuarioId) {
+        return estadoMarcacionService.obtenerEstado(usuarioId);
     }
 
     public Jornada ajustarJornadaA8Horas(Long id, Long sucursalId, String observacion) {

--- a/src/main/java/com/franco/dev/graphql/administrativo/MarcacionGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/administrativo/MarcacionGraphQL.java
@@ -130,6 +130,10 @@ public class MarcacionGraphQL implements GraphQLQueryResolver, GraphQLMutationRe
         return service.save(e);
     }
 
+    public Marcacion reprocesarJornadaDeMarcacion(Long id, Long sucursalId) {
+        return service.reprocesarJornadaDeMarcacion(id, sucursalId);
+    }
+
     public String imprimirReporteMarcaciones(Long usuarioId, String fechaInicio, String fechaFin,
             Long usuarioResponsableId) {
         com.franco.dev.domain.personas.Usuario usuarioReporte = null;

--- a/src/main/java/com/franco/dev/graphql/administrativo/MarcacionGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/administrativo/MarcacionGraphQL.java
@@ -31,12 +31,6 @@ public class MarcacionGraphQL implements GraphQLQueryResolver, GraphQLMutationRe
     private SucursalService sucursalService;
 
     @Autowired
-    private com.franco.dev.service.personas.PersonaService personaService;
-
-    @Autowired(required = false)
-    private com.fasterxml.jackson.databind.ObjectMapper objectMapper;
-
-    @Autowired
     private ImpresionService impresionService;
 
     @Autowired
@@ -70,26 +64,6 @@ public class MarcacionGraphQL implements GraphQLQueryResolver, GraphQLMutationRe
     }
 
     public Marcacion saveMarcacion(MarcacionInput marcacion) {
-        if (marcacion.getUsuarioId() != null && marcacion.getEmbedding() != null
-                && !marcacion.getEmbedding().isEmpty()) {
-            com.franco.dev.domain.personas.Usuario usuario = usuarioService.findById(marcacion.getUsuarioId())
-                    .orElse(null);
-            if (usuario != null && usuario.getPersona() != null) {
-                String storedEmbeddingJson = usuario.getPersona().getEmbedding();
-                if (storedEmbeddingJson == null || storedEmbeddingJson.isEmpty()) {
-                    try {
-                        if (objectMapper == null)
-                            objectMapper = new com.fasterxml.jackson.databind.ObjectMapper();
-                        String newEmbeddingJson = objectMapper.writeValueAsString(marcacion.getEmbedding());
-                        usuario.getPersona().setEmbedding(newEmbeddingJson);
-                        personaService.save(usuario.getPersona());
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                    }
-                }
-            }
-        }
-
         Marcacion e = new Marcacion();
         if (marcacion.getId() != null && marcacion.getSucursalId() != null) {
             Optional<Marcacion> existing = service

--- a/src/main/java/com/franco/dev/graphql/personas/IncorporarEmbeddingMarcacionResult.java
+++ b/src/main/java/com/franco/dev/graphql/personas/IncorporarEmbeddingMarcacionResult.java
@@ -1,0 +1,14 @@
+package com.franco.dev.graphql.personas;
+
+import com.franco.dev.domain.personas.enums.ResultadoIncorporacionEmbedding;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class IncorporarEmbeddingMarcacionResult {
+    private ResultadoIncorporacionEmbedding resultado;
+    private String mensaje;
+}

--- a/src/main/java/com/franco/dev/graphql/personas/UsuarioGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/personas/UsuarioGraphQL.java
@@ -88,8 +88,9 @@ public class UsuarioGraphQL implements GraphQLQueryResolver, GraphQLMutationReso
         return res;
     }
 
-    public Boolean saveUsuarioImage(Long id, String type, String image, List<Double> embedding) throws IOException {
-        return service.saveUserImage(id, type, image, embedding);
+    public Boolean saveUsuarioImage(Long id, String type, String image, List<Double> embedding, String embeddingGaleriaJson)
+            throws IOException {
+        return service.saveUserImage(id, type, image, embedding, embeddingGaleriaJson);
     }
 
     public List<String> getUsuarioImages(Long id, String type) {

--- a/src/main/java/com/franco/dev/graphql/personas/UsuarioGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/personas/UsuarioGraphQL.java
@@ -117,4 +117,8 @@ public class UsuarioGraphQL implements GraphQLQueryResolver, GraphQLMutationReso
     public UsuarioSimilitudResult usuarioPorEmbedding(List<Double> embedding, List<Integer> excludeIds) {
         return service.findUsuarioByEmbedding(embedding, excludeIds);
     }
+
+    public Boolean incorporarEmbeddingMarcacion(Long usuarioId, List<Double> embedding, Double score) {
+        return service.incorporarEmbeddingMarcacion(usuarioId, embedding, score);
+    }
 }

--- a/src/main/java/com/franco/dev/graphql/personas/UsuarioGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/personas/UsuarioGraphQL.java
@@ -118,7 +118,7 @@ public class UsuarioGraphQL implements GraphQLQueryResolver, GraphQLMutationReso
         return service.findUsuarioByEmbedding(embedding, excludeIds);
     }
 
-    public Boolean incorporarEmbeddingMarcacion(Long usuarioId, List<Double> embedding, Double score) {
+    public IncorporarEmbeddingMarcacionResult incorporarEmbeddingMarcacion(Long usuarioId, List<Double> embedding, Double score) {
         return service.incorporarEmbeddingMarcacion(usuarioId, embedding, score);
     }
 }

--- a/src/main/java/com/franco/dev/graphql/personas/dto/EmbeddingGaleriaDto.java
+++ b/src/main/java/com/franco/dev/graphql/personas/dto/EmbeddingGaleriaDto.java
@@ -1,0 +1,16 @@
+package com.franco.dev.graphql.personas.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmbeddingGaleriaDto {
+    private List<Double> master = new ArrayList<>();
+    private List<EmbeddingGaleriaItemDto> gallery = new ArrayList<>();
+}

--- a/src/main/java/com/franco/dev/graphql/personas/dto/EmbeddingGaleriaItemDto.java
+++ b/src/main/java/com/franco/dev/graphql/personas/dto/EmbeddingGaleriaItemDto.java
@@ -1,0 +1,16 @@
+package com.franco.dev.graphql.personas.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmbeddingGaleriaItemDto {
+    private String pose;
+    private List<Double> embedding;
+    private Double score;
+}

--- a/src/main/java/com/franco/dev/graphql/personas/resolver/PersonaResolver.java
+++ b/src/main/java/com/franco/dev/graphql/personas/resolver/PersonaResolver.java
@@ -45,4 +45,8 @@ public class PersonaResolver implements GraphQLResolver<Persona> {
         return usuarioService.findByPersonaId(p.getId())!=null;
     }
 
+    public String embeddingFacial(Persona p) {
+        return p.getEmbedding();
+    }
+
 }

--- a/src/main/java/com/franco/dev/service/administrativo/EstadoMarcacionService.java
+++ b/src/main/java/com/franco/dev/service/administrativo/EstadoMarcacionService.java
@@ -1,0 +1,26 @@
+package com.franco.dev.service.administrativo;
+
+import com.franco.dev.domain.administrativo.EstadoMarcacionUsuario;
+import com.franco.dev.domain.administrativo.Jornada;
+import com.franco.dev.service.administrativo.helper.JornadaMarcacionRules;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class EstadoMarcacionService {
+
+    private final JornadaService jornadaService;
+    private final JornadaMarcacionRules jornadaMarcacionRules;
+
+    public EstadoMarcacionUsuario obtenerEstado(Long usuarioId) {
+        LocalDate hoy = LocalDate.now();
+        LocalDate ayer = hoy.minusDays(1);
+        List<Jornada> jornadas = jornadaService.findByUsuarioIdAndFechaRange(
+                usuarioId, ayer.toString(), hoy.toString());
+        return jornadaMarcacionRules.construirEstado(jornadas, hoy);
+    }
+}

--- a/src/main/java/com/franco/dev/service/administrativo/MarcacionService.java
+++ b/src/main/java/com/franco/dev/service/administrativo/MarcacionService.java
@@ -34,6 +34,7 @@ public class MarcacionService extends CrudService<Marcacion, MarcacionRepository
     private final TardanzaCalculator tardanzaCalculator;
     private final HorasTrabajadasCalculator horasTrabajadasCalculator;
     private final AlmuerzoProcessor almuerzoProcessor;
+    private final JornadaFactory jornadaFactory;
 
     @Override
     public MarcacionRepository getRepository() {
@@ -83,6 +84,15 @@ public class MarcacionService extends CrudService<Marcacion, MarcacionRepository
         return marcacionGuardada;
     }
 
+    @Transactional(isolation = Isolation.SERIALIZABLE)
+    public Marcacion reprocesarJornadaDeMarcacion(Long id, Long sucursalId) {
+        Marcacion marcacion = findById(new EmbebedPrimaryKey(id, sucursalId))
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Marcación no encontrada: id=" + id + ", sucursalId=" + sucursalId));
+        procesarJornada(marcacion);
+        return marcacion;
+    }
+
     private void prepararMarcacion(Marcacion marcacion) {
         if (marcacion.getId() == null) {
             asignarNuevoId(marcacion);
@@ -127,6 +137,18 @@ public class MarcacionService extends CrudService<Marcacion, MarcacionRepository
             }
 
             almuerzoProcessor.procesar(jornada, marcacion);
+
+            if (!marcacionVinculadaAJornada(jornada, marcacion)) {
+                log.warn(
+                        "Marcación {} no vinculada a jornada {} (fecha {}), creando jornada nueva para usuario {}",
+                        marcacion.getId(), jornada.getId(), jornada.getFecha(),
+                        marcacion.getUsuario().getId());
+                jornada = jornadaFactory.crearNuevaJornada(marcacion, fechaReferencia.toLocalDate());
+                if (horario != null) {
+                    aplicarHorarioAJornada(jornada, horario);
+                }
+                almuerzoProcessor.procesar(jornada, marcacion);
+            }
             tardanzaCalculator.calcular(jornada);
             horasTrabajadasCalculator.calcular(jornada);
 
@@ -144,6 +166,22 @@ public class MarcacionService extends CrudService<Marcacion, MarcacionRepository
         if (marcacion.getFechaSalida() != null)
             return marcacion.getFechaSalida();
         return LocalDateTime.now();
+    }
+
+    private boolean marcacionVinculadaAJornada(Jornada jornada, Marcacion marcacion) {
+        if (marcacion.getTipo() == TipoMarcacion.ENTRADA) {
+            return (jornada.getMarcacionEntrada() != null
+                    && jornada.getMarcacionEntrada().getId().equals(marcacion.getId()))
+                    || (jornada.getMarcacionEntradaAlmuerzo() != null
+                            && jornada.getMarcacionEntradaAlmuerzo().getId().equals(marcacion.getId()));
+        }
+        if (marcacion.getTipo() == TipoMarcacion.SALIDA) {
+            return (jornada.getMarcacionSalida() != null
+                    && jornada.getMarcacionSalida().getId().equals(marcacion.getId()))
+                    || (jornada.getMarcacionSalidaAlmuerzo() != null
+                            && jornada.getMarcacionSalidaAlmuerzo().getId().equals(marcacion.getId()));
+        }
+        return false;
     }
 
     private void aplicarHorarioAJornada(Jornada jornada, Horario horario) {

--- a/src/main/java/com/franco/dev/service/administrativo/MarcacionService.java
+++ b/src/main/java/com/franco/dev/service/administrativo/MarcacionService.java
@@ -35,6 +35,7 @@ public class MarcacionService extends CrudService<Marcacion, MarcacionRepository
     private final HorasTrabajadasCalculator horasTrabajadasCalculator;
     private final AlmuerzoProcessor almuerzoProcessor;
     private final JornadaFactory jornadaFactory;
+    private final JornadaMarcacionRules jornadaMarcacionRules;
 
     @Override
     public MarcacionRepository getRepository() {
@@ -70,6 +71,7 @@ public class MarcacionService extends CrudService<Marcacion, MarcacionRepository
     @Transactional(isolation = Isolation.SERIALIZABLE)
     public Marcacion save(Marcacion marcacion) {
         prepararMarcacion(marcacion);
+        validarMarcacion(marcacion);
 
         // Guardamos el estado transiente antes de la persistencia
         Boolean esSalidaAlmuerzo = marcacion.getEsSalidaAlmuerzo();
@@ -154,9 +156,24 @@ public class MarcacionService extends CrudService<Marcacion, MarcacionRepository
 
             jornadaService.save(jornada);
 
+        } catch (IllegalStateException e) {
+            throw e;
         } catch (Exception e) {
             log.error("Error crítico procesando jornada para marcación ID: {} en sucursal: {}",
                     marcacion.getId(), marcacion.getSucursalId(), e);
+            throw new RuntimeException("Error procesando jornada de marcación", e);
+        }
+    }
+
+    private void validarMarcacion(Marcacion marcacion) {
+        if (marcacion.getUsuario() == null || marcacion.getUsuario().getId() == null) {
+            return;
+        }
+        java.time.LocalDate fechaMarcacion = obtenerFechaReferencia(marcacion).toLocalDate();
+        if (marcacion.getTipo() == TipoMarcacion.ENTRADA) {
+            jornadaMarcacionRules.validarEntrada(marcacion.getUsuario().getId(), fechaMarcacion);
+        } else if (marcacion.getTipo() == TipoMarcacion.SALIDA) {
+            jornadaMarcacionRules.validarSalida(marcacion.getUsuario().getId(), fechaMarcacion);
         }
     }
 

--- a/src/main/java/com/franco/dev/service/administrativo/helper/JornadaMarcacionResolver.java
+++ b/src/main/java/com/franco/dev/service/administrativo/helper/JornadaMarcacionResolver.java
@@ -22,6 +22,7 @@ public class JornadaMarcacionResolver {
 
     private final JornadaService jornadaService;
     private final JornadaFactory jornadaFactory;
+    private final JornadaMarcacionRules jornadaMarcacionRules;
 
     public Jornada resolver(Marcacion marcacion, LocalDate fechaReferencia) {
         if (marcacion.getTipo() == TipoMarcacion.SALIDA) {
@@ -33,6 +34,8 @@ public class JornadaMarcacionResolver {
 
     private Jornada resolverSalida(Marcacion marcacion, LocalDate fechaReferencia) {
         Long usuarioId = marcacion.getUsuario().getId();
+
+        jornadaMarcacionRules.validarSalida(usuarioId, fechaReferencia);
 
         Optional<Jornada> jornadaNocturnaAbierta = jornadaService.findIncompletaSinSalidaNocturnaParaSalida(
                 usuarioId, fechaReferencia);
@@ -54,19 +57,18 @@ public class JornadaMarcacionResolver {
     private Jornada resolverEntrada(Marcacion marcacion, LocalDate fechaReferencia) {
         Long usuarioId = marcacion.getUsuario().getId();
 
-        Optional<Jornada> jornadaCruzaMedianoche = jornadaService.findIncompletaSinSalidaNocturnaParaSalida(
+        jornadaMarcacionRules.validarEntrada(usuarioId, fechaReferencia);
+
+        Optional<Jornada> jornadaNocturna = jornadaService.findIncompletaSinSalidaNocturnaParaSalida(
                 usuarioId, fechaReferencia);
-        if (jornadaCruzaMedianoche.isPresent()) {
-            Jornada abierta = jornadaCruzaMedianoche.get();
-            if (abierta.getMarcacionSalidaAlmuerzo() != null && abierta.getMarcacionEntradaAlmuerzo() == null) {
-                return abierta;
-            }
+        if (jornadaNocturna.isPresent() && jornadaMarcacionRules.esRetornoAlmuerzoPendiente(jornadaNocturna.get())) {
+            return jornadaNocturna.get();
         }
 
-        Optional<Jornada> jornadaAbiertaConEntrada = jornadaService.findJornadaAbiertaConEntradaSinSalida(
+        Optional<Jornada> jornadaHoy = jornadaService.findJornadaAbiertaConEntradaSinSalida(
                 usuarioId, fechaReferencia);
-        if (jornadaAbiertaConEntrada.isPresent()) {
-            return jornadaAbiertaConEntrada.get();
+        if (jornadaHoy.isPresent() && jornadaMarcacionRules.esRetornoAlmuerzoPendiente(jornadaHoy.get())) {
+            return jornadaHoy.get();
         }
 
         Optional<Jornada> jornadaAbiertaSinEntrada = jornadaService.findJornadaAbiertaSinEntrada(

--- a/src/main/java/com/franco/dev/service/administrativo/helper/JornadaMarcacionResolver.java
+++ b/src/main/java/com/franco/dev/service/administrativo/helper/JornadaMarcacionResolver.java
@@ -58,7 +58,7 @@ public class JornadaMarcacionResolver {
                 usuarioId, fechaReferencia);
         if (jornadaCruzaMedianoche.isPresent()) {
             Jornada abierta = jornadaCruzaMedianoche.get();
-            if (abierta.getMarcacionEntrada() != null && abierta.getMarcacionSalida() == null) {
+            if (abierta.getMarcacionSalidaAlmuerzo() != null && abierta.getMarcacionEntradaAlmuerzo() == null) {
                 return abierta;
             }
         }

--- a/src/main/java/com/franco/dev/service/administrativo/helper/JornadaMarcacionRules.java
+++ b/src/main/java/com/franco/dev/service/administrativo/helper/JornadaMarcacionRules.java
@@ -1,0 +1,175 @@
+package com.franco.dev.service.administrativo.helper;
+
+import com.franco.dev.domain.administrativo.EstadoMarcacionUsuario;
+import com.franco.dev.domain.administrativo.Jornada;
+import com.franco.dev.domain.administrativo.enums.AccionMarcacionPendiente;
+import com.franco.dev.domain.administrativo.enums.EstadoJornada;
+import com.franco.dev.domain.administrativo.enums.Turno;
+import com.franco.dev.service.administrativo.JornadaService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class JornadaMarcacionRules {
+
+    private final JornadaService jornadaService;
+
+    /**
+     * Turnos NOCHE/MADRUGADA o horarios cuya salida es anterior a la entrada (cruzan medianoche).
+     */
+    public boolean cruzaMedianoche(Jornada jornada) {
+        if (jornada == null) {
+            return false;
+        }
+        if (jornada.getTurno() == Turno.NOCHE || jornada.getTurno() == Turno.MADRUGADA) {
+            return true;
+        }
+        if (jornada.getHoraEntradaHorario() != null && jornada.getHoraSalidaHorario() != null) {
+            return jornada.getHoraSalidaHorario().isBefore(jornada.getHoraEntradaHorario());
+        }
+        return false;
+    }
+
+    /**
+     * Jornadas de turno DIA vencen a medianoche. NOCHE/MADRUGADA permanecen activas al día siguiente
+     * mientras no tengan salida definitiva.
+     */
+    public boolean esJornadaActiva(Jornada jornada, LocalDate fechaConsulta) {
+        if (jornada == null
+                || jornada.getEstado() != EstadoJornada.INCOMPLETO
+                || jornada.getMarcacionSalida() != null) {
+            return false;
+        }
+        if (!jornada.getFecha().isBefore(fechaConsulta)) {
+            return true;
+        }
+        return cruzaMedianoche(jornada) && jornada.getMarcacionEntrada() != null;
+    }
+
+    public boolean esRetornoAlmuerzoPendiente(Jornada jornada) {
+        return jornada != null
+                && jornada.getMarcacionEntrada() != null
+                && jornada.getMarcacionSalidaAlmuerzo() != null
+                && jornada.getMarcacionEntradaAlmuerzo() == null;
+    }
+
+    public boolean esJornadaAbiertaSinSalida(Jornada jornada) {
+        return jornada != null
+                && jornada.getEstado() == EstadoJornada.INCOMPLETO
+                && jornada.getMarcacionEntrada() != null
+                && jornada.getMarcacionSalida() == null;
+    }
+
+    public void validarEntrada(Long usuarioId, LocalDate fechaMarcacion) {
+        Optional<Jornada> jornadaHoy = jornadaService.findJornadaAbiertaConEntradaSinSalida(usuarioId, fechaMarcacion);
+        if (jornadaHoy.isPresent()) {
+            if (esRetornoAlmuerzoPendiente(jornadaHoy.get())) {
+                return;
+            }
+            throw new IllegalStateException(
+                    "Ya registró entrada en la jornada del día. Debe marcar salida antes de una nueva entrada.");
+        }
+
+        Optional<Jornada> jornadaNocturna = jornadaService.findIncompletaSinSalidaNocturnaParaSalida(
+                usuarioId, fechaMarcacion);
+        if (jornadaNocturna.isPresent()) {
+            Jornada jornada = jornadaNocturna.get();
+            if (jornada.getFecha().isBefore(fechaMarcacion)) {
+                if (esRetornoAlmuerzoPendiente(jornada)) {
+                    return;
+                }
+                if (jornada.getMarcacionEntrada() != null) {
+                    throw new IllegalStateException(
+                            "Tiene una jornada nocturna o madrugada abierta. "
+                                    + "Debe marcar salida antes de registrar una nueva entrada.");
+                }
+            }
+        }
+    }
+
+    public void validarSalida(Long usuarioId, LocalDate fechaMarcacion) {
+        Optional<Jornada> jornadaNocturna = jornadaService.findIncompletaSinSalidaNocturnaParaSalida(
+                usuarioId, fechaMarcacion);
+        if (jornadaNocturna.isPresent()) {
+            return;
+        }
+
+        Optional<Jornada> jornadaAbierta = jornadaService.findJornadaAbiertaConEntradaSinSalida(
+                usuarioId, fechaMarcacion);
+        if (jornadaAbierta.isPresent()) {
+            return;
+        }
+
+        throw new IllegalStateException("No existe una jornada abierta para registrar la salida");
+    }
+
+    public AccionMarcacionPendiente resolverAccionPendiente(Jornada jornada, LocalDate fechaConsulta) {
+        if (jornada == null
+                || !esJornadaActiva(jornada, fechaConsulta)
+                || jornada.getEstado() == EstadoJornada.NORMAL
+                || jornada.getMarcacionSalida() != null) {
+            return AccionMarcacionPendiente.ENTRADA;
+        }
+        if (jornada.getMarcacionEntrada() == null) {
+            return AccionMarcacionPendiente.ENTRADA;
+        }
+        if (jornada.getMarcacionSalidaAlmuerzo() == null) {
+            return AccionMarcacionPendiente.SALIDA;
+        }
+        if (jornada.getMarcacionEntradaAlmuerzo() == null) {
+            return AccionMarcacionPendiente.RETORNO_ALMUERZO;
+        }
+        return AccionMarcacionPendiente.SALIDA_DEFINITIVA;
+    }
+
+    public Jornada seleccionarJornadaRelevante(List<Jornada> jornadas, LocalDate fechaConsulta) {
+        if (jornadas == null || jornadas.isEmpty()) {
+            return null;
+        }
+
+        List<Jornada> abiertas = jornadas.stream()
+                .filter(this::esJornadaAbiertaSinSalida)
+                .collect(Collectors.toList());
+
+        if (!abiertas.isEmpty()) {
+            List<Jornada> nocturnas = abiertas.stream()
+                    .filter(this::cruzaMedianoche)
+                    .collect(Collectors.toList());
+            List<Jornada> candidatas = nocturnas.isEmpty() ? abiertas : nocturnas;
+            return candidatas.stream()
+                    .max(Comparator.comparing(Jornada::getId))
+                    .orElse(null);
+        }
+
+        return jornadas.stream()
+                .max(Comparator
+                        .comparing((Jornada j) -> j.getFecha().equals(fechaConsulta))
+                        .thenComparing(Jornada::getId))
+                .orElse(null);
+    }
+
+    public EstadoMarcacionUsuario construirEstado(List<Jornada> jornadas, LocalDate fechaConsulta) {
+        Jornada relevante = seleccionarJornadaRelevante(jornadas, fechaConsulta);
+        AccionMarcacionPendiente accion = resolverAccionPendiente(relevante, fechaConsulta);
+        boolean activa = relevante != null && esJornadaActiva(relevante, fechaConsulta);
+
+        EstadoMarcacionUsuario estado = new EstadoMarcacionUsuario();
+        estado.setJornadaRelevante(relevante);
+        estado.setAccionPendiente(accion);
+        estado.setEstaEnJornada(activa && accion != AccionMarcacionPendiente.ENTRADA);
+        estado.setPuedeMarcarEntrada(accion == AccionMarcacionPendiente.ENTRADA);
+        estado.setPuedeMarcarSalida(
+                accion == AccionMarcacionPendiente.SALIDA
+                        || accion == AccionMarcacionPendiente.SALIDA_DEFINITIVA);
+        estado.setPuedeMarcarSalidaAlmuerzo(accion == AccionMarcacionPendiente.SALIDA);
+        estado.setPuedeMarcarEntradaAlmuerzo(accion == AccionMarcacionPendiente.RETORNO_ALMUERZO);
+        return estado;
+    }
+}

--- a/src/main/java/com/franco/dev/service/personas/EmbeddingGaleriaService.java
+++ b/src/main/java/com/franco/dev/service/personas/EmbeddingGaleriaService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.franco.dev.graphql.personas.dto.EmbeddingGaleriaDto;
 import com.franco.dev.graphql.personas.dto.EmbeddingGaleriaItemDto;
+import com.franco.dev.service.personas.dto.IncorporarCapturaMarcacionResult;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -108,31 +109,34 @@ public class EmbeddingGaleriaService {
 
     /**
      * Incorpora un embedding de marcación verificada a la galería existente.
-     * Solo agrega capturas de calidad que confirmen identidad y aporten diversidad visual.
-     *
-     * @return galería actualizada o null si la captura no cumple criterios de calidad
      */
-    public EmbeddingGaleriaDto incorporarCapturaMarcacion(
+    public IncorporarCapturaMarcacionResult incorporarCapturaMarcacion(
             EmbeddingGaleriaDto galeria,
             List<Double> nuevoEmbedding,
             Double score) {
         if (galeria == null || nuevoEmbedding == null || nuevoEmbedding.isEmpty()) {
-            return null;
+            return IncorporarCapturaMarcacionResult.rechazadoSimilitud(
+                    "No se encontró galería facial válida para actualizar.");
         }
         double scoreCaptura = score != null ? score : 0.0;
         if (scoreCaptura < MIN_SCORE_MARCACION) {
-            return null;
+            return IncorporarCapturaMarcacionResult.rechazadoScore(
+                    "La captura no alcanzó la calidad mínima (70%) para actualizar el perfil facial.");
         }
 
         double[] candidato = toArray(nuevoEmbedding);
         double[] master = toArray(galeria.getMaster());
         if (master.length == 0 || candidato.length != master.length) {
-            return null;
+            return IncorporarCapturaMarcacionResult.rechazadoSimilitud(
+                    "El perfil facial registrado no es compatible con esta captura.");
         }
 
         double similitudMaster = cosineSimilarity(candidato, master);
         if (similitudMaster < MIN_SIMILITUD_MASTER) {
-            return null;
+            int pct = (int) Math.round(similitudMaster * 100);
+            int umbralPct = (int) Math.round(MIN_SIMILITUD_MASTER * 100);
+            return IncorporarCapturaMarcacionResult.rechazadoSimilitud(
+                    "Similitud insuficiente (" + pct + "%). Se requiere al menos " + umbralPct + "%.");
         }
 
         EmbeddingGaleriaDto actualizada = normalizar(galeria);
@@ -141,16 +145,12 @@ public class EmbeddingGaleriaService {
         }
 
         int indiceDuplicado = -1;
-        double maxSimilitudExistente = -1.0;
         for (int i = 0; i < actualizada.getGallery().size(); i++) {
             EmbeddingGaleriaItemDto item = actualizada.getGallery().get(i);
             if (item == null || item.getEmbedding() == null) {
                 continue;
             }
             double similitud = cosineSimilarity(candidato, toArray(item.getEmbedding()));
-            if (similitud > maxSimilitudExistente) {
-                maxSimilitudExistente = similitud;
-            }
             if (similitud >= MAX_SIMILITUD_DUPLICADO) {
                 indiceDuplicado = i;
                 break;
@@ -161,7 +161,8 @@ public class EmbeddingGaleriaService {
             EmbeddingGaleriaItemDto existente = actualizada.getGallery().get(indiceDuplicado);
             double scoreExistente = existente.getScore() != null ? existente.getScore() : 0.0;
             if (scoreCaptura <= scoreExistente) {
-                return null;
+                return IncorporarCapturaMarcacionResult.rechazadoScore(
+                        "Ya existe una captura similar con igual o mejor calidad en el perfil.");
             }
             existente.setEmbedding(new ArrayList<>(nuevoEmbedding));
             existente.setScore(scoreCaptura);
@@ -175,7 +176,7 @@ public class EmbeddingGaleriaService {
         }
 
         actualizada.setMaster(recalcularMaster(actualizada.getGallery()));
-        return actualizada;
+        return IncorporarCapturaMarcacionResult.ok(actualizada);
     }
 
     private void podarGaleria(EmbeddingGaleriaDto galeria) {

--- a/src/main/java/com/franco/dev/service/personas/EmbeddingGaleriaService.java
+++ b/src/main/java/com/franco/dev/service/personas/EmbeddingGaleriaService.java
@@ -13,6 +13,13 @@ import java.util.List;
 @Service
 public class EmbeddingGaleriaService {
 
+    private static final double MIN_SCORE_MARCACION = 0.7;
+    private static final double MIN_SIMILITUD_MASTER = 0.55;
+    private static final double MAX_SIMILITUD_DUPLICADO = 0.93;
+    private static final int MAX_GALLERY_SIZE = 15;
+    private static final double SCORE_MINIMO_MASTER = 0.5;
+    private static final java.util.Set<String> POSES_ENROLLMENT = java.util.Set.of("left", "right", "front");
+
     private final ObjectMapper objectMapper;
 
     public EmbeddingGaleriaService() {
@@ -97,6 +104,168 @@ public class EmbeddingGaleriaService {
             }
         }
         return maxima < 0 ? 0.0 : maxima;
+    }
+
+    /**
+     * Incorpora un embedding de marcación verificada a la galería existente.
+     * Solo agrega capturas de calidad que confirmen identidad y aporten diversidad visual.
+     *
+     * @return galería actualizada o null si la captura no cumple criterios de calidad
+     */
+    public EmbeddingGaleriaDto incorporarCapturaMarcacion(
+            EmbeddingGaleriaDto galeria,
+            List<Double> nuevoEmbedding,
+            Double score) {
+        if (galeria == null || nuevoEmbedding == null || nuevoEmbedding.isEmpty()) {
+            return null;
+        }
+        double scoreCaptura = score != null ? score : 0.0;
+        if (scoreCaptura < MIN_SCORE_MARCACION) {
+            return null;
+        }
+
+        double[] candidato = toArray(nuevoEmbedding);
+        double[] master = toArray(galeria.getMaster());
+        if (master.length == 0 || candidato.length != master.length) {
+            return null;
+        }
+
+        double similitudMaster = cosineSimilarity(candidato, master);
+        if (similitudMaster < MIN_SIMILITUD_MASTER) {
+            return null;
+        }
+
+        EmbeddingGaleriaDto actualizada = normalizar(galeria);
+        if (actualizada.getGallery() == null) {
+            actualizada.setGallery(new ArrayList<>());
+        }
+
+        int indiceDuplicado = -1;
+        double maxSimilitudExistente = -1.0;
+        for (int i = 0; i < actualizada.getGallery().size(); i++) {
+            EmbeddingGaleriaItemDto item = actualizada.getGallery().get(i);
+            if (item == null || item.getEmbedding() == null) {
+                continue;
+            }
+            double similitud = cosineSimilarity(candidato, toArray(item.getEmbedding()));
+            if (similitud > maxSimilitudExistente) {
+                maxSimilitudExistente = similitud;
+            }
+            if (similitud >= MAX_SIMILITUD_DUPLICADO) {
+                indiceDuplicado = i;
+                break;
+            }
+        }
+
+        if (indiceDuplicado >= 0) {
+            EmbeddingGaleriaItemDto existente = actualizada.getGallery().get(indiceDuplicado);
+            double scoreExistente = existente.getScore() != null ? existente.getScore() : 0.0;
+            if (scoreCaptura <= scoreExistente) {
+                return null;
+            }
+            existente.setEmbedding(new ArrayList<>(nuevoEmbedding));
+            existente.setScore(scoreCaptura);
+        } else {
+            EmbeddingGaleriaItemDto item = new EmbeddingGaleriaItemDto();
+            item.setPose("marcacion-" + System.currentTimeMillis());
+            item.setEmbedding(new ArrayList<>(nuevoEmbedding));
+            item.setScore(scoreCaptura);
+            actualizada.getGallery().add(item);
+            podarGaleria(actualizada);
+        }
+
+        actualizada.setMaster(recalcularMaster(actualizada.getGallery()));
+        return actualizada;
+    }
+
+    private void podarGaleria(EmbeddingGaleriaDto galeria) {
+        if (galeria.getGallery() == null || galeria.getGallery().size() <= MAX_GALLERY_SIZE) {
+            return;
+        }
+        while (galeria.getGallery().size() > MAX_GALLERY_SIZE) {
+            int indiceRemover = -1;
+            double peorScore = Double.MAX_VALUE;
+            for (int i = 0; i < galeria.getGallery().size(); i++) {
+                EmbeddingGaleriaItemDto item = galeria.getGallery().get(i);
+                if (item == null) {
+                    indiceRemover = i;
+                    break;
+                }
+                String pose = item.getPose() != null ? item.getPose().toLowerCase() : "";
+                if (POSES_ENROLLMENT.contains(pose)) {
+                    continue;
+                }
+                double itemScore = item.getScore() != null ? item.getScore() : 0.0;
+                if (itemScore < peorScore) {
+                    peorScore = itemScore;
+                    indiceRemover = i;
+                }
+            }
+            if (indiceRemover < 0) {
+                break;
+            }
+            galeria.getGallery().remove(indiceRemover);
+        }
+    }
+
+    private List<Double> recalcularMaster(List<EmbeddingGaleriaItemDto> gallery) {
+        if (gallery == null || gallery.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        List<EmbeddingGaleriaItemDto> validas = new ArrayList<>();
+        for (EmbeddingGaleriaItemDto item : gallery) {
+            if (item == null || item.getEmbedding() == null || item.getEmbedding().isEmpty()) {
+                continue;
+            }
+            double score = item.getScore() != null ? item.getScore() : 0.0;
+            if (score >= SCORE_MINIMO_MASTER) {
+                validas.add(item);
+            }
+        }
+        if (validas.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        int dim = validas.get(0).getEmbedding().size();
+        double[] promedio = new double[dim];
+        double pesoTotal = 0.0;
+
+        for (EmbeddingGaleriaItemDto item : validas) {
+            double peso = item.getScore() != null ? item.getScore() : 1.0;
+            double[] vector = toArray(item.getEmbedding());
+            if (vector.length != dim) {
+                continue;
+            }
+            pesoTotal += peso;
+            for (int i = 0; i < dim; i++) {
+                promedio[i] += vector[i] * peso;
+            }
+        }
+        if (pesoTotal <= 0) {
+            return new ArrayList<>();
+        }
+
+        for (int i = 0; i < dim; i++) {
+            promedio[i] /= pesoTotal;
+        }
+
+        double magnitud = 0.0;
+        for (double val : promedio) {
+            magnitud += val * val;
+        }
+        magnitud = Math.sqrt(magnitud);
+        if (magnitud > 0) {
+            for (int i = 0; i < dim; i++) {
+                promedio[i] /= magnitud;
+            }
+        }
+
+        List<Double> master = new ArrayList<>(dim);
+        for (double val : promedio) {
+            master.add(val);
+        }
+        return master;
     }
 
     private EmbeddingGaleriaDto normalizar(EmbeddingGaleriaDto galeria) {

--- a/src/main/java/com/franco/dev/service/personas/EmbeddingGaleriaService.java
+++ b/src/main/java/com/franco/dev/service/personas/EmbeddingGaleriaService.java
@@ -1,0 +1,140 @@
+package com.franco.dev.service.personas;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.franco.dev.graphql.personas.dto.EmbeddingGaleriaDto;
+import com.franco.dev.graphql.personas.dto.EmbeddingGaleriaItemDto;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Service
+public class EmbeddingGaleriaService {
+
+    private final ObjectMapper objectMapper;
+
+    public EmbeddingGaleriaService() {
+        this.objectMapper = new ObjectMapper();
+    }
+
+    public EmbeddingGaleriaDto parsearDesdeJson(String json) {
+        if (json == null || json.isBlank()) {
+            return null;
+        }
+        try {
+            JsonNode root = objectMapper.readTree(json);
+            if (root.isObject()) {
+                EmbeddingGaleriaDto galeria = objectMapper.treeToValue(root, EmbeddingGaleriaDto.class);
+                return normalizar(galeria);
+            }
+        } catch (Exception ignored) {
+            return null;
+        }
+        return null;
+    }
+
+    public String serializar(EmbeddingGaleriaDto galeria) {
+        if (galeria == null) {
+            return null;
+        }
+        try {
+            return objectMapper.writeValueAsString(normalizar(galeria));
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public String normalizarJsonEntrada(String embeddingGaleriaJson) {
+        EmbeddingGaleriaDto galeria = parsearDesdeJson(embeddingGaleriaJson);
+        if (galeria == null || galeria.getMaster() == null || galeria.getMaster().isEmpty()) {
+            throw new IllegalArgumentException("embeddingGaleriaJson inválido o sin master");
+        }
+        if (galeria.getGallery() == null || galeria.getGallery().isEmpty()) {
+            throw new IllegalArgumentException("embeddingGaleriaJson debe incluir al menos un item en gallery");
+        }
+        return serializar(galeria);
+    }
+
+    public List<double[]> extraerVectores(EmbeddingGaleriaDto galeria) {
+        if (galeria == null) {
+            return Collections.emptyList();
+        }
+        List<double[]> vectores = new ArrayList<>();
+        double[] master = toArray(galeria.getMaster());
+        if (master.length > 0) {
+            vectores.add(master);
+        }
+        if (galeria.getGallery() != null) {
+            for (EmbeddingGaleriaItemDto item : galeria.getGallery()) {
+                if (item == null || item.getEmbedding() == null) {
+                    continue;
+                }
+                double[] vector = toArray(item.getEmbedding());
+                if (vector.length > 0) {
+                    vectores.add(vector);
+                }
+            }
+        }
+        return vectores;
+    }
+
+    public List<double[]> extraerVectoresDesdeJson(String json) {
+        return extraerVectores(parsearDesdeJson(json));
+    }
+
+    public double calcularMaximaSimilitud(List<Double> consulta, List<double[]> referencias) {
+        if (consulta == null || consulta.isEmpty() || referencias == null || referencias.isEmpty()) {
+            return 0.0;
+        }
+        double[] query = toArray(consulta);
+        double maxima = -1.0;
+        for (double[] referencia : referencias) {
+            double similitud = cosineSimilarity(query, referencia);
+            if (similitud > maxima) {
+                maxima = similitud;
+            }
+        }
+        return maxima < 0 ? 0.0 : maxima;
+    }
+
+    private EmbeddingGaleriaDto normalizar(EmbeddingGaleriaDto galeria) {
+        if (galeria.getMaster() == null) {
+            galeria.setMaster(new ArrayList<>());
+        }
+        if (galeria.getGallery() == null) {
+            galeria.setGallery(new ArrayList<>());
+        }
+        return galeria;
+    }
+
+    private static double[] toArray(List<Double> list) {
+        if (list == null || list.isEmpty()) {
+            return new double[0];
+        }
+        double[] arr = new double[list.size()];
+        for (int i = 0; i < list.size(); i++) {
+            arr[i] = list.get(i) != null ? list.get(i) : 0.0;
+        }
+        return arr;
+    }
+
+    private static double cosineSimilarity(double[] v1, double[] v2) {
+        if (v1.length != v2.length || v1.length == 0) {
+            return 0.0;
+        }
+        double dot = 0.0;
+        double normA = 0.0;
+        double normB = 0.0;
+        for (int i = 0; i < v1.length; i++) {
+            dot += v1[i] * v2[i];
+            normA += v1[i] * v1[i];
+            normB += v2[i] * v2[i];
+        }
+        if (normA == 0 || normB == 0) {
+            return 0.0;
+        }
+        return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+    }
+}

--- a/src/main/java/com/franco/dev/service/personas/UsuarioEmbeddingCacheService.java
+++ b/src/main/java/com/franco/dev/service/personas/UsuarioEmbeddingCacheService.java
@@ -101,7 +101,7 @@ public class UsuarioEmbeddingCacheService {
             }
         }
 
-        if (best != null && maxSimilarity > MATCH_THRESHOLD) {
+        if (best != null) {
             return new UsuarioSimilitudResult(best.usuario, maxSimilarity);
         }
         return null;

--- a/src/main/java/com/franco/dev/service/personas/UsuarioEmbeddingCacheService.java
+++ b/src/main/java/com/franco/dev/service/personas/UsuarioEmbeddingCacheService.java
@@ -1,7 +1,5 @@
 package com.franco.dev.service.personas;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.franco.dev.domain.personas.Usuario;
 import com.franco.dev.graphql.personas.UsuarioSimilitudResult;
 import com.franco.dev.repository.personas.UsuarioRepository;
@@ -15,8 +13,7 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
- * Caché en memoria de embeddings faciales de usuarios activos.
- * Evita cargar y parsear JSON en cada búsqueda por similitud.
+ * Caché en memoria de galerías faciales de usuarios activos.
  */
 @Service
 @Slf4j
@@ -25,12 +22,14 @@ public class UsuarioEmbeddingCacheService {
     private static final double MATCH_THRESHOLD = 0.55;
 
     private final UsuarioRepository usuarioRepository;
-    private final ObjectMapper objectMapper;
+    private final EmbeddingGaleriaService embeddingGaleriaService;
     private final CopyOnWriteArrayList<CachedEntry> entries = new CopyOnWriteArrayList<>();
 
-    public UsuarioEmbeddingCacheService(UsuarioRepository usuarioRepository) {
+    public UsuarioEmbeddingCacheService(
+            UsuarioRepository usuarioRepository,
+            EmbeddingGaleriaService embeddingGaleriaService) {
         this.usuarioRepository = usuarioRepository;
-        this.objectMapper = new ObjectMapper();
+        this.embeddingGaleriaService = embeddingGaleriaService;
     }
 
     @PostConstruct
@@ -46,33 +45,35 @@ public class UsuarioEmbeddingCacheService {
         }
         entries.clear();
         entries.addAll(loaded);
-        log.info("Caché de embeddings faciales: {} usuarios activos con embedding", entries.size());
+        log.info("Caché de embeddings faciales: {} usuarios activos con galería", entries.size());
     }
 
-    public void refreshUsuario(Long usuarioId) {
-        refreshUsuario(usuarioId, null);
-    }
-
-    /**
-     * Actualiza la entrada en caché del usuario. Si se provee embedding, lo usa directamente
-     * (evita leer datos obsoletos del persistence context de JPA).
-     */
-    public void refreshUsuario(Long usuarioId, List<Double> embedding) {
+    public void refreshUsuario(Long usuarioId, String embeddingJson) {
         if (usuarioId == null) {
             return;
         }
         entries.removeIf(e -> e.usuarioId.equals(usuarioId));
 
-        usuarioRepository.findById(usuarioId).ifPresent(usuario -> {
-            if (!Boolean.TRUE.equals(usuario.getActivo())) {
+        if (embeddingJson != null && !embeddingJson.isBlank()) {
+            com.franco.dev.graphql.personas.dto.EmbeddingGaleriaDto galeria = embeddingGaleriaService
+                    .parsearDesdeJson(embeddingJson);
+            if (galeria == null || galeria.getGallery() == null || galeria.getGallery().isEmpty()) {
                 return;
             }
-            if (embedding != null && !embedding.isEmpty()) {
-                double[] arr = toArray(embedding);
-                if (arr.length > 0) {
-                    entries.add(new CachedEntry(usuarioId, arr, usuario));
-                    log.debug("Caché de embedding actualizada para usuario {}", usuarioId);
-                }
+            List<double[]> vectores = embeddingGaleriaService.extraerVectores(galeria);
+            if (!vectores.isEmpty()) {
+                usuarioRepository.findById(usuarioId).ifPresent(usuario -> {
+                    if (Boolean.TRUE.equals(usuario.getActivo())) {
+                        entries.add(new CachedEntry(usuarioId, vectores, usuario));
+                        log.debug("Caché de galería facial actualizada para usuario {}", usuarioId);
+                    }
+                });
+            }
+            return;
+        }
+
+        usuarioRepository.findById(usuarioId).ifPresent(usuario -> {
+            if (!Boolean.TRUE.equals(usuario.getActivo())) {
                 return;
             }
             parseEntry(usuario).ifPresent(entries::add);
@@ -84,7 +85,6 @@ public class UsuarioEmbeddingCacheService {
             return null;
         }
 
-        double[] query = toArray(queryEmbedding);
         List<Integer> excluded = excludeIds != null ? excludeIds : Collections.emptyList();
 
         CachedEntry best = null;
@@ -94,7 +94,7 @@ public class UsuarioEmbeddingCacheService {
             if (excluded.contains(entry.usuarioId.intValue())) {
                 continue;
             }
-            double similarity = cosineSimilarity(query, entry.embedding);
+            double similarity = embeddingGaleriaService.calcularMaximaSimilitud(queryEmbedding, entry.vectores);
             if (similarity > maxSimilarity) {
                 maxSimilarity = similarity;
                 best = entry;
@@ -116,57 +116,25 @@ public class UsuarioEmbeddingCacheService {
             return java.util.Optional.empty();
         }
         String json = usuario.getPersona().getEmbedding();
-        if (json == null || json.isEmpty()) {
+        com.franco.dev.graphql.personas.dto.EmbeddingGaleriaDto galeria = embeddingGaleriaService.parsearDesdeJson(json);
+        if (galeria == null || galeria.getGallery() == null || galeria.getGallery().isEmpty()) {
             return java.util.Optional.empty();
         }
-        try {
-            List<Double> list = objectMapper.readValue(json, new TypeReference<List<Double>>() {
-            });
-            double[] arr = toArray(list);
-            if (arr.length == 0) {
-                return java.util.Optional.empty();
-            }
-            return java.util.Optional.of(new CachedEntry(usuario.getId(), arr, usuario));
-        } catch (Exception e) {
-            log.warn("Embedding inválido para usuario {}: {}", usuario.getId(), e.getMessage());
+        List<double[]> vectores = embeddingGaleriaService.extraerVectores(galeria);
+        if (vectores.isEmpty()) {
             return java.util.Optional.empty();
         }
-    }
-
-    private static double[] toArray(List<Double> list) {
-        double[] arr = new double[list.size()];
-        for (int i = 0; i < list.size(); i++) {
-            arr[i] = list.get(i) != null ? list.get(i) : 0.0;
-        }
-        return arr;
-    }
-
-    private static double cosineSimilarity(double[] v1, double[] v2) {
-        if (v1.length != v2.length || v1.length == 0) {
-            return 0.0;
-        }
-        double dot = 0.0;
-        double normA = 0.0;
-        double normB = 0.0;
-        for (int i = 0; i < v1.length; i++) {
-            dot += v1[i] * v2[i];
-            normA += v1[i] * v1[i];
-            normB += v2[i] * v2[i];
-        }
-        if (normA == 0 || normB == 0) {
-            return 0.0;
-        }
-        return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+        return java.util.Optional.of(new CachedEntry(usuario.getId(), vectores, usuario));
     }
 
     private static final class CachedEntry {
         private final Long usuarioId;
-        private final double[] embedding;
+        private final List<double[]> vectores;
         private final Usuario usuario;
 
-        private CachedEntry(Long usuarioId, double[] embedding, Usuario usuario) {
+        private CachedEntry(Long usuarioId, List<double[]> vectores, Usuario usuario) {
             this.usuarioId = usuarioId;
-            this.embedding = embedding;
+            this.vectores = vectores;
             this.usuario = usuario;
         }
     }

--- a/src/main/java/com/franco/dev/service/personas/UsuarioService.java
+++ b/src/main/java/com/franco/dev/service/personas/UsuarioService.java
@@ -1,9 +1,12 @@
 package com.franco.dev.service.personas;
 
+import com.franco.dev.domain.personas.Persona;
 import com.franco.dev.domain.personas.Role;
 import com.franco.dev.domain.personas.Usuario;
 import com.franco.dev.domain.personas.UsuarioRole;
-import com.franco.dev.domain.personas.Persona;
+import com.franco.dev.domain.personas.enums.ResultadoIncorporacionEmbedding;
+import com.franco.dev.graphql.personas.IncorporarEmbeddingMarcacionResult;
+import com.franco.dev.service.personas.dto.IncorporarCapturaMarcacionResult;
 import com.franco.dev.repository.personas.PersonaRepository;
 import com.franco.dev.repository.personas.RoleRepository;
 import com.franco.dev.repository.personas.UsuarioRepository;
@@ -218,36 +221,44 @@ public class UsuarioService extends CrudService<Usuario, UsuarioRepository, Long
         return embeddingCacheService.findBestMatch(embeddingInfo, excludeIds);
     }
 
-    public Boolean incorporarEmbeddingMarcacion(Long usuarioId, List<Double> embedding, Double score) {
+    public IncorporarEmbeddingMarcacionResult incorporarEmbeddingMarcacion(Long usuarioId, List<Double> embedding, Double score) {
         if (usuarioId == null || embedding == null || embedding.isEmpty()) {
-            return false;
+            return new IncorporarEmbeddingMarcacionResult(
+                    ResultadoIncorporacionEmbedding.RECHAZADO_SCORE,
+                    "Datos de captura incompletos para actualizar el perfil facial.");
         }
         Usuario usuario = repository.findById(usuarioId).orElse(null);
         if (usuario == null || usuario.getPersona() == null) {
-            return false;
+            return new IncorporarEmbeddingMarcacionResult(
+                    ResultadoIncorporacionEmbedding.RECHAZADO_SIMILITUD,
+                    "No se encontró galería facial válida para actualizar.");
         }
         String jsonActual = usuario.getPersona().getEmbedding();
         com.franco.dev.graphql.personas.dto.EmbeddingGaleriaDto galeria = embeddingGaleriaService.parsearDesdeJson(jsonActual);
         if (galeria == null || galeria.getGallery() == null || galeria.getGallery().isEmpty()) {
-            return false;
+            return new IncorporarEmbeddingMarcacionResult(
+                    ResultadoIncorporacionEmbedding.RECHAZADO_SIMILITUD,
+                    "No se encontró galería facial válida para actualizar.");
         }
 
-        com.franco.dev.graphql.personas.dto.EmbeddingGaleriaDto actualizada = embeddingGaleriaService
+        IncorporarCapturaMarcacionResult resultado = embeddingGaleriaService
                 .incorporarCapturaMarcacion(galeria, embedding, score);
-        if (actualizada == null) {
-            return false;
+        if (resultado.getResultado() != ResultadoIncorporacionEmbedding.OK) {
+            return new IncorporarEmbeddingMarcacionResult(resultado.getResultado(), resultado.getMensaje());
         }
 
-        String embeddingJson = embeddingGaleriaService.serializar(actualizada);
+        String embeddingJson = embeddingGaleriaService.serializar(resultado.getGaleria());
         if (embeddingJson == null) {
-            return false;
+            return new IncorporarEmbeddingMarcacionResult(
+                    ResultadoIncorporacionEmbedding.RECHAZADO_SIMILITUD,
+                    "No se pudo guardar la galería facial actualizada.");
         }
 
         Persona persona = usuario.getPersona();
         persona.setEmbedding(embeddingJson);
         personaRepository.saveAndFlush(persona);
         embeddingCacheService.refreshUsuario(usuarioId, embeddingJson);
-        return true;
+        return new IncorporarEmbeddingMarcacionResult(resultado.getResultado(), resultado.getMensaje());
     }
 
     private String resolverEmbeddingJson(String embeddingGaleriaJson) {

--- a/src/main/java/com/franco/dev/service/personas/UsuarioService.java
+++ b/src/main/java/com/franco/dev/service/personas/UsuarioService.java
@@ -45,6 +45,9 @@ public class UsuarioService extends CrudService<Usuario, UsuarioRepository, Long
     @Autowired
     private final UsuarioEmbeddingCacheService embeddingCacheService;
 
+    @Autowired
+    private final EmbeddingGaleriaService embeddingGaleriaService;
+
     @Override
     public UsuarioRepository getRepository() {
         return repository;
@@ -146,7 +149,8 @@ public class UsuarioService extends CrudService<Usuario, UsuarioRepository, Long
         return e;
     }
 
-    public Boolean saveUserImage(Long id, String type, String image, List<Double> embedding) throws IOException {
+    public Boolean saveUserImage(Long id, String type, String image, List<Double> embedding, String embeddingGaleriaJson)
+            throws IOException {
         System.out.println("Saving user image for id: " + id + ", type: " + type);
         try {
             String directoryPath = imageService.getImagePath() + File.separator + "personas" + File.separator + type
@@ -176,16 +180,14 @@ public class UsuarioService extends CrudService<Usuario, UsuarioRepository, Long
             if (usuario != null && usuario.getPersona() != null) {
                 Persona persona = usuario.getPersona();
                 persona.setImagenes(fileName);
-                if (embedding != null && !embedding.isEmpty()) {
-                    try {
-                        com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
-                        persona.setEmbedding(mapper.writeValueAsString(embedding));
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                    }
+                String embeddingJson = resolverEmbeddingJson(embeddingGaleriaJson);
+                if (embeddingJson != null) {
+                    persona.setEmbedding(embeddingJson);
                 }
                 personaRepository.saveAndFlush(persona);
-                embeddingCacheService.refreshUsuario(id, embedding);
+                if (embeddingJson != null) {
+                    embeddingCacheService.refreshUsuario(id, embeddingJson);
+                }
             }
         }
         return saved;
@@ -198,11 +200,13 @@ public class UsuarioService extends CrudService<Usuario, UsuarioRepository, Long
     public Integer isUserFaceAuth(Long id) {
         Usuario usuario = repository.findById(id).orElse(null);
         if (usuario != null && usuario.getPersona() != null) {
-            // Si ya tiene embedding o ya tiene imagenes de perfil, consideramos que tiene
-            // registro facial
-            if ((usuario.getPersona().getEmbedding() != null && !usuario.getPersona().getEmbedding().isEmpty()) ||
-                    (usuario.getPersona().getImagenes() != null && !usuario.getPersona().getImagenes().isEmpty())) {
-                return 3;
+            String embeddingJson = usuario.getPersona().getEmbedding();
+            if (embeddingJson != null && !embeddingJson.isEmpty()) {
+                com.franco.dev.graphql.personas.dto.EmbeddingGaleriaDto galeria = embeddingGaleriaService
+                        .parsearDesdeJson(embeddingJson);
+                if (galeria != null && galeria.getGallery() != null && !galeria.getGallery().isEmpty()) {
+                    return 3;
+                }
             }
         }
         List<String> images = getUserImages(id, "auth");
@@ -212,5 +216,12 @@ public class UsuarioService extends CrudService<Usuario, UsuarioRepository, Long
     public com.franco.dev.graphql.personas.UsuarioSimilitudResult findUsuarioByEmbedding(List<Double> embeddingInfo,
             List<Integer> excludeIds) {
         return embeddingCacheService.findBestMatch(embeddingInfo, excludeIds);
+    }
+
+    private String resolverEmbeddingJson(String embeddingGaleriaJson) {
+        if (embeddingGaleriaJson == null || embeddingGaleriaJson.isBlank()) {
+            return null;
+        }
+        return embeddingGaleriaService.normalizarJsonEntrada(embeddingGaleriaJson);
     }
 }

--- a/src/main/java/com/franco/dev/service/personas/UsuarioService.java
+++ b/src/main/java/com/franco/dev/service/personas/UsuarioService.java
@@ -218,6 +218,38 @@ public class UsuarioService extends CrudService<Usuario, UsuarioRepository, Long
         return embeddingCacheService.findBestMatch(embeddingInfo, excludeIds);
     }
 
+    public Boolean incorporarEmbeddingMarcacion(Long usuarioId, List<Double> embedding, Double score) {
+        if (usuarioId == null || embedding == null || embedding.isEmpty()) {
+            return false;
+        }
+        Usuario usuario = repository.findById(usuarioId).orElse(null);
+        if (usuario == null || usuario.getPersona() == null) {
+            return false;
+        }
+        String jsonActual = usuario.getPersona().getEmbedding();
+        com.franco.dev.graphql.personas.dto.EmbeddingGaleriaDto galeria = embeddingGaleriaService.parsearDesdeJson(jsonActual);
+        if (galeria == null || galeria.getGallery() == null || galeria.getGallery().isEmpty()) {
+            return false;
+        }
+
+        com.franco.dev.graphql.personas.dto.EmbeddingGaleriaDto actualizada = embeddingGaleriaService
+                .incorporarCapturaMarcacion(galeria, embedding, score);
+        if (actualizada == null) {
+            return false;
+        }
+
+        String embeddingJson = embeddingGaleriaService.serializar(actualizada);
+        if (embeddingJson == null) {
+            return false;
+        }
+
+        Persona persona = usuario.getPersona();
+        persona.setEmbedding(embeddingJson);
+        personaRepository.saveAndFlush(persona);
+        embeddingCacheService.refreshUsuario(usuarioId, embeddingJson);
+        return true;
+    }
+
     private String resolverEmbeddingJson(String embeddingGaleriaJson) {
         if (embeddingGaleriaJson == null || embeddingGaleriaJson.isBlank()) {
             return null;

--- a/src/main/java/com/franco/dev/service/personas/dto/IncorporarCapturaMarcacionResult.java
+++ b/src/main/java/com/franco/dev/service/personas/dto/IncorporarCapturaMarcacionResult.java
@@ -1,0 +1,37 @@
+package com.franco.dev.service.personas.dto;
+
+import com.franco.dev.domain.personas.enums.ResultadoIncorporacionEmbedding;
+import com.franco.dev.graphql.personas.dto.EmbeddingGaleriaDto;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class IncorporarCapturaMarcacionResult {
+    private ResultadoIncorporacionEmbedding resultado;
+    private EmbeddingGaleriaDto galeria;
+    private String mensaje;
+
+    public static IncorporarCapturaMarcacionResult ok(EmbeddingGaleriaDto galeria) {
+        return new IncorporarCapturaMarcacionResult(
+                ResultadoIncorporacionEmbedding.OK,
+                galeria,
+                "Perfil facial actualizado con esta marcación.");
+    }
+
+    public static IncorporarCapturaMarcacionResult rechazadoScore(String mensaje) {
+        return new IncorporarCapturaMarcacionResult(
+                ResultadoIncorporacionEmbedding.RECHAZADO_SCORE,
+                null,
+                mensaje);
+    }
+
+    public static IncorporarCapturaMarcacionResult rechazadoSimilitud(String mensaje) {
+        return new IncorporarCapturaMarcacionResult(
+                ResultadoIncorporacionEmbedding.RECHAZADO_SIMILITUD,
+                null,
+                mensaje);
+    }
+}

--- a/src/main/resources/graphql/administrativo/jornada.graphqls
+++ b/src/main/resources/graphql/administrativo/jornada.graphqls
@@ -26,10 +26,28 @@ enum EstadoJornada {
     AUSENTE
 }
 
+enum AccionMarcacionPendiente {
+    ENTRADA
+    SALIDA
+    RETORNO_ALMUERZO
+    SALIDA_DEFINITIVA
+}
+
+type EstadoMarcacionUsuario {
+    jornadaRelevante: Jornada
+    accionPendiente: AccionMarcacionPendiente
+    puedeMarcarEntrada: Boolean
+    puedeMarcarSalida: Boolean
+    puedeMarcarSalidaAlmuerzo: Boolean
+    puedeMarcarEntradaAlmuerzo: Boolean
+    estaEnJornada: Boolean
+}
+
 extend type Query {
     jornada(id: ID!, sucursalId: ID!): Jornada
     jornadasPorUsuario(usuarioId: ID!, fechaInicio: String, fechaFin: String): [Jornada]
     jornadas(fechaInicio: String, fechaFin: String, page: Int, size: Int): [Jornada]
+    estadoMarcacionUsuario(usuarioId: ID!): EstadoMarcacionUsuario
 }
 
 extend type Mutation {

--- a/src/main/resources/graphql/administrativo/marcacion.graphqls
+++ b/src/main/resources/graphql/administrativo/marcacion.graphqls
@@ -74,4 +74,5 @@ extend type Query {
 
 extend type Mutation {
     saveMarcacion(marcacion: MarcacionInput!): Marcacion
+    reprocesarJornadaDeMarcacion(id: ID!, sucursalId: ID!): Marcacion
 }

--- a/src/main/resources/graphql/personas/persona.graphqls
+++ b/src/main/resources/graphql/personas/persona.graphqls
@@ -17,6 +17,7 @@ type Persona {
     isCliente: Boolean
     isProveedor: Boolean
     isUsuario: Boolean
+    embeddingFacial: String
 }
 
 input PersonaInput {

--- a/src/main/resources/graphql/personas/usuario.graphqls
+++ b/src/main/resources/graphql/personas/usuario.graphqls
@@ -53,6 +53,6 @@ type UsuarioPage {
 extend type Mutation {
     saveUsuario(usuario:UsuarioInput!):Usuario!
     deleteUsuario(id:ID!):Boolean!
-    saveUsuarioImage(id:ID!, type:String!, image:String!, embedding: [Float]):Boolean
+    saveUsuarioImage(id:ID!, type:String!, image:String!, embedding: [Float], embeddingGaleriaJson: String):Boolean
 }
 

--- a/src/main/resources/graphql/personas/usuario.graphqls
+++ b/src/main/resources/graphql/personas/usuario.graphqls
@@ -15,6 +15,17 @@ type UsuarioSimilitud {
     similitud: Float
 }
 
+enum ResultadoIncorporacionEmbedding {
+    OK
+    RECHAZADO_SCORE
+    RECHAZADO_SIMILITUD
+}
+
+type IncorporarEmbeddingMarcacionResult {
+    resultado: ResultadoIncorporacionEmbedding!
+    mensaje: String!
+}
+
 input UsuarioInput {
     id:ID
     personaId: Int
@@ -54,6 +65,6 @@ extend type Mutation {
     saveUsuario(usuario:UsuarioInput!):Usuario!
     deleteUsuario(id:ID!):Boolean!
     saveUsuarioImage(id:ID!, type:String!, image:String!, embedding: [Float], embeddingGaleriaJson: String):Boolean
-    incorporarEmbeddingMarcacion(usuarioId:ID!, embedding:[Float]!, score:Float):Boolean
+    incorporarEmbeddingMarcacion(usuarioId:ID!, embedding:[Float]!, score:Float):IncorporarEmbeddingMarcacionResult
 }
 

--- a/src/main/resources/graphql/personas/usuario.graphqls
+++ b/src/main/resources/graphql/personas/usuario.graphqls
@@ -54,5 +54,6 @@ extend type Mutation {
     saveUsuario(usuario:UsuarioInput!):Usuario!
     deleteUsuario(id:ID!):Boolean!
     saveUsuarioImage(id:ID!, type:String!, image:String!, embedding: [Float], embeddingGaleriaJson: String):Boolean
+    incorporarEmbeddingMarcacion(usuarioId:ID!, embedding:[Float]!, score:Float):Boolean
 }
 


### PR DESCRIPTION
## Summary
- Implementa `EmbeddingGaleriaService` para gestionar y enriquecer la galería de embeddings faciales, con DTOs y endpoints GraphQL asociados.
- Expone `estadoMarcacionUsuario` y resultado tipado al incorporar embedding tras marcación (`IncorporarEmbeddingMarcacionResult`).
- Centraliza reglas de jornada en `JornadaMarcacionRules` y bloquea entradas duplicadas en turnos nocturnos.

## Test plan
- [ ] Consultar `estadoMarcacionUsuario` vía GraphQL y verificar respuesta según jornada activa del usuario.
- [ ] Probar incorporación de embedding tras marcación y validar resultado tipado retornado.
- [ ] Verificar enriquecimiento de galería facial con múltiples capturas del mismo usuario.
- [ ] Confirmar bloqueo de entrada duplicada en turnos nocturnos.
- [ ] Validar búsqueda de usuario por embedding (`usuarioPorEmbedding`) con galería enriquecida.


Made with [Cursor](https://cursor.com)