### PR TITLE
feat(financiero): agregar módulo terminal POS

### DIFF
--- a/src/main/java/com/franco/dev/domain/financiero/TerminalPos.java
+++ b/src/main/java/com/franco/dev/domain/financiero/TerminalPos.java
@@ -1,0 +1,50 @@
+package com.franco.dev.domain.financiero;
+
+import com.franco.dev.config.Identifiable;
+import com.franco.dev.domain.personas.Usuario;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "terminal_pos", schema = "financiero")
+public class TerminalPos implements Identifiable<Long> {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GenericGenerator(
+            name = "assigned-identity",
+            strategy = "com.franco.dev.config.AssignedIdentityGenerator"
+    )
+    @GeneratedValue(
+            generator = "assigned-identity",
+            strategy = GenerationType.IDENTITY
+    )
+    private Long id;
+
+    private String descripcion;
+
+    private String codigo;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "cuenta_bancaria_id", nullable = true)
+    private CuentaBancaria cuentaBancaria;
+
+    private Boolean activo;
+
+    @CreationTimestamp
+    private LocalDateTime creadoEn;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "usuario_id", nullable = true)
+    private Usuario usuario;
+}

--- a/src/main/java/com/franco/dev/graphql/financiero/TerminalPosGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/TerminalPosGraphQL.java
@@ -1,0 +1,65 @@
+package com.franco.dev.graphql.financiero;
+
+import com.franco.dev.domain.financiero.TerminalPos;
+import com.franco.dev.graphql.financiero.input.TerminalPosInput;
+import com.franco.dev.service.financiero.CuentaBancariaService;
+import com.franco.dev.service.financiero.TerminalPosService;
+import com.franco.dev.service.personas.UsuarioService;
+import graphql.kickstart.tools.GraphQLMutationResolver;
+import graphql.kickstart.tools.GraphQLQueryResolver;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+@Component
+public class TerminalPosGraphQL implements GraphQLQueryResolver, GraphQLMutationResolver {
+
+    @Autowired
+    private TerminalPosService service;
+
+    @Autowired
+    private UsuarioService usuarioService;
+
+    @Autowired
+    private CuentaBancariaService cuentaBancariaService;
+
+    public Optional<TerminalPos> terminalPos(Long id) {
+        return service.findById(id);
+    }
+
+    public List<TerminalPos> terminalesPos(int page, int size) {
+        return service.findAll2();
+    }
+
+    public List<TerminalPos> searchTerminalPos(String texto) {
+        return service.searchByAll(texto);
+    }
+
+    public Page<TerminalPos> filterTerminalPos(String descripcion, String codigo, Boolean activo, int page, int size) {
+        return service.filter(descripcion, codigo, activo, page, size);
+    }
+
+    public Long countTerminalPos() {
+        return service.count();
+    }
+
+    public TerminalPos saveTerminalPos(TerminalPosInput input) {
+        ModelMapper m = new ModelMapper();
+        TerminalPos e = m.map(input, TerminalPos.class);
+        if (input.getUsuarioId() != null) {
+            e.setUsuario(usuarioService.findById(input.getUsuarioId()).orElse(null));
+        }
+        if (input.getCuentaBancariaId() != null) {
+            e.setCuentaBancaria(cuentaBancariaService.findById(input.getCuentaBancariaId()).orElse(null));
+        }
+        return service.save(e);
+    }
+
+    public Boolean deleteTerminalPos(Long id) {
+        return service.deleteById(id);
+    }
+}

--- a/src/main/java/com/franco/dev/graphql/financiero/input/TerminalPosInput.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/input/TerminalPosInput.java
@@ -1,0 +1,22 @@
+package com.franco.dev.graphql.financiero.input;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class TerminalPosInput {
+    private Long id;
+
+    private String descripcion;
+
+    private String codigo;
+
+    private Long cuentaBancariaId;
+
+    private Boolean activo;
+
+    private LocalDateTime creadoEn;
+
+    private Long usuarioId;
+}

--- a/src/main/java/com/franco/dev/repository/financiero/TerminalPosRepository.java
+++ b/src/main/java/com/franco/dev/repository/financiero/TerminalPosRepository.java
@@ -1,0 +1,39 @@
+package com.franco.dev.repository.financiero;
+
+import com.franco.dev.domain.financiero.TerminalPos;
+import com.franco.dev.repository.HelperRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface TerminalPosRepository extends HelperRepository<TerminalPos, Long> {
+
+    default Class<TerminalPos> getEntityClass() {
+        return TerminalPos.class;
+    }
+
+    @Query("select t from TerminalPos t " +
+            "where (UPPER(CAST(t.id as text)) like %?1% or UPPER(t.descripcion) like %?1% or UPPER(t.codigo) like %?1%)")
+    public List<TerminalPos> findByAll(String texto);
+
+    @Query(value = "select t from TerminalPos t " +
+            "where (:descripcion is null or UPPER(t.descripcion) like %:descripcion%) " +
+            "and (:codigo is null or UPPER(t.codigo) like %:codigo%) " +
+            "and (:activo is null or t.activo = :activo) " +
+            "order by t.id asc",
+            countQuery = "select count(t) from TerminalPos t " +
+                    "where (:descripcion is null or UPPER(t.descripcion) like %:descripcion%) " +
+                    "and (:codigo is null or UPPER(t.codigo) like %:codigo%) " +
+                    "and (:activo is null or t.activo = :activo)")
+    public Page<TerminalPos> filterTerminalPos(@Param("descripcion") String descripcion,
+                                               @Param("codigo") String codigo,
+                                               @Param("activo") Boolean activo,
+                                               Pageable pageable);
+
+    TerminalPos findByCodigoIgnoreCase(String codigo);
+
+    Page<TerminalPos> findAll(Pageable pageable);
+}

--- a/src/main/java/com/franco/dev/service/financiero/TerminalPosService.java
+++ b/src/main/java/com/franco/dev/service/financiero/TerminalPosService.java
@@ -1,0 +1,46 @@
+package com.franco.dev.service.financiero;
+
+import com.franco.dev.domain.financiero.TerminalPos;
+import com.franco.dev.repository.financiero.TerminalPosRepository;
+import com.franco.dev.service.CrudService;
+import lombok.AllArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@AllArgsConstructor
+public class TerminalPosService extends CrudService<TerminalPos, TerminalPosRepository, Long> {
+
+    private final TerminalPosRepository repository;
+
+    @Override
+    public TerminalPosRepository getRepository() {
+        return repository;
+    }
+
+    public TerminalPos findByCodigo(String codigo) {
+        return repository.findByCodigoIgnoreCase(codigo);
+    }
+
+    public List<TerminalPos> searchByAll(String texto) {
+        texto = texto != null ? texto.toUpperCase() : "";
+        return repository.findByAll(texto);
+    }
+
+    public Page<TerminalPos> filter(String descripcion, String codigo, Boolean activo, int page, int size) {
+        descripcion = (descripcion != null && !descripcion.trim().isEmpty()) ? descripcion.toUpperCase() : null;
+        codigo = (codigo != null && !codigo.trim().isEmpty()) ? codigo.toUpperCase() : null;
+        return repository.filterTerminalPos(descripcion, codigo, activo, PageRequest.of(page, size));
+    }
+
+    @Override
+    public TerminalPos save(TerminalPos entity) {
+        if (entity.getId() == null) entity.setCreadoEn(LocalDateTime.now());
+        if (entity.getCreadoEn() == null) entity.setCreadoEn(LocalDateTime.now());
+        return super.save(entity);
+    }
+}

--- a/src/main/resources/db/migration/V137.1__create_pos_terminal_table.sql
+++ b/src/main/resources/db/migration/V137.1__create_pos_terminal_table.sql
@@ -1,0 +1,11 @@
+CREATE TABLE financiero.terminal_pos (
+    id SERIAL PRIMARY KEY,
+    descripcion VARCHAR(255),
+    codigo VARCHAR(55),
+    cuenta_bancaria_id BIGINT,
+    activo BOOLEAN DEFAULT FALSE,
+    creado_en TIMESTAMP,
+    usuario_id BIGINT,
+    CONSTRAINT fk_terminal_pos_cuenta_bancaria FOREIGN KEY (cuenta_bancaria_id) REFERENCES financiero.cuenta_bancaria(id),
+    CONSTRAINT fk_terminal_pos_usuario FOREIGN KEY (usuario_id) REFERENCES personas.usuario(id)
+);

--- a/src/main/resources/graphql/financiero/terminalpos.graphqls
+++ b/src/main/resources/graphql/financiero/terminalpos.graphqls
@@ -1,0 +1,42 @@
+type TerminalPos {
+    id:ID!
+    descripcion: String
+    codigo: String
+    activo: Boolean
+    creadoEn: Date
+    usuario: Usuario
+}
+
+type TerminalPosPage {
+    getTotalPages: Int
+    getTotalElements: Int
+    getNumberOfElements: Int
+    isFirst: Boolean
+    isLast: Boolean
+    hasNext: Boolean
+    hasPrevious: Boolean
+    getContent: [TerminalPos]
+}
+
+input TerminalPosInput {
+    id:ID
+    descripcion: String
+    codigo: String
+    cuentaBancariaId: Int
+    activo: Boolean
+    creadoEn: Date
+    usuarioId: Int
+}
+
+extend type Query {
+    terminalPos(id:ID!):TerminalPos
+    terminalesPos(page:Int = 0, size:Int = 10):[TerminalPos]!
+    countTerminalPos: Int
+    searchTerminalPos(texto: String):[TerminalPos]
+    filterTerminalPos(descripcion: String, codigo: String, activo: Boolean, page: Int = 0, size: Int = 10):TerminalPosPage
+}
+
+extend type Mutation {
+    saveTerminalPos(terminalPos:TerminalPosInput!):TerminalPos!
+    deleteTerminalPos(id:ID!):Boolean!
+}


### PR DESCRIPTION
## Que resuelve

Incorpora el modulo de terminales POS al dominio financiero. Permite registrar, consultar, filtrar y eliminar terminales de punto de venta, asociandolas a una cuenta bancaria y al usuario que las creo.

## Como probarlo

1. Aplicar la migracion Flyway ejecutando la aplicacion normalmente (se aplica automaticamente).
2. Abrir GraphiQL en desarrollo.
3. Ejecutar la mutation `saveTerminalPos` para crear una terminal:

```graphql
mutation {
  saveTerminalPos(terminalPos: {
    descripcion: "Terminal Principal"
    codigo: "POS-001"
    activo: true
    cuentaBancariaId: 1
    usuarioId: 1
  }) {
    id
    descripcion
    codigo
    activo
  }
}
```

4. Verificar con la query `terminalesPos` que el registro aparece.
5. Probar `filterTerminalPos` con distintos parametros (descripcion, codigo, activo).
6. Probar `deleteTerminalPos` con el id creado.

## Impacto en DB

Se agrega la migracion `V137.1__create_pos_terminal_table.sql` que crea la tabla `financiero.terminal_pos`:

- Columnas: `id` (SERIAL PK), `descripcion`, `codigo`, `cuenta_bancaria_id`, `activo`, `creado_en`, `usuario_id`
- FK a `financiero.cuenta_bancaria(id)` y `personas.usuario(id)`
- Ambas FK son nullable, no rompen datos existentes

La migracion es aditiva (solo `CREATE TABLE`), compatible con la estrategia de rollback automatico del deploy (el rollback del JAR no revierte la tabla, pero la tabla vacia no afecta el funcionamiento de la version anterior).

## Riesgo

**Bajo.** El cambio es exclusivamente aditivo: nueva tabla, nuevos endpoints GraphQL, sin modificacion de entidades o esquemas existentes. No hay impacto en clientes actuales (desktop/mobile) porque no se modifico ninguna API existente.