### PR TITLE
fix(notificaciones): push FCM y alertas de stock crítico

### DIFF
--- a/src/main/java/com/franco/dev/fmc/controller/PushNotificationController.java
+++ b/src/main/java/com/franco/dev/fmc/controller/PushNotificationController.java
@@ -9,6 +9,7 @@ import com.franco.dev.fmc.model.VentaStockCriticoNotificationRequest;
 import com.franco.dev.fmc.service.NotificationRoleService;
 import com.franco.dev.fmc.service.NotificationTemplateService;
 import com.franco.dev.fmc.service.PushNotificationService;
+import com.franco.dev.service.configuracion.NotificacionPreferenciaService;
 import com.franco.dev.service.empresarial.SucursalService;
 import com.franco.dev.service.financiero.VentaCreditoService;
 import com.franco.dev.service.personas.UsuarioService;
@@ -47,6 +48,9 @@ public class PushNotificationController {
 
         @Autowired
         private VentaCreditoService ventaCreditoService;
+
+        @Autowired
+        private NotificacionPreferenciaService notificacionPreferenciaService;
 
         public PushNotificationController(PushNotificationService pushNotificationService) {
                 this.pushNotificationService = pushNotificationService;
@@ -280,8 +284,12 @@ public class PushNotificationController {
                                                 HttpStatus.BAD_REQUEST);
                         }
 
-                        List<String> rolesRelevantes = notificationRoleService.getRolesForVentaStockCritico();
-                        List<Long> usuariosRelevantes = notificationRoleService.getUserIdsByRoles(rolesRelevantes);
+                        List<Usuario> usuariosDestino = notificacionPreferenciaService
+                                        .obtenerUsuariosPorTipoNotificacion("VENTA_STOCK_CRITICO");
+                        List<Long> usuariosRelevantes = usuariosDestino.stream()
+                                        .map(Usuario::getId)
+                                        .distinct()
+                                        .collect(Collectors.toList());
 
                         if (!usuariosRelevantes.isEmpty()) {
                                 PushNotificationRequest request = notificationTemplateService.ventaStockCritico(

--- a/src/main/java/com/franco/dev/fmc/service/NotificationRoleService.java
+++ b/src/main/java/com/franco/dev/fmc/service/NotificationRoleService.java
@@ -154,14 +154,4 @@ public class NotificationRoleService {
                 "ANALISIS DE CAJA",
                 "ANALISIS DE VENTA");
     }
-
-    public List<String> getRolesForVentaStockCritico() {
-        return Arrays.asList(
-                "ADMIN",
-                "SOPORTE",
-                "ANALISIS DE VENTA",
-                "ANALISIS DE CAJA",
-                "VER MOVIMIENTO DE STOCK",
-                "VER PRODUCTOS");
-    }
 }

--- a/src/main/java/com/franco/dev/fmc/service/PushNotificationService.java
+++ b/src/main/java/com/franco/dev/fmc/service/PushNotificationService.java
@@ -153,7 +153,8 @@ public class PushNotificationService {
 
                 if (usuarioId != null) {
                     if (!blockedUsers.contains(usuarioId)) {
-                        if (token != null && dedup.add(token)) {
+                        String dedupKey = "u:" + usuarioId;
+                        if (token != null && dedup.add(dedupKey)) {
                             targets.add(new Target(usuarioId, token));
                         }
                     }
@@ -177,7 +178,49 @@ public class PushNotificationService {
                     .filter(dedup::add)
                     .forEach(token -> targets.add(new Target(null, token)));
         }
-        return targets;
+        return excluirTokensConUsuariosBloqueados(targets, tipoNotificacion);
+    }
+
+    private List<Target> excluirTokensConUsuariosBloqueados(List<Target> targets, String tipoNotificacion) {
+        if (targets.isEmpty()) {
+            return targets;
+        }
+
+        Set<String> tokens = targets.stream()
+                .map(Target::getToken)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+        if (tokens.isEmpty()) {
+            return targets;
+        }
+
+        List<com.franco.dev.domain.configuracion.InicioSesion> sesionesPorToken = inicioSesionService
+                .findActiveSessionsByTokens(tokens);
+        if (sesionesPorToken.isEmpty()) {
+            return targets;
+        }
+
+        List<Long> usuariosEnTokens = sesionesPorToken.stream()
+                .map(s -> s.getUsuario() != null ? s.getUsuario().getId() : null)
+                .filter(Objects::nonNull)
+                .distinct()
+                .collect(Collectors.toList());
+
+        Set<Long> usuariosBloqueados = preferenciaService.getUsuariosConNotificacionDeshabilitada(
+                tipoNotificacion, usuariosEnTokens);
+        if (usuariosBloqueados.isEmpty()) {
+            return targets;
+        }
+
+        Set<String> tokensBloqueados = sesionesPorToken.stream()
+                .filter(s -> s.getUsuario() != null && usuariosBloqueados.contains(s.getUsuario().getId()))
+                .map(com.franco.dev.domain.configuracion.InicioSesion::getToken)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+
+        return targets.stream()
+                .filter(target -> !tokensBloqueados.contains(target.getToken()))
+                .collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/com/franco/dev/graphql/personas/UsuarioRoleGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/personas/UsuarioRoleGraphQL.java
@@ -1,6 +1,7 @@
 package com.franco.dev.graphql.personas;
 
 import com.franco.dev.config.multitenant.MultiTenantService;
+import com.franco.dev.domain.personas.Usuario;
 import com.franco.dev.domain.personas.UsuarioRole;
 import com.franco.dev.domain.productos.Producto;
 import com.franco.dev.graphql.personas.input.UsuarioRoleInput;
@@ -36,13 +37,12 @@ public class UsuarioRoleGraphQL implements GraphQLQueryResolver, GraphQLMutation
 
     public UsuarioRole saveUsuarioRole(UsuarioRoleInput input) {
         UsuarioRole e = new UsuarioRole();
-        if (input.getId() != null) e.setId(input.getId());
-        e.setUser(usuarioService.findById(input.getUserId()).orElse(null));
-        if (input.getUsuarioId() != null) {
-            e.setUsuario(usuarioService.findById(input.getUsuarioId()).orElse(null));
-        } else {
-            e.setUsuario(usuarioService.findById(input.getUserId()).orElse(null));
+        if (input.getId() != null) {
+            e.setId(input.getId());
         }
+        Usuario usuario = usuarioService.findById(input.getUserId()).orElse(null);
+        e.setUser(usuario);
+        e.setUsuario(usuario);
         e.setRole(roleService.findById(input.getRoleId()).orElse(null));
         e = service.save(e);
         return e;

--- a/src/main/java/com/franco/dev/repository/configuracion/InicioSesionGraphQL.java
+++ b/src/main/java/com/franco/dev/repository/configuracion/InicioSesionGraphQL.java
@@ -76,6 +76,18 @@ public class InicioSesionGraphQL implements GraphQLQueryResolver, GraphQLMutatio
         if (input.getCreadoEn() != null)
             e.setCreadoEn(stringToDate(input.getCreadoEn()));
 
+        if (e.getId() == null && e.getUsuario() != null && e.getIdDispositivo() != null
+                && !e.getIdDispositivo().trim().isEmpty() && e.getHoraFin() == null) {
+            InicioSesion sesionExistente = service.findActiveSessionByUsuarioAndDispositivo(
+                    e.getUsuario().getId(), e.getIdDispositivo());
+            if (sesionExistente != null) {
+                e.setId(sesionExistente.getId());
+                if (e.getHoraInicio() == null && sesionExistente.getHoraInicio() != null) {
+                    e.setHoraInicio(sesionExistente.getHoraInicio());
+                }
+            }
+        }
+
         InicioSesion saved = service.save(e);
 
         return saved;
@@ -89,7 +101,7 @@ public class InicioSesionGraphQL implements GraphQLQueryResolver, GraphQLMutatio
         return service.count();
     }
 
-    public Boolean actualizarTokenFcm(String tokenFcm) {
+    public Boolean actualizarTokenFcm(String tokenFcm, String idDispositivo) {
         try {
             org.springframework.security.core.Authentication authentication = org.springframework.security.core.context.SecurityContextHolder
                     .getContext().getAuthentication();
@@ -106,32 +118,21 @@ public class InicioSesionGraphQL implements GraphQLQueryResolver, GraphQLMutatio
                 return false;
             }
 
-            List<InicioSesion> sesionesConToken = service.getRepository().findByToken(tokenFcm);
+            service.reclamarTokenParaUsuario(tokenFcm, usuario.getId());
 
-            if (!sesionesConToken.isEmpty()) {
-                InicioSesion sesionExistente = sesionesConToken.get(0);
-                if (sesionExistente.getUsuario() != null &&
-                        sesionExistente.getUsuario().getId().equals(usuario.getId()) &&
-                        sesionExistente.getHoraFin() == null) {
-                    return true;
-                }
-            }
-            Pageable pageable = PageRequest.of(0, 100);
-            Page<InicioSesion> sesionesActivas = service.findByUsuarioIdAndHoraFinIsNul(usuario.getId(), null,
-                    pageable);
-
-            if (sesionesActivas.isEmpty()) {
-                return false;
-            }
             InicioSesion sesionParaActualizar = null;
-
-            for (InicioSesion sesion : sesionesActivas.getContent()) {
-                if (sesion.getToken() == null || sesion.getToken().trim().isEmpty()) {
-                    sesionParaActualizar = sesion;
-                    break;
-                }
+            if (idDispositivo != null && !idDispositivo.trim().isEmpty()) {
+                sesionParaActualizar = service.findActiveSessionByUsuarioAndDispositivo(usuario.getId(),
+                        idDispositivo);
             }
+
             if (sesionParaActualizar == null) {
+                Pageable pageable = PageRequest.of(0, 1);
+                Page<InicioSesion> sesionesActivas = service.findByUsuarioIdAndHoraFinIsNul(usuario.getId(), null,
+                        pageable);
+                if (sesionesActivas.isEmpty()) {
+                    return false;
+                }
                 sesionParaActualizar = sesionesActivas.getContent().get(0);
             }
 

--- a/src/main/java/com/franco/dev/repository/configuracion/InicioSesionRepository.java
+++ b/src/main/java/com/franco/dev/repository/configuracion/InicioSesionRepository.java
@@ -27,9 +27,23 @@ public interface InicioSesionRepository extends HelperRepository<InicioSesion, L
     List<InicioSesion> findByUsuarioIdAndIdDispositivoAndHoraFinIsNull(Long usuarioId, String idDispositivo);
     Optional<InicioSesion> findFirstByIdDispositivoAndUsuarioIsNotNullOrderByIdAsc(String idDispositivo);
 
-    @org.springframework.data.jpa.repository.Modifying
+    @org.springframework.data.jpa.repository.Modifying(clearAutomatically = true, flushAutomatically = true)
     @org.springframework.data.jpa.repository.Query("UPDATE InicioSesion s SET s.token = null WHERE s.token = :token")
     void clearTokenByToken(@org.springframework.data.repository.query.Param("token") String token);
+
+    @org.springframework.data.jpa.repository.Modifying(clearAutomatically = true, flushAutomatically = true)
+    @org.springframework.data.jpa.repository.Query("UPDATE InicioSesion s SET s.token = null WHERE s.token = :token "
+            + "AND (s.usuario.id IS NULL OR s.usuario.id <> :usuarioId)")
+    int liberarTokenDeOtrosUsuarios(
+            @org.springframework.data.repository.query.Param("token") String token,
+            @org.springframework.data.repository.query.Param("usuarioId") Long usuarioId);
+
+    @org.springframework.data.jpa.repository.Modifying(clearAutomatically = true, flushAutomatically = true)
+    @org.springframework.data.jpa.repository.Query("UPDATE InicioSesion s SET s.token = null WHERE s.token = :token "
+            + "AND s.id <> :sesionActivaId")
+    int liberarTokenDeOtrasSesiones(
+            @org.springframework.data.repository.query.Param("token") String token,
+            @org.springframework.data.repository.query.Param("sesionActivaId") Long sesionActivaId);
 
     @org.springframework.data.jpa.repository.Query("SELECT s FROM InicioSesion s WHERE s.usuario.id IN :usuarioIds " +
             "AND s.token IS NOT NULL AND s.token != '' AND s.horaFin IS NULL " +
@@ -41,4 +55,9 @@ public interface InicioSesionRepository extends HelperRepository<InicioSesion, L
             "s.token IS NOT NULL AND s.token != '' AND s.usuario IS NOT NULL AND s.horaFin IS NULL " +
             "ORDER BY s.id DESC")
     List<InicioSesion> findAllWithValidTokens();
+
+    @org.springframework.data.jpa.repository.Query("SELECT s FROM InicioSesion s WHERE s.token IN :tokens " +
+            "AND s.horaFin IS NULL AND s.usuario IS NOT NULL")
+    List<InicioSesion> findActiveSessionsByTokens(
+            @org.springframework.data.repository.query.Param("tokens") Collection<String> tokens);
 }

--- a/src/main/java/com/franco/dev/service/configuracion/InicioSesionService.java
+++ b/src/main/java/com/franco/dev/service/configuracion/InicioSesionService.java
@@ -9,9 +9,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 @Service
 @AllArgsConstructor
@@ -32,26 +35,75 @@ public class InicioSesionService extends CrudService<InicioSesion, InicioSesionR
     private org.springframework.context.ApplicationEventPublisher publisher;
 
     @Override
+    @org.springframework.transaction.annotation.Transactional
     public InicioSesion save(InicioSesion entity) {
         boolean isNew = entity.getId() == null;
+        LocalDateTime now = LocalDateTime.now();
+
         if (isNew) {
-            entity.setCreadoEn(LocalDateTime.now());
-            if (entity.getIdDispositivo() != null && entity.getUsuario() != null) {
-                List<InicioSesion> sesionesPrevias = repository.findByUsuarioIdAndIdDispositivoAndHoraFinIsNull(
-                        entity.getUsuario().getId(), entity.getIdDispositivo());
-                for (InicioSesion previa : sesionesPrevias) {
-                    previa.setHoraFin(LocalDateTime.now());
-                    repository.save(previa);
-                }
-            }
+            entity.setCreadoEn(now);
         }
+
+        cerrarOtrasSesionesActivasDelDispositivo(entity, now);
+
+        if (entity.getHoraFin() != null) {
+            entity.setToken(null);
+        }
+
+        if (tieneTokenValido(entity.getToken()) && entity.getUsuario() != null) {
+            repository.liberarTokenDeOtrosUsuarios(entity.getToken(), entity.getUsuario().getId());
+        }
+
         InicioSesion e = super.save(entity);
+
+        if (entity.getHoraFin() == null && e.getUsuario() != null && e.getId() != null
+                && tieneTokenValido(e.getToken())) {
+            asignarTokenExclusivo(e.getToken(), e.getUsuario().getId(), e.getId());
+        }
 
         if (isNew) {
             publisher.publishEvent(new com.franco.dev.fmc.event.InicioSesionCreadoEvent(this, e));
         }
 
         return e;
+    }
+
+    private void cerrarOtrasSesionesActivasDelDispositivo(InicioSesion entity, LocalDateTime now) {
+        if (entity.getIdDispositivo() == null || entity.getUsuario() == null) {
+            return;
+        }
+        List<InicioSesion> sesionesPrevias = repository.findByUsuarioIdAndIdDispositivoAndHoraFinIsNull(
+                entity.getUsuario().getId(), entity.getIdDispositivo());
+        for (InicioSesion previa : sesionesPrevias) {
+            if (entity.getId() != null && entity.getId().equals(previa.getId())) {
+                continue;
+            }
+            previa.setHoraFin(now);
+            previa.setToken(null);
+            repository.save(previa);
+        }
+    }
+
+    private boolean tieneTokenValido(String token) {
+        return token != null && !token.trim().isEmpty();
+    }
+
+    @org.springframework.transaction.annotation.Transactional
+    public void reclamarTokenParaUsuario(String token, Long usuarioId) {
+        if (!tieneTokenValido(token) || usuarioId == null) {
+            return;
+        }
+        repository.liberarTokenDeOtrosUsuarios(token, usuarioId);
+    }
+
+    /**
+     * Reasigna el token FCM sin cerrar sesiones activas:
+     * - ningún otro usuario conserva ese token
+     * - el usuario no mantiene ese token en otra sesión distinta
+     */
+    private void asignarTokenExclusivo(String token, Long usuarioId, Long sesionActivaId) {
+        repository.liberarTokenDeOtrosUsuarios(token, usuarioId);
+        repository.liberarTokenDeOtrasSesiones(token, sesionActivaId);
     }
 
     public Page<InicioSesion> findByUsuarioIdAndHoraFinIsNul(Long id, Long sucId, Pageable pageable) {
@@ -64,12 +116,7 @@ public class InicioSesionService extends CrudService<InicioSesion, InicioSesionR
 
     @Override
     public InicioSesion saveAndSend(InicioSesion entity, Boolean recibir) {
-        if (entity.getId() == null) {
-            entity.setCreadoEn(LocalDateTime.now());
-        }
-
-        InicioSesion e = super.save(entity);
-        return e;
+        return save(entity);
     }
 
     public List<InicioSesion> findActiveSessionsByUsuarioIds(Collection<Long> usuarioIds) {
@@ -83,7 +130,7 @@ public class InicioSesionService extends CrudService<InicioSesion, InicioSesionR
         if (usuarioIds == null || usuarioIds.isEmpty()) {
             return Collections.emptyList();
         }
-        return repository.findByUsuarioIdInWithValidTokens(usuarioIds);
+        return deduplicarSesionesParaEnvio(repository.findByUsuarioIdInWithValidTokens(usuarioIds));
     }
 
     /**
@@ -93,7 +140,48 @@ public class InicioSesionService extends CrudService<InicioSesion, InicioSesionR
      * @return Lista de sesiones con tokens válidos
      */
     public List<InicioSesion> findSessionsWithValidTokens() {
-        return repository.findAllWithValidTokens();
+        return deduplicarSesionesParaEnvio(repository.findAllWithValidTokens());
+    }
+
+    public List<InicioSesion> findActiveSessionsByTokens(Collection<String> tokens) {
+        if (tokens == null || tokens.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return repository.findActiveSessionsByTokens(tokens);
+    }
+
+    public InicioSesion findActiveSessionByUsuarioAndDispositivo(Long usuarioId, String idDispositivo) {
+        if (usuarioId == null || idDispositivo == null || idDispositivo.trim().isEmpty()) {
+            return null;
+        }
+        List<InicioSesion> sesiones = repository.findByUsuarioIdAndIdDispositivoAndHoraFinIsNull(usuarioId,
+                idDispositivo);
+        return sesiones.stream()
+                .max(java.util.Comparator.comparing(InicioSesion::getId,
+                        java.util.Comparator.nullsLast(java.util.Comparator.naturalOrder())))
+                .orElse(null);
+    }
+
+    /**
+     * Deja un solo destino push por usuario (sesión más reciente) y deduplica
+     * tokens huérfanos sin usuario asociado.
+     */
+    private List<InicioSesion> deduplicarSesionesParaEnvio(List<InicioSesion> sesiones) {
+        Set<Long> usuariosVistos = new LinkedHashSet<>();
+        Set<String> tokensHuerfanos = new LinkedHashSet<>();
+        List<InicioSesion> resultado = new ArrayList<>();
+        for (InicioSesion sesion : sesiones) {
+            Long usuarioId = sesion.getUsuario() != null ? sesion.getUsuario().getId() : null;
+            String token = sesion.getToken();
+            if (usuarioId != null) {
+                if (usuariosVistos.add(usuarioId)) {
+                    resultado.add(sesion);
+                }
+            } else if (token != null && tokensHuerfanos.add(token)) {
+                resultado.add(sesion);
+            }
+        }
+        return resultado;
     }
 
     @org.springframework.transaction.annotation.Transactional

--- a/src/main/java/com/franco/dev/service/configuracion/NotificacionPreferenciaService.java
+++ b/src/main/java/com/franco/dev/service/configuracion/NotificacionPreferenciaService.java
@@ -131,8 +131,8 @@ public class NotificacionPreferenciaService {
         for (NotificacionTipoRole config : configs) {
             List<UsuarioRole> usuarioRoles = usuarioRoleService.findByRoleId(config.getRole().getId());
             for (UsuarioRole ur : usuarioRoles) {
-                if (ur.getUsuario() != null) {
-                    usuariosSet.add(ur.getUsuario());
+                if (ur.getUser() != null) {
+                    usuariosSet.add(ur.getUser());
                 }
             }
         }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,7 +9,7 @@
 #spring.devtools.livereload.enabled=true
 #spring.devtools.restart.enabled=false
 #spring.devtools.restart.exclude=static/**,public/**,templates/**,META-INF/**,resources/**
-spring.profiles.active=user-dev
+
 # ----------------------------------------------------------------------------
 # DataSource Configuration
 # ----------------------------------------------------------------------------

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,7 +9,7 @@
 #spring.devtools.livereload.enabled=true
 #spring.devtools.restart.enabled=false
 #spring.devtools.restart.exclude=static/**,public/**,templates/**,META-INF/**,resources/**
-
+spring.profiles.active=user-dev
 # ----------------------------------------------------------------------------
 # DataSource Configuration
 # ----------------------------------------------------------------------------

--- a/src/main/resources/db/migration/V137.3__cleanup_sesiones_and_venta_stock_critico_admin.sql
+++ b/src/main/resources/db/migration/V137.3__cleanup_sesiones_and_venta_stock_critico_admin.sql
@@ -1,0 +1,56 @@
+-- Cerrar sesiones activas duplicadas: conservar solo la más reciente por usuario y dispositivo
+WITH sesiones_duplicadas AS (
+    SELECT id,
+           ROW_NUMBER() OVER (
+               PARTITION BY usuario_id, id_dispositivo
+               ORDER BY id DESC
+           ) AS orden
+    FROM configuraciones.inicio_sesion
+    WHERE hora_fin IS NULL
+      AND usuario_id IS NOT NULL
+      AND id_dispositivo IS NOT NULL
+)
+UPDATE configuraciones.inicio_sesion s
+SET hora_fin = NOW(),
+    token = NULL
+FROM sesiones_duplicadas d
+WHERE s.id = d.id
+  AND d.orden > 1;
+
+-- Limpiar tokens en sesiones ya cerradas
+UPDATE configuraciones.inicio_sesion
+SET token = NULL
+WHERE hora_fin IS NOT NULL
+  AND token IS NOT NULL;
+
+-- Por cada token FCM activo, conservar solo la sesión más reciente
+WITH tokens_duplicados AS (
+    SELECT id,
+           ROW_NUMBER() OVER (
+               PARTITION BY token
+               ORDER BY id DESC
+           ) AS orden
+    FROM configuraciones.inicio_sesion
+    WHERE hora_fin IS NULL
+      AND token IS NOT NULL
+      AND token <> ''
+)
+UPDATE configuraciones.inicio_sesion s
+SET token = NULL
+FROM tokens_duplicados t
+WHERE s.id = t.id
+  AND t.orden > 1;
+
+-- VENTA_STOCK_CRITICO solo para rol ADMIN (preferencias y envío alineados)
+DELETE FROM configuraciones.notificacion_tipo_role
+WHERE tipo_notificacion = 'VENTA_STOCK_CRITICO';
+
+INSERT INTO configuraciones.notificacion_tipo_role (role_id, tipo_notificacion, descripcion, es_obligatorio, creado_en)
+SELECT r.id,
+       'VENTA_STOCK_CRITICO',
+       'Alerta de venta con stock resultante cero o negativo',
+       false,
+       NOW()
+FROM personas.role r
+WHERE r.nombre = 'ADMIN'
+ON CONFLICT (role_id, tipo_notificacion) DO NOTHING;

--- a/src/main/resources/db/migration/V138.3__cleanup_duplicate_push_sessions.sql
+++ b/src/main/resources/db/migration/V138.3__cleanup_duplicate_push_sessions.sql
@@ -1,0 +1,69 @@
+-- Limpieza única al actualizar el sistema (Flyway). No hay limpieza programada en runtime.
+-- Un token FCM solo puede existir en una sesión (global, todos los usuarios)
+WITH tokens_duplicados AS (
+    SELECT id,
+           ROW_NUMBER() OVER (
+               PARTITION BY token
+               ORDER BY id DESC
+           ) AS orden
+    FROM configuraciones.inicio_sesion
+    WHERE hora_fin IS NULL
+      AND token IS NOT NULL
+      AND token <> ''
+)
+UPDATE configuraciones.inicio_sesion s
+SET token = NULL
+FROM tokens_duplicados t
+WHERE s.id = t.id
+  AND t.orden > 1;
+
+-- Cerrar sesiones activas duplicadas por usuario y dispositivo (conservar la más reciente)
+WITH sesiones_duplicadas AS (
+    SELECT id,
+           ROW_NUMBER() OVER (
+               PARTITION BY usuario_id, id_dispositivo
+               ORDER BY id DESC
+           ) AS orden
+    FROM configuraciones.inicio_sesion
+    WHERE hora_fin IS NULL
+      AND usuario_id IS NOT NULL
+      AND id_dispositivo IS NOT NULL
+)
+UPDATE configuraciones.inicio_sesion s
+SET hora_fin = NOW(),
+    token = NULL
+FROM sesiones_duplicadas d
+WHERE s.id = d.id
+  AND d.orden > 1;
+
+-- Cerrar todas las sesiones abiertas sin token push (huérfanas)
+UPDATE configuraciones.inicio_sesion
+SET hora_fin = NOW()
+WHERE hora_fin IS NULL
+  AND (token IS NULL OR token = '');
+
+-- Conservar solo una sesión abierta por usuario (prioriza la que tiene token push)
+WITH sesion_activa_por_usuario AS (
+    SELECT id,
+           ROW_NUMBER() OVER (
+               PARTITION BY usuario_id
+               ORDER BY CASE WHEN token IS NOT NULL AND token <> '' THEN 0 ELSE 1 END,
+                        id DESC
+           ) AS orden
+    FROM configuraciones.inicio_sesion
+    WHERE hora_fin IS NULL
+      AND usuario_id IS NOT NULL
+)
+UPDATE configuraciones.inicio_sesion s
+SET hora_fin = NOW(),
+    token = NULL
+FROM sesion_activa_por_usuario a
+WHERE s.id = a.id
+  AND a.orden > 1;
+
+-- Cerrar sesiones abiertas antiguas sin token (residual)
+UPDATE configuraciones.inicio_sesion
+SET hora_fin = NOW()
+WHERE hora_fin IS NULL
+  AND (token IS NULL OR token = '')
+  AND hora_inicio < NOW() - INTERVAL '7 days';

--- a/src/main/resources/db/migration/V139.3__fix_usuario_role_usuario_id_mismatch.sql
+++ b/src/main/resources/db/migration/V139.3__fix_usuario_role_usuario_id_mismatch.sql
@@ -1,0 +1,6 @@
+-- user_id es el titular del rol (UI, JWT, NotificationRoleService).
+-- Corrige registros donde usuario_id apunta a otro usuario distinto.
+UPDATE personas.usuario_role
+SET usuario_id = user_id
+WHERE user_id IS NOT NULL
+  AND (usuario_id IS NULL OR usuario_id <> user_id);

--- a/src/main/resources/graphql/configuracion/inicio-sesion.graphqls
+++ b/src/main/resources/graphql/configuracion/inicio-sesion.graphqls
@@ -40,7 +40,7 @@ extend type Query {
 
 extend type Mutation {
     saveInicioSesion(entity:InicioSesionInput!):InicioSesion
-    actualizarTokenFcm(tokenFcm: String!): Boolean
+    actualizarTokenFcm(tokenFcm: String!, idDispositivo: String): Boolean
     notificarInicioSesion(usuarioId: Int!): Boolean
 }
 


### PR DESCRIPTION
## Summary
- Deduplica el envío push por usuario, asegura exclusividad de tokens FCM y limpia sesiones duplicadas en migraciones Flyway.
- Corrige la resolución de destinatarios de `VENTA_STOCK_CRITICO` para usar `user_id` en lugar de `usuario_id`, alineado con la UI y el resto de notificaciones.
- Sincroniza `user_id` y `usuario_id` al guardar `usuario_role` y agrega migración para corregir registros históricos inconsistentes.

## Test plan
- [ ] Reiniciar backend y verificar que Flyway aplique V137.3, V138.3 y V139.3 en bodega3
- [ ] Confirmar en BD que `usuario_role.usuario_id = user_id` para el usuario DIEGO AMARILLA (id 494) en roles ADMIN y SOPORTE
- [ ] Realizar una venta con stock cero o negativo y verificar que el admin recibe la notificación `VENTA_STOCK_CRITICO`
- [ ] Verificar que otras notificaciones push siguen llegando correctamente en desktop y mobile
- [ ] Validar que al iniciar sesión desde mobile/desktop se actualiza el token FCM sin duplicar sesiones activas


Made with [Cursor](https://cursor.com)