### PR TITLE
feat(graficos): agregar precio promedio y cantidad en unidad base

### DIFF
--- a/src/main/java/com/franco/dev/graphql/operaciones/dto/ProductoVendidoEstadistica.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/dto/ProductoVendidoEstadistica.java
@@ -17,6 +17,8 @@ public class ProductoVendidoEstadistica {
     private String descripcion;
     private Double cantidad;
     private Double totalMonto;
+    /** Dinero vendido / unidades vendidas (unidad base) */
+    private Double precioPromedio;
     private Double porcentaje;
     /** Entradas por COMPRA + TRANSFERENCIA (movimiento_stock, cantidad > 0) */
     private Double cantidadEntrada;

--- a/src/main/java/com/franco/dev/graphql/operaciones/dto/ProductoVentaPorPeriodo.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/dto/ProductoVentaPorPeriodo.java
@@ -11,4 +11,6 @@ public class ProductoVentaPorPeriodo {
     private String periodo;
     private Double cantidad;
     private Double totalMonto;
+    /** Dinero vendido / unidades vendidas (unidad base) */
+    private Double precioPromedio;
 }

--- a/src/main/java/com/franco/dev/service/grafico/GraficoAggregationService.java
+++ b/src/main/java/com/franco/dev/service/grafico/GraficoAggregationService.java
@@ -542,8 +542,16 @@ public class GraficoAggregationService {
         }
         for (ProductoVendidoEstadistica item : items) {
             item.setPorcentaje(total > 0 ? (item.getTotalMonto() / total) * 100.0 : 0.0);
+            item.setPrecioPromedio(calcularPrecioPromedio(item.getTotalMonto(), item.getCantidad()));
             item.setIndiceRotacion(calcularIndiceRotacion(item));
         }
+    }
+
+    private Double calcularPrecioPromedio(Double totalMonto, Double cantidad) {
+        if (cantidad != null && cantidad > 0 && totalMonto != null) {
+            return Math.round((totalMonto / cantidad) * 100.0) / 100.0;
+        }
+        return 0.0;
     }
 
     private Double calcularIndiceRotacion(ProductoVendidoEstadistica item) {

--- a/src/main/java/com/franco/dev/service/operaciones/VentaItemService.java
+++ b/src/main/java/com/franco/dev/service/operaciones/VentaItemService.java
@@ -144,10 +144,11 @@ public class VentaItemService extends CrudService<VentaItem, VentaItemRepository
         String filtrosVi = construirFiltrosVentaItem(
                 inicio, fin, sucursalId, familiaId, subfamiliaId, productoId, productoIds);
 
-        String sql = "SELECT p.id, p.descripcion, SUM(vi.cantidad) AS cantidad, "
+        String sql = "SELECT p.id, p.descripcion, SUM(vi.cantidad * pre.cantidad) AS cantidad, "
                 + "SUM((vi.precio * vi.cantidad) - COALESCE(vi.descuento_unitario * vi.cantidad, 0)) AS total_monto "
                 + "FROM operaciones.venta_item vi "
                 + "JOIN productos.producto p ON vi.producto_id = p.id "
+                + "JOIN productos.presentacion pre ON pre.id = vi.presentacion_id "
                 + "JOIN operaciones.venta v ON vi.venta_id = v.id AND vi.sucursal_id = v.sucursal_id "
                 + "LEFT JOIN productos.subfamilia sf ON p.sub_familia_id = sf.id "
                 + "WHERE v.estado = 'CONCLUIDA' AND vi.activo = true "
@@ -322,9 +323,10 @@ public class VentaItemService extends CrudService<VentaItem, VentaItemRepository
 
     public List<ProductoVentaPorPeriodo> obtenerVentasProductoPorDia(LocalDateTime inicio, LocalDateTime fin,
             Long productoId, Long sucursalId) {
-        String sql = "SELECT CAST(vi.creado_en AS DATE) as periodo, SUM(vi.cantidad) as cantidad, " +
+        String sql = "SELECT CAST(vi.creado_en AS DATE) as periodo, SUM(vi.cantidad * pre.cantidad) as cantidad, " +
                 "SUM((vi.precio * vi.cantidad) - COALESCE(vi.descuento_unitario * vi.cantidad, 0)) as total_monto " +
                 "FROM operaciones.venta_item vi " +
+                "JOIN productos.presentacion pre ON pre.id = vi.presentacion_id " +
                 "JOIN operaciones.venta v ON vi.venta_id = v.id AND vi.sucursal_id = v.sucursal_id " +
                 "WHERE v.estado = 'CONCLUIDA' AND vi.activo = true AND vi.producto_id = :productoId ";
 
@@ -347,9 +349,10 @@ public class VentaItemService extends CrudService<VentaItem, VentaItemRepository
 
     public List<ProductoVentaPorPeriodo> obtenerVentasProductoPorMes(LocalDateTime inicio, LocalDateTime fin,
             Long productoId, Long sucursalId) {
-        String sql = "SELECT TO_CHAR(vi.creado_en, 'YYYY-MM') as periodo, SUM(vi.cantidad) as cantidad, " +
+        String sql = "SELECT TO_CHAR(vi.creado_en, 'YYYY-MM') as periodo, SUM(vi.cantidad * pre.cantidad) as cantidad, " +
                 "SUM((vi.precio * vi.cantidad) - COALESCE(vi.descuento_unitario * vi.cantidad, 0)) as total_monto " +
                 "FROM operaciones.venta_item vi " +
+                "JOIN productos.presentacion pre ON pre.id = vi.presentacion_id " +
                 "JOIN operaciones.venta v ON vi.venta_id = v.id AND vi.sucursal_id = v.sucursal_id " +
                 "WHERE v.estado = 'CONCLUIDA' AND vi.activo = true AND vi.producto_id = :productoId ";
 
@@ -437,7 +440,12 @@ public class VentaItemService extends CrudService<VentaItem, VentaItemRepository
             String periodo = fila[0] != null ? fila[0].toString() : "";
             Double cantidad = fila[1] != null ? ((Number) fila[1]).doubleValue() : 0.0;
             Double totalMonto = fila[2] != null ? ((Number) fila[2]).doubleValue() : 0.0;
-            periodos.add(new ProductoVentaPorPeriodo(periodo, cantidad, totalMonto));
+            ProductoVentaPorPeriodo dto = new ProductoVentaPorPeriodo();
+            dto.setPeriodo(periodo);
+            dto.setCantidad(cantidad);
+            dto.setTotalMonto(totalMonto);
+            dto.setPrecioPromedio(calcularPrecioPromedio(totalMonto, cantidad));
+            periodos.add(dto);
         }
         return periodos;
     }
@@ -475,6 +483,7 @@ public class VentaItemService extends CrudService<VentaItem, VentaItemRepository
             dto.setDescripcion(descripcion);
             dto.setCantidad(cantidad);
             dto.setTotalMonto(totalMonto);
+            dto.setPrecioPromedio(calcularPrecioPromedio(totalMonto, cantidad));
             dto.setPorcentaje(porcentaje);
             dto.setCantidadEntrada(cantidadEntrada);
             dto.setCantidadVentaMovimiento(cantidadVentaMovimiento);
@@ -483,6 +492,16 @@ public class VentaItemService extends CrudService<VentaItem, VentaItemRepository
         }
 
         return estadisticas;
+    }
+
+    /**
+     * Precio promedio por unidad base: dinero vendido / unidades vendidas.
+     */
+    private Double calcularPrecioPromedio(Double totalMonto, Double cantidad) {
+        if (cantidad != null && cantidad > 0 && totalMonto != null) {
+            return Math.round((totalMonto / cantidad) * 100.0) / 100.0;
+        }
+        return 0.0;
     }
 
     /**

--- a/src/main/resources/graphql/operaciones/venta-item.graphqls
+++ b/src/main/resources/graphql/operaciones/venta-item.graphqls
@@ -36,6 +36,7 @@ type ProductoVendidoEstadistica {
     descripcion: String
     cantidad: Float
     totalMonto: Float
+    precioPromedio: Float
     porcentaje: Float
     cantidadEntrada: Float
     cantidadVentaMovimiento: Float
@@ -48,6 +49,7 @@ type ProductoVentaPorPeriodo {
     periodo: String
     cantidad: Float
     totalMonto: Float
+    precioPromedio: Float
 }
 
 type ProductoCompraPorPeriodo {


### PR DESCRIPTION
## Summary
- Agrega el campo `precioPromedio` (dinero vendido / unidades en unidad base) a `ProductoVendidoEstadistica` y `ProductoVentaPorPeriodo`.
- Corrige el cálculo de cantidad en consultas de ventas usando el multiplicador de presentación (`vi.cantidad * pre.cantidad`).
- Expone `precioPromedio` en el esquema GraphQL de `venta-item`.

## Test plan
- [ ] Consultar productos vendidos por rango de fechas y verificar que `cantidad` refleja unidades base.
- [ ] Verificar que `precioPromedio` = `totalMonto / cantidad` con dos decimales.
- [ ] Consultar ventas de un producto por día/mes y validar `precioPromedio` en cada período.
- [ ] Confirmar que el frontend de gráficos muestra correctamente los nuevos datos.

## Impacto en DB
Ninguno. Solo cambios en consultas SQL, DTOs y esquema GraphQL.

## Impacto en rollback
Bajo. El campo nuevo es aditivo; clientes anteriores no lo consumen.

## Riesgo
Bajo

Made with [Cursor](https://cursor.com)