### PR TITLE
fix(inicio-sesion): corregir guardado con clave compuesta al cerrar sesion

### DIFF
--- a/src/main/java/com/franco/dev/domain/configuracion/InicioSesion.java
+++ b/src/main/java/com/franco/dev/domain/configuracion/InicioSesion.java
@@ -1,5 +1,6 @@
 package com.franco.dev.domain.configuracion;
 
+import com.franco.dev.domain.EmbebedPrimaryKey;
 import com.franco.dev.domain.configuracion.enums.TipoDispositivo;
 import com.franco.dev.domain.empresarial.Sucursal;
 import com.franco.dev.domain.personas.Usuario;
@@ -21,20 +22,24 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "inicio_sesion", schema = "configuraciones")
 @TypeDef(name = "tipo_dispositivo", typeClass = PostgreSQLEnumType.class)
+@IdClass(EmbebedPrimaryKey.class)
 public class InicioSesion implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Id
+    @Column(name = "sucursal_id", nullable = false)
+    private Long sucursalId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "usuario_id", nullable = true)
     private Usuario usuario;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "sucursal_id", nullable = true)
+    @JoinColumn(name = "sucursal_id", insertable = false, updatable = false)
     private Sucursal sucursal;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/franco/dev/repository/configuracion/InicioSesionGraphQL.java
+++ b/src/main/java/com/franco/dev/repository/configuracion/InicioSesionGraphQL.java
@@ -1,5 +1,6 @@
 package com.franco.dev.repository.configuracion;
 
+import com.franco.dev.domain.EmbebedPrimaryKey;
 import com.franco.dev.domain.configuracion.InicioSesion;
 import com.franco.dev.fmc.service.NotificationTemplateService;
 import com.franco.dev.fmc.service.PushNotificationService;
@@ -36,8 +37,11 @@ public class InicioSesionGraphQL implements GraphQLQueryResolver, GraphQLMutatio
     @Autowired
     private SucursalService sucursalService;
 
-    public Optional<InicioSesion> inicioSesion(Long id) {
-        return service.findById(id);
+    public Optional<InicioSesion> inicioSesion(Long id, Long sucursalId) {
+        if (sucursalId == null) {
+            sucursalId = 0L;
+        }
+        return service.findById(new EmbebedPrimaryKey(id, sucursalId));
     }
 
     public List<InicioSesion> inicioSesiones() {
@@ -63,6 +67,10 @@ public class InicioSesionGraphQL implements GraphQLQueryResolver, GraphQLMutatio
 
         if (e.getSucursal() == null) {
             e.setSucursal(sucursalService.findById(0L).orElse(null));
+        }
+
+        if (e.getSucursal() != null) {
+            e.setSucursalId(e.getSucursal().getId());
         }
 
         e.setIdDispositivo(input.getIdDispositivo());
@@ -93,8 +101,11 @@ public class InicioSesionGraphQL implements GraphQLQueryResolver, GraphQLMutatio
         return saved;
     }
 
-    public Boolean deleteInicioSesion(Long id) {
-        return service.deleteById(id);
+    public Boolean deleteInicioSesion(Long id, Long sucursalId) {
+        if (sucursalId == null) {
+            sucursalId = 0L;
+        }
+        return service.deleteById(new EmbebedPrimaryKey(id, sucursalId));
     }
 
     public Long countInicioSesion() {

--- a/src/main/java/com/franco/dev/repository/configuracion/InicioSesionRepository.java
+++ b/src/main/java/com/franco/dev/repository/configuracion/InicioSesionRepository.java
@@ -1,5 +1,6 @@
 package com.franco.dev.repository.configuracion;
 
+import com.franco.dev.domain.EmbebedPrimaryKey;
 import com.franco.dev.domain.configuracion.InicioSesion;
 import com.franco.dev.repository.HelperRepository;
 import java.util.Collection;
@@ -7,12 +8,17 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface InicioSesionRepository extends HelperRepository<InicioSesion, Long> {
+public interface InicioSesionRepository extends HelperRepository<InicioSesion, EmbebedPrimaryKey> {
 
     default Class<InicioSesion> getEntityClass() {
         return InicioSesion.class;
     }
+
+    @Query("SELECT MAX(s.id) FROM InicioSesion s WHERE s.sucursalId = :sucursalId")
+    Long findMaxId(@Param("sucursalId") Long sucursalId);
 
     Page<InicioSesion> findByUsuarioIdAndHoraFinIsNullOrderByIdDesc(Long id, Pageable page);
 

--- a/src/main/java/com/franco/dev/service/configuracion/InicioSesionService.java
+++ b/src/main/java/com/franco/dev/service/configuracion/InicioSesionService.java
@@ -1,5 +1,6 @@
 package com.franco.dev.service.configuracion;
 
+import com.franco.dev.domain.EmbebedPrimaryKey;
 import com.franco.dev.domain.configuracion.InicioSesion;
 import com.franco.dev.repository.configuracion.InicioSesionRepository;
 import com.franco.dev.service.CrudService;
@@ -18,7 +19,7 @@ import java.util.Set;
 
 @Service
 @AllArgsConstructor
-public class InicioSesionService extends CrudService<InicioSesion, InicioSesionRepository, Long> {
+public class InicioSesionService extends CrudService<InicioSesion, InicioSesionRepository, EmbebedPrimaryKey> {
 
     private final InicioSesionRepository repository;
 
@@ -42,6 +43,23 @@ public class InicioSesionService extends CrudService<InicioSesion, InicioSesionR
 
         if (isNew) {
             entity.setCreadoEn(now);
+        }
+
+        if (entity.getSucursalId() == null) {
+            if (entity.getSucursal() != null) {
+                entity.setSucursalId(entity.getSucursal().getId());
+            } else {
+                entity.setSucursalId(0L);
+            }
+        }
+
+        if (entity.getId() == null) {
+            Long lastId = repository.findMaxId(entity.getSucursalId());
+            long newId = (lastId == null ? 0L : lastId) + 1L;
+            if (newId % 2 == 0) {
+                newId++;
+            }
+            entity.setId(newId);
         }
 
         cerrarOtrasSesionesActivasDelDispositivo(entity, now);


### PR DESCRIPTION
## Summary
- Alinea `InicioSesion` con el patrón de clave compuesta (`id` + `sucursalId`) usado en el resto del backend.
- Elimina `@GeneratedValue` incompatible con `@IdClass`, que provocaba el error `POST_INSERT_INDICATOR` al cerrar sesión.
- Asigna el `id` manualmente con `findMaxId` y asegura `sucursalId` en el guardado GraphQL.

## Test plan
- [ ] Iniciar sesión en la app y verificar que se crea correctamente el registro en `inicio_sesion`.
- [ ] Cerrar sesión y confirmar que `horaFin` se persiste sin error GraphQL.
- [ ] Verificar que `deleteInicioSesion` y `inicioSesion` funcionan con `id` y `sucursalId`.


Made with [Cursor](https://cursor.com)