### PR TITLE
feat(inventario): fuentes de verdad en productos vencidos y alertas en transferencia

### DIFF
--- a/src/main/java/com/franco/dev/domain/operaciones/enums/FuenteVerdadVencimiento.java
+++ b/src/main/java/com/franco/dev/domain/operaciones/enums/FuenteVerdadVencimiento.java
@@ -1,0 +1,7 @@
+package com.franco.dev.domain.operaciones.enums;
+
+public enum FuenteVerdadVencimiento {
+    INVENTARIO,
+    COMPRA,
+    TRANSFERENCIA
+}

--- a/src/main/java/com/franco/dev/graphql/operaciones/InventarioProductoItemGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/InventarioProductoItemGraphQL.java
@@ -6,9 +6,12 @@ import com.franco.dev.domain.operaciones.InventarioProductoItem;
 import com.franco.dev.domain.operaciones.dto.ProductoSaldoDto;
 import com.franco.dev.domain.operaciones.dto.ReporteInventarioDto;
 import com.franco.dev.graphql.operaciones.input.InventarioProductoItemInput;
+import com.franco.dev.domain.operaciones.enums.FuenteVerdadVencimiento;
+import com.franco.dev.graphql.operaciones.dto.ProductoVencidoViewDTO;
 import com.franco.dev.service.operaciones.InventarioProductoItemService;
 import com.franco.dev.service.operaciones.InventarioProductoService;
 import com.franco.dev.service.operaciones.MovimientoStockService;
+import com.franco.dev.service.operaciones.ProductosVencidosService;
 import com.franco.dev.service.personas.UsuarioService;
 import com.franco.dev.service.productos.PresentacionService;
 import com.franco.dev.service.utils.ImageService;
@@ -33,6 +36,7 @@ import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.time.LocalDateTime;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static com.franco.dev.utilitarios.DateUtils.stringToDate;
 
@@ -60,6 +64,9 @@ public class InventarioProductoItemGraphQL implements GraphQLQueryResolver, Grap
 
     @Autowired
     private MovimientoStockService movimientoStockService;
+
+    @Autowired
+    private ProductosVencidosService productosVencidosService;
 
     private static final int DEFAULT_PAGE_SIZE = 50;
     private static final String DEFAULT_SORT_FIELD = "vencimiento";
@@ -269,7 +276,7 @@ public class InventarioProductoItemGraphQL implements GraphQLQueryResolver, Grap
         return movimientoStockService.findProductosFaltantes(sucursalId, productoId, stringToDate(fechaInicio), stringToDate(fechaFin), pageable);
     }
 
-    public Page<InventarioProductoItem> productosVencidos(
+    public Page<ProductoVencidoViewDTO> productosVencidos(
             @Nullable String startDate,
             @Nullable String endDate,
             @Nullable List<Long> sucursalIdList,
@@ -277,25 +284,27 @@ public class InventarioProductoItemGraphQL implements GraphQLQueryResolver, Grap
             @Nullable List<Long> zonaIdList,
             @Nullable List<Long> usuarioIdList,
             @Nullable List<Long> productoIdList,
+            @Nullable List<FuenteVerdadVencimiento> fuenteVerdadList,
             @Nullable Boolean soloRealmenteVencidos,
             Integer page,
             Integer size) {
 
         Pageable pageable = createPageable(page, size, DEFAULT_SORT_FIELD, "ASC");
 
-        if (startDate != null && endDate != null) {
-            return service.findProductosVencidosConFecha(
-                    sucursalIdList, sectorIdList, zonaIdList, stringToDate(startDate), stringToDate(endDate),
-                    usuarioIdList, productoIdList, pageable);
-        }
+        List<String> fuenteVerdadNombres = fuenteVerdadList == null ? null
+                : fuenteVerdadList.stream().map(FuenteVerdadVencimiento::name).collect(Collectors.toList());
 
-        if (Boolean.TRUE.equals(soloRealmenteVencidos)) {
-            return service.findProductosVencidos(
-                    sucursalIdList, sectorIdList, zonaIdList, usuarioIdList, productoIdList, pageable);
-        }
-
-        return service.findProductosVencidos(
-                sucursalIdList, sectorIdList, zonaIdList, usuarioIdList, productoIdList, pageable);
+        return productosVencidosService.buscarProductosVencidos(
+                stringToDate(startDate),
+                stringToDate(endDate),
+                sucursalIdList,
+                sectorIdList,
+                zonaIdList,
+                usuarioIdList,
+                productoIdList,
+                fuenteVerdadNombres,
+                soloRealmenteVencidos,
+                pageable);
     }
 
     public Page<InventarioProductoItem> productosVencidosPorSucursal(

--- a/src/main/java/com/franco/dev/graphql/operaciones/TransferenciaItemGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/TransferenciaItemGraphQL.java
@@ -9,9 +9,11 @@ import com.franco.dev.domain.operaciones.enums.TipoMovimiento;
 import com.franco.dev.domain.operaciones.enums.TransferenciaEstado;
 import com.franco.dev.domain.productos.CostoPorProducto;
 import com.franco.dev.domain.productos.Producto;
+import com.franco.dev.graphql.operaciones.dto.TransferenciaItemAlertaDTO;
 import com.franco.dev.graphql.operaciones.input.TransferenciaItemInput;
 import com.franco.dev.service.financiero.MonedaService;
 import com.franco.dev.service.operaciones.MovimientoStockService;
+import com.franco.dev.service.operaciones.TransferenciaItemAlertaService;
 import com.franco.dev.service.operaciones.TransferenciaItemService;
 import com.franco.dev.service.operaciones.TransferenciaService;
 import com.franco.dev.service.personas.UsuarioService;
@@ -60,6 +62,9 @@ public class TransferenciaItemGraphQL implements GraphQLQueryResolver, GraphQLMu
     @Autowired
     private MultiTenantService multiTenantService;
 
+    @Autowired
+    private TransferenciaItemAlertaService transferenciaItemAlertaService;
+
     public Optional<TransferenciaItem> transferenciaItem(Long id) {
         return service.findById(id);
     }
@@ -78,6 +83,10 @@ public class TransferenciaItemGraphQL implements GraphQLQueryResolver, GraphQLMu
             Integer size) {
         Page<TransferenciaItem> res = service.findByTransferenciaItemIdWithFilter(id, name, page, size);
         return res;
+    }
+
+    public List<TransferenciaItemAlertaDTO> alertasTransferenciaItems(Long transferenciaId, List<Long> itemIds) {
+        return transferenciaItemAlertaService.calcularAlertas(transferenciaId, itemIds);
     }
 
     public TransferenciaItem saveTransferenciaItem(TransferenciaItemInput input, Double precioCosto) {

--- a/src/main/java/com/franco/dev/graphql/operaciones/dto/InventarioAlertaProjectionDTO.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/dto/InventarioAlertaProjectionDTO.java
@@ -1,0 +1,19 @@
+package com.franco.dev.graphql.operaciones.dto;
+
+import com.franco.dev.domain.operaciones.enums.InventarioProductoEstado;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class InventarioAlertaProjectionDTO {
+
+    private Long productoId;
+    private Long presentacionId;
+    private LocalDateTime vencimiento;
+    private InventarioProductoEstado estado;
+}

--- a/src/main/java/com/franco/dev/graphql/operaciones/dto/ProductoVencidoViewDTO.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/dto/ProductoVencidoViewDTO.java
@@ -1,0 +1,44 @@
+package com.franco.dev.graphql.operaciones.dto;
+
+import com.franco.dev.domain.operaciones.enums.FuenteVerdadVencimiento;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductoVencidoViewDTO {
+
+    private Long id;
+    private Long presentacionId;
+    private Double presentacionCantidad;
+    private Long productoId;
+    private String productoDescripcion;
+    private String codigoBarras;
+    private Double cantidad;
+    private LocalDateTime vencimiento;
+    private Long inventarioProductoId;
+    private Long sucursalId;
+    private String sucursalNombre;
+    private String sectorDescripcion;
+    private String zonaDescripcion;
+    private Long usuarioId;
+    private String usuarioNickname;
+
+    private FuenteVerdadVencimiento fuenteVerdad;
+    private Long origenId;
+    private LocalDateTime fechaFuente;
+    private Long inventarioId;
+    private Double cantidadInventario;
+    private LocalDateTime vencimientoInventario;
+    private String referenciaInventario;
+    private String detalleFuente;
+
+    private Integer diasVencimiento;
+    private String diasVencimientoTexto;
+    private String vencimientoColor;
+    private String diasVencimientoClase;
+}

--- a/src/main/java/com/franco/dev/graphql/operaciones/dto/ProductoVencimientoCompraProjectionDTO.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/dto/ProductoVencimientoCompraProjectionDTO.java
@@ -1,0 +1,16 @@
+package com.franco.dev.graphql.operaciones.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductoVencimientoCompraProjectionDTO {
+
+    private Long productoId;
+    private LocalDate vencimientoEnNota;
+}

--- a/src/main/java/com/franco/dev/graphql/operaciones/dto/TransferenciaItemAlertaDTO.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/dto/TransferenciaItemAlertaDTO.java
@@ -1,0 +1,18 @@
+package com.franco.dev.graphql.operaciones.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TransferenciaItemAlertaDTO {
+
+    private Long transferenciaItemId;
+    private Boolean alertaVencido;
+    private Boolean alertaAveriado;
+    private LocalDateTime fechaVencimientoReferencia;
+}

--- a/src/main/java/com/franco/dev/repository/operaciones/InventarioProductoItemRepository.java
+++ b/src/main/java/com/franco/dev/repository/operaciones/InventarioProductoItemRepository.java
@@ -93,11 +93,11 @@ public interface InventarioProductoItemRepository extends HelperRepository<Inven
                         "JOIN i.usuario u " +
                         "WHERE (i.vencimiento < CURRENT_TIMESTAMP OR i.estado = :estadoVencido) " +
                         "AND inv.id = (SELECT MAX(inv2.id) FROM Inventario inv2 JOIN inv2.sucursal s2 WHERE s2.id = s.id) " +
-                        "AND (COALESCE(:sucursalIdList, NULL) IS NULL OR s.id IN :sucursalIdList) " +
-                        "AND (COALESCE(:sectorIdList, NULL) IS NULL OR sec.id IN :sectorIdList) " +
-                        "AND (COALESCE(:zonaIdList, NULL) IS NULL OR z.id IN :zonaIdList) " +
-                        "AND (COALESCE(:usuarioIdList, NULL) IS NULL OR u.id IN :usuarioIdList) " +
-                        "AND (COALESCE(:productoIdList, NULL) IS NULL OR pro.id IN :productoIdList) " +
+                        "AND (:#{#sucursalIdList == null || #sucursalIdList.isEmpty()} = true OR s.id IN :sucursalIdList) " +
+                        "AND (:#{#sectorIdList == null || #sectorIdList.isEmpty()} = true OR sec.id IN :sectorIdList) " +
+                        "AND (:#{#zonaIdList == null || #zonaIdList.isEmpty()} = true OR z.id IN :zonaIdList) " +
+                        "AND (:#{#usuarioIdList == null || #usuarioIdList.isEmpty()} = true OR u.id IN :usuarioIdList) " +
+                        "AND (:#{#productoIdList == null || #productoIdList.isEmpty()} = true OR pro.id IN :productoIdList) " +
                         "ORDER BY i.vencimiento DESC")
         Page<InventarioProductoItem> findProductosVencidos(
                         @Param("sucursalIdList") @Nullable List<Long> sucursalIdList,
@@ -130,11 +130,11 @@ public interface InventarioProductoItemRepository extends HelperRepository<Inven
                         "JOIN i.usuario u " +
                         "WHERE i.vencimiento BETWEEN :startDate AND :endDate " +
                         "AND inv.id = (SELECT MAX(inv2.id) FROM Inventario inv2 JOIN inv2.sucursal s2 WHERE s2.id = s.id) " +
-                        "AND (COALESCE(:sucursalIdList, NULL) IS NULL OR s.id IN :sucursalIdList) " +
-                        "AND (COALESCE(:sectorIdList, NULL) IS NULL OR sec.id IN :sectorIdList) " +
-                        "AND (COALESCE(:zonaIdList, NULL) IS NULL OR z.id IN :zonaIdList) " +
-                        "AND (COALESCE(:usuarioIdList, NULL) IS NULL OR u.id IN :usuarioIdList) " +
-                        "AND (COALESCE(:productoIdList, NULL) IS NULL OR pro.id IN :productoIdList) " +
+                        "AND (:#{#sucursalIdList == null || #sucursalIdList.isEmpty()} = true OR s.id IN :sucursalIdList) " +
+                        "AND (:#{#sectorIdList == null || #sectorIdList.isEmpty()} = true OR sec.id IN :sectorIdList) " +
+                        "AND (:#{#zonaIdList == null || #zonaIdList.isEmpty()} = true OR z.id IN :zonaIdList) " +
+                        "AND (:#{#usuarioIdList == null || #usuarioIdList.isEmpty()} = true OR u.id IN :usuarioIdList) " +
+                        "AND (:#{#productoIdList == null || #productoIdList.isEmpty()} = true OR pro.id IN :productoIdList) " +
                         "ORDER BY i.vencimiento DESC")
         Page<InventarioProductoItem> findProductosVencidosConFecha(
                         @Param("sucursalIdList") @Nullable List<Long> sucursalIdList,
@@ -197,11 +197,11 @@ public interface InventarioProductoItemRepository extends HelperRepository<Inven
                         "JOIN i.usuario u " +
                         "WHERE (i.vencimiento < CURRENT_TIMESTAMP OR i.estado = :estadoVencido) " +
                         "AND inv.id = (SELECT MAX(inv2.id) FROM Inventario inv2 JOIN inv2.sucursal s2 WHERE s2.id = s.id) " +
-                        "AND (COALESCE(:sucursalIdList, NULL) IS NULL OR s.id IN :sucursalIdList) " +
-                        "AND (COALESCE(:sectorIdList, NULL) IS NULL OR sec.id IN :sectorIdList) " +
-                        "AND (COALESCE(:zonaIdList, NULL) IS NULL OR z.id IN :zonaIdList) " +
-                        "AND (COALESCE(:usuarioIdList, NULL) IS NULL OR u.id IN :usuarioIdList) " +
-                        "AND (COALESCE(:productoIdList, NULL) IS NULL OR pro.id IN :productoIdList)")
+                        "AND (:#{#sucursalIdList == null || #sucursalIdList.isEmpty()} = true OR s.id IN :sucursalIdList) " +
+                        "AND (:#{#sectorIdList == null || #sectorIdList.isEmpty()} = true OR sec.id IN :sectorIdList) " +
+                        "AND (:#{#zonaIdList == null || #zonaIdList.isEmpty()} = true OR z.id IN :zonaIdList) " +
+                        "AND (:#{#usuarioIdList == null || #usuarioIdList.isEmpty()} = true OR u.id IN :usuarioIdList) " +
+                        "AND (:#{#productoIdList == null || #productoIdList.isEmpty()} = true OR pro.id IN :productoIdList)")
         Long countProductosVencidos(
                         @Param("sucursalIdList") @Nullable List<Long> sucursalIdList,
                         @Param("sectorIdList") @Nullable List<Long> sectorIdList,

--- a/src/main/java/com/franco/dev/repository/operaciones/InventarioProductoItemRepository.java
+++ b/src/main/java/com/franco/dev/repository/operaciones/InventarioProductoItemRepository.java
@@ -1,6 +1,7 @@
 package com.franco.dev.repository.operaciones;
 
 import com.franco.dev.domain.operaciones.InventarioProductoItem;
+import com.franco.dev.graphql.operaciones.dto.InventarioAlertaProjectionDTO;
 import com.franco.dev.domain.operaciones.enums.InventarioProductoEstado;
 import com.franco.dev.repository.HelperRepository;
 import org.springframework.data.domain.Page;
@@ -297,4 +298,17 @@ public interface InventarioProductoItemRepository extends HelperRepository<Inven
                 return findItemsDeInventariosAnterioresSoloSucursal(presentacionId, sucursalId,
                                 fechaInicioInventarioActual, pageable.getPageSize(), (int) pageable.getOffset());
         }
+
+        @Query("SELECT new com.franco.dev.graphql.operaciones.dto.InventarioAlertaProjectionDTO(" +
+                        "pre.producto.id, ipi.presentacion.id, ipi.vencimiento, ipi.estado) " +
+                        "FROM InventarioProductoItem ipi " +
+                        "JOIN ipi.presentacion pre " +
+                        "JOIN ipi.inventarioProducto ip " +
+                        "JOIN ip.inventario inv " +
+                        "WHERE inv.sucursal.id = :sucursalId " +
+                        "AND inv.id = (SELECT MAX(inv2.id) FROM Inventario inv2 WHERE inv2.sucursal.id = :sucursalId) " +
+                        "AND pre.producto.id IN :productoIds")
+        List<InventarioAlertaProjectionDTO> findAlertasBySucursalAndProductoIds(
+                        @Param("sucursalId") Long sucursalId,
+                        @Param("productoIds") List<Long> productoIds);
 }

--- a/src/main/java/com/franco/dev/repository/operaciones/InventarioProductoItemRepository.java
+++ b/src/main/java/com/franco/dev/repository/operaciones/InventarioProductoItemRepository.java
@@ -92,7 +92,6 @@ public interface InventarioProductoItemRepository extends HelperRepository<Inven
                         "LEFT JOIN z.sector sec " +
                         "JOIN i.usuario u " +
                         "WHERE (i.vencimiento < CURRENT_TIMESTAMP OR i.estado = :estadoVencido) " +
-                        "AND (SELECT COALESCE(SUM(ms.cantidad), 0) FROM MovimientoStock ms WHERE ms.estado = true AND ms.producto = pro AND ms.sucursalId = s.id) > 0 " +
                         "AND inv.id = (SELECT MAX(inv2.id) FROM Inventario inv2 JOIN inv2.sucursal s2 WHERE s2.id = s.id) " +
                         "AND (COALESCE(:sucursalIdList, NULL) IS NULL OR s.id IN :sucursalIdList) " +
                         "AND (COALESCE(:sectorIdList, NULL) IS NULL OR sec.id IN :sectorIdList) " +
@@ -130,7 +129,6 @@ public interface InventarioProductoItemRepository extends HelperRepository<Inven
                         "LEFT JOIN z.sector sec " +
                         "JOIN i.usuario u " +
                         "WHERE i.vencimiento BETWEEN :startDate AND :endDate " +
-                        "AND (SELECT COALESCE(SUM(ms.cantidad), 0) FROM MovimientoStock ms WHERE ms.estado = true AND ms.producto = pro AND ms.sucursalId = s.id) > 0 " +
                         "AND inv.id = (SELECT MAX(inv2.id) FROM Inventario inv2 JOIN inv2.sucursal s2 WHERE s2.id = s.id) " +
                         "AND (COALESCE(:sucursalIdList, NULL) IS NULL OR s.id IN :sucursalIdList) " +
                         "AND (COALESCE(:sectorIdList, NULL) IS NULL OR sec.id IN :sectorIdList) " +

--- a/src/main/java/com/franco/dev/repository/operaciones/NotaRecepcionItemRepository.java
+++ b/src/main/java/com/franco/dev/repository/operaciones/NotaRecepcionItemRepository.java
@@ -1,6 +1,7 @@
 package com.franco.dev.repository.operaciones;
 
 import com.franco.dev.domain.operaciones.NotaRecepcionItem;
+import com.franco.dev.graphql.operaciones.dto.ProductoVencimientoCompraProjectionDTO;
 import com.franco.dev.graphql.operaciones.dto.ResumenItemsNotaDTO;
 import com.franco.dev.repository.HelperRepository;
 import org.springframework.data.domain.Page;
@@ -212,4 +213,17 @@ public interface NotaRecepcionItemRepository extends HelperRepository<NotaRecepc
            countQuery = "SELECT COUNT(nri) FROM NotaRecepcionItem nri " +
            "WHERE nri.producto.id = :productoId")
     Page<NotaRecepcionItem> findUltimasComprasByProductoId(@Param("productoId") Long productoId, Pageable pageable);
+
+    @Query("SELECT new com.franco.dev.graphql.operaciones.dto.ProductoVencimientoCompraProjectionDTO(" +
+           "nri.producto.id, nri.vencimientoEnNota) " +
+           "FROM NotaRecepcionItem nri " +
+           "WHERE nri.producto.id IN :productoIds " +
+           "AND nri.vencimientoEnNota IS NOT NULL " +
+           "AND nri.creadoEn = (" +
+           "  SELECT MAX(nri2.creadoEn) FROM NotaRecepcionItem nri2 " +
+           "  WHERE nri2.producto.id = nri.producto.id " +
+           "  AND nri2.vencimientoEnNota IS NOT NULL" +
+           ")")
+    List<ProductoVencimientoCompraProjectionDTO> findUltimoVencimientoEnNotaByProductoIds(
+            @Param("productoIds") List<Long> productoIds);
 }

--- a/src/main/java/com/franco/dev/repository/operaciones/TransferenciaItemRepository.java
+++ b/src/main/java/com/franco/dev/repository/operaciones/TransferenciaItemRepository.java
@@ -47,6 +47,8 @@ public interface TransferenciaItemRepository extends HelperRepository<Transferen
 
     public List<TransferenciaItem> findByTransferenciaIdOrderByIdDesc(Long id);//
     public List<TransferenciaItem> findByTransferenciaIdOrderByIdAsc(Long id);//
+
+    List<TransferenciaItem> findByIdInAndTransferenciaId(List<Long> ids, Long transferenciaId);
     // public List<Transferencia> findBySucursalDestinoId(Long id);
 //
 //    @Query("select e from Transferencia e " +

--- a/src/main/java/com/franco/dev/service/operaciones/InventarioProductoItemService.java
+++ b/src/main/java/com/franco/dev/service/operaciones/InventarioProductoItemService.java
@@ -15,6 +15,7 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Service
 @AllArgsConstructor
@@ -75,7 +76,15 @@ public class InventarioProductoItemService
             @Nullable String estado,
             Pageable pageable) {
         return repository.findAllWithFilters(
-                sucursalIdList, sectorIdList, zonaIdList, startDate, endDate, usuarioIdList, productoIdList, estado, pageable);
+                toLongList(sucursalIdList),
+                toLongList(sectorIdList),
+                toLongList(zonaIdList),
+                startDate,
+                endDate,
+                toLongList(usuarioIdList),
+                toLongList(productoIdList),
+                estado,
+                pageable);
     }
 
     public Page<InventarioProductoItem> findProductosVencidos(
@@ -86,7 +95,12 @@ public class InventarioProductoItemService
             @Nullable List<Long> productoIdList,
             Pageable pageable) {
         return repository.findProductosVencidos(
-                sucursalIdList, sectorIdList, zonaIdList, usuarioIdList, productoIdList, pageable);
+                toLongList(sucursalIdList),
+                toLongList(sectorIdList),
+                toLongList(zonaIdList),
+                toLongList(usuarioIdList),
+                toLongList(productoIdList),
+                pageable);
     }
 
     public Page<InventarioProductoItem> findProductosVencidosConFecha(
@@ -99,7 +113,14 @@ public class InventarioProductoItemService
             @Nullable List<Long> productoIdList,
             Pageable pageable) {
         return repository.findProductosVencidosConFecha(
-                sucursalIdList, sectorIdList, zonaIdList, startDate, endDate, usuarioIdList, productoIdList, pageable);
+                toLongList(sucursalIdList),
+                toLongList(sectorIdList),
+                toLongList(zonaIdList),
+                startDate,
+                endDate,
+                toLongList(usuarioIdList),
+                toLongList(productoIdList),
+                pageable);
     }
 
     public Page<InventarioProductoItem> findProductosProximosAVencer(
@@ -111,7 +132,12 @@ public class InventarioProductoItemService
             LocalDateTime fechaProximoVencimiento,
             Pageable pageable) {
         return repository.findProductosProximosAVencer(
-                sucursalIdList, sectorIdList, zonaIdList, usuarioIdList, productoIdList, fechaProximoVencimiento,
+                toLongList(sucursalIdList),
+                toLongList(sectorIdList),
+                toLongList(zonaIdList),
+                toLongList(usuarioIdList),
+                toLongList(productoIdList),
+                fechaProximoVencimiento,
                 pageable);
     }
 
@@ -181,7 +207,11 @@ public class InventarioProductoItemService
             @Nullable List<Long> usuarioIdList,
             @Nullable List<Long> productoIdList) {
         return repository.countProductosVencidos(
-                sucursalIdList, sectorIdList, zonaIdList, usuarioIdList, productoIdList);
+                toLongList(sucursalIdList),
+                toLongList(sectorIdList),
+                toLongList(zonaIdList),
+                toLongList(usuarioIdList),
+                toLongList(productoIdList));
     }
 
     @Override
@@ -249,5 +279,21 @@ public class InventarioProductoItemService
         } catch (Exception e) {
             return false;
         }
+    }
+
+    /**
+     * GraphQL puede enviar [Int] como Integer; Hibernate requiere Long en listas IN.
+     */
+    @SuppressWarnings("unchecked")
+    @Nullable
+    private List<Long> toLongList(@Nullable List<Long> idList) {
+        if (idList == null || idList.isEmpty()) {
+            return null;
+        }
+        List<Long> converted = ((List<?>) (List<?>) idList).stream()
+                .filter(Objects::nonNull)
+                .map(id -> id instanceof Number ? ((Number) id).longValue() : Long.parseLong(id.toString()))
+                .collect(Collectors.toList());
+        return converted.isEmpty() ? null : converted;
     }
 }

--- a/src/main/java/com/franco/dev/service/operaciones/ProductosVencidosService.java
+++ b/src/main/java/com/franco/dev/service/operaciones/ProductosVencidosService.java
@@ -1,0 +1,546 @@
+package com.franco.dev.service.operaciones;
+
+import com.franco.dev.domain.operaciones.enums.FuenteVerdadVencimiento;
+import com.franco.dev.graphql.operaciones.dto.ProductoVencidoViewDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.Query;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+@Service
+public class ProductosVencidosService {
+
+    private static final String COLOR_SUCCESS = "#4caf50";
+    private static final String COLOR_WARNING = "#ff9800";
+    private static final String COLOR_DANGER = "#f44336";
+    private static final DateTimeFormatter FECHA_FORMATO = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Transactional(readOnly = true)
+    public Page<ProductoVencidoViewDTO> buscarProductosVencidos(
+            @Nullable LocalDateTime startDate,
+            @Nullable LocalDateTime endDate,
+            @Nullable List<Long> sucursalIdList,
+            @Nullable List<Long> sectorIdList,
+            @Nullable List<Long> zonaIdList,
+            @Nullable List<Long> usuarioIdList,
+            @Nullable List<Long> productoIdList,
+            @Nullable List<String> fuenteVerdadList,
+            @Nullable Boolean soloRealmenteVencidos,
+            Pageable pageable) {
+
+        FiltrosProductosVencidos filtros = new FiltrosProductosVencidos(
+                startDate, endDate, sucursalIdList, sectorIdList, zonaIdList, usuarioIdList, productoIdList,
+                fuenteVerdadList, soloRealmenteVencidos);
+
+        String sqlBase = construirSqlBase(filtros);
+        Map<String, Object> params = filtros.parametros();
+
+        String countSql = "SELECT COUNT(*) FROM (" + sqlBase + ") AS total";
+        Query countQuery = entityManager.createNativeQuery(countSql);
+        aplicarParametros(countQuery, params);
+        long total = ((Number) countQuery.getSingleResult()).longValue();
+
+        String paginatedSql = sqlBase + " ORDER BY vencimiento DESC LIMIT :pageSize OFFSET :pageOffset";
+        Query dataQuery = entityManager.createNativeQuery(paginatedSql);
+        aplicarParametros(dataQuery, params);
+        dataQuery.setParameter("pageSize", pageable.getPageSize());
+        dataQuery.setParameter("pageOffset", pageable.getOffset());
+
+        @SuppressWarnings("unchecked")
+        List<Object[]> rows = dataQuery.getResultList();
+        List<ProductoVencidoViewDTO> content = new ArrayList<>();
+        for (Object[] row : rows) {
+            content.add(enriquecer(mapearFila(row)));
+        }
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    private String construirSqlBase(FiltrosProductosVencidos filtros) {
+        return ""
+                + "WITH ultimo_inv AS ( "
+                + "  SELECT inv.sucursal_id, MAX(inv.id) AS inventario_id, MAX(inv.fecha_inicio) AS fecha_inicio "
+                + "  FROM operaciones.inventario inv "
+                + "  GROUP BY inv.sucursal_id "
+                + "), "
+                + "inv_snap AS ( "
+                + "  SELECT inv.sucursal_id, ipi.presentacion_id, DATE(ipi.vencimiento) AS vencimiento_dia, "
+                + "         MAX(ipi.cantidad) AS cantidad_inventario, MAX(ipi.vencimiento) AS vencimiento_inventario "
+                + "  FROM operaciones.inventario_producto_item ipi "
+                + "  JOIN operaciones.inventario_producto ip ON ip.id = ipi.inventario_producto_id "
+                + "  JOIN operaciones.inventario inv ON inv.id = ip.inventario_id "
+                + "  JOIN ultimo_inv ui ON ui.inventario_id = inv.id "
+                + "  WHERE ipi.vencimiento IS NOT NULL "
+                + "  GROUP BY inv.sucursal_id, ipi.presentacion_id, DATE(ipi.vencimiento) "
+                + "), "
+                + "candidatos AS ( "
+                + construirSqlInventario(filtros)
+                + "  UNION ALL "
+                + construirSqlCompraNota(filtros)
+                + "  UNION ALL "
+                + construirSqlCompraRecepcion(filtros)
+                + "  UNION ALL "
+                + construirSqlTransferenciaSalida(filtros)
+                + "  UNION ALL "
+                + construirSqlTransferenciaIngreso(filtros)
+                + "), "
+                + "rankeados AS ( "
+                + "  SELECT c.*, ui.fecha_inicio AS fecha_ultimo_inventario, "
+                + "         ROW_NUMBER() OVER ( "
+                + "           PARTITION BY c.sucursal_id, c.presentacion_id, DATE(c.vencimiento) "
+                + "           ORDER BY "
+                + "             CASE WHEN c.fuente_verdad <> 'INVENTARIO' AND c.fecha_fuente > ui.fecha_inicio THEN 0 ELSE 1 END, "
+                + "             c.fecha_fuente DESC "
+                + "         ) AS rn "
+                + "  FROM candidatos c "
+                + "  JOIN ultimo_inv ui ON ui.sucursal_id = c.sucursal_id "
+                + ") "
+                + "SELECT registro_id, fuente_verdad, presentacion_id, producto_id, producto_descripcion, codigo_barras, "
+                + "       presentacion_cantidad, cantidad, vencimiento, inventario_producto_id, sucursal_id, sucursal_nombre, "
+                + "       sector_descripcion, zona_descripcion, usuario_id, usuario_nickname, inventario_id, fecha_fuente, origen_id, "
+                + "       cantidad_inventario, vencimiento_inventario, tipo_movimiento "
+                + "FROM rankeados WHERE rn = 1 "
+                + filtros.filtroFuenteVerdad();
+    }
+
+    private String construirSqlInventario(FiltrosProductosVencidos filtros) {
+        return "  SELECT ipi.id AS registro_id, 'INVENTARIO' AS fuente_verdad, ipi.presentacion_id, pro.id AS producto_id, "
+                + "         pro.descripcion AS producto_descripcion, cod.codigo AS codigo_barras, "
+                + "         pre.cantidad AS presentacion_cantidad, ipi.cantidad, ipi.vencimiento, ip.id AS inventario_producto_id, "
+                + "         s.id AS sucursal_id, s.nombre AS sucursal_nombre, "
+                + "         COALESCE(sec_item.descripcion, sec_inv.descripcion) AS sector_descripcion, "
+                + "         COALESCE(z_item.descripcion, z_inv.descripcion) AS zona_descripcion, "
+                + "         u.id AS usuario_id, u.nickname AS usuario_nickname, inv.id AS inventario_id, "
+                + "         inv.fecha_inicio AS fecha_fuente, CAST(NULL AS bigint) AS origen_id, "
+                + "         snap.cantidad_inventario, snap.vencimiento_inventario, CAST(NULL AS text) AS tipo_movimiento "
+                + "  FROM operaciones.inventario_producto_item ipi "
+                + "  JOIN operaciones.inventario_producto ip ON ip.id = ipi.inventario_producto_id "
+                + "  JOIN operaciones.inventario inv ON inv.id = ip.inventario_id "
+                + "  JOIN ultimo_inv ui ON ui.inventario_id = inv.id "
+                + "  JOIN empresarial.sucursal s ON s.id = inv.sucursal_id "
+                + "  JOIN productos.presentacion pre ON pre.id = ipi.presentacion_id "
+                + "  JOIN productos.producto pro ON pro.id = pre.producto_id "
+                + "  LEFT JOIN productos.codigo cod ON cod.presentacion_id = pre.id AND cod.principal = true AND cod.activo = true "
+                + "  LEFT JOIN empresarial.zona z_item ON z_item.id = ipi.zona_id "
+                + "  LEFT JOIN empresarial.sector sec_item ON sec_item.id = z_item.sector_id "
+                + "  JOIN empresarial.zona z_inv ON z_inv.id = ip.zona_id "
+                + "  JOIN empresarial.sector sec_inv ON sec_inv.id = z_inv.sector_id "
+                + "  LEFT JOIN personas.usuario u ON u.id = ipi.usuario_id "
+                + "  LEFT JOIN inv_snap snap ON snap.sucursal_id = s.id AND snap.presentacion_id = ipi.presentacion_id "
+                + "       AND snap.vencimiento_dia = DATE(ipi.vencimiento) "
+                + "  WHERE ipi.vencimiento IS NOT NULL "
+                + filtros.filtroVencimientoInventario()
+                + filtros.filtroSucursal("s.id")
+                + filtros.filtroSectorInventario()
+                + filtros.filtroZonaInventario()
+                + filtros.filtroUsuario("u.id")
+                + filtros.filtroProducto("pro.id");
+    }
+
+    private String construirSqlCompraNota(FiltrosProductosVencidos filtros) {
+        if (filtros.tieneFiltroSectorOZona()) {
+            return construirSqlVacio();
+        }
+        return "  SELECT nrid.id, 'COMPRA', nri.presentacion_en_nota_id, nri.producto_id, pro.descripcion, cod.codigo, "
+                + "         pre.cantidad, nrid.cantidad, CAST(nri.vencimiento_en_nota AS timestamp), CAST(NULL AS bigint), "
+                + "         s.id, s.nombre, NULL, NULL, u.id, u.nickname, ui.inventario_id, "
+                + "         COALESCE(nri.creado_en, nr.fecha), nr.id, "
+                + "         snap.cantidad_inventario, snap.vencimiento_inventario, NULL "
+                + "  FROM operaciones.nota_recepcion_item_distribucion nrid "
+                + "  JOIN operaciones.nota_recepcion_item nri ON nri.id = nrid.nota_recepcion_item_id "
+                + "  JOIN operaciones.nota_recepcion nr ON nr.id = nri.nota_recepcion_id "
+                + "  JOIN ultimo_inv ui ON ui.sucursal_id = nrid.sucursal_entrega_id "
+                + "  JOIN empresarial.sucursal s ON s.id = nrid.sucursal_entrega_id "
+                + "  JOIN productos.producto pro ON pro.id = nri.producto_id "
+                + "  JOIN productos.presentacion pre ON pre.id = nri.presentacion_en_nota_id "
+                + "  LEFT JOIN productos.codigo cod ON cod.presentacion_id = pre.id AND cod.principal = true AND cod.activo = true "
+                + "  LEFT JOIN personas.usuario u ON u.id = COALESCE(nrid.usuario_id, nri.usuario_id) "
+                + "  LEFT JOIN inv_snap snap ON snap.sucursal_id = s.id AND snap.presentacion_id = nri.presentacion_en_nota_id "
+                + "       AND snap.vencimiento_dia = nri.vencimiento_en_nota "
+                + "  WHERE nri.vencimiento_en_nota IS NOT NULL "
+                + "    AND nri.presentacion_en_nota_id IS NOT NULL "
+                + "    AND COALESCE(nri.creado_en, nr.fecha) > ui.fecha_inicio "
+                + "    AND NOT EXISTS ( "
+                + "      SELECT 1 FROM operaciones.recepcion_mercaderia_item rmi "
+                + "      WHERE rmi.nota_recepcion_item_id = nri.id "
+                + "        AND rmi.sucursal_entrega_id = nrid.sucursal_entrega_id "
+                + "        AND rmi.vencimiento_recibido IS NOT NULL "
+                + "        AND COALESCE(rmi.cantidad_rechazada, 0) < rmi.cantidad_recibida "
+                + "    ) "
+                + filtros.filtroVencimientoGenerico("CAST(nri.vencimiento_en_nota AS timestamp)")
+                + filtros.filtroSucursal("s.id")
+                + filtros.filtroUsuario("u.id")
+                + filtros.filtroProducto("pro.id");
+    }
+
+    private String construirSqlCompraRecepcion(FiltrosProductosVencidos filtros) {
+        if (filtros.tieneFiltroSectorOZona()) {
+            return construirSqlVacio();
+        }
+        return "  SELECT rmi.id, 'COMPRA', rmi.presentacion_recibida_id, pro.id, pro.descripcion, cod.codigo, "
+                + "         pre.cantidad, rmi.cantidad_recibida, CAST(rmi.vencimiento_recibido AS timestamp), CAST(NULL AS bigint), "
+                + "         s.id, s.nombre, NULL, NULL, u.id, u.nickname, ui.inventario_id, rm.fecha, rm.id, "
+                + "         snap.cantidad_inventario, snap.vencimiento_inventario, NULL "
+                + "  FROM operaciones.recepcion_mercaderia_item rmi "
+                + "  JOIN operaciones.recepcion_mercaderia rm ON rm.id = rmi.recepcion_mercaderia_id "
+                + "  JOIN ultimo_inv ui ON ui.sucursal_id = rmi.sucursal_entrega_id "
+                + "  JOIN empresarial.sucursal s ON s.id = rmi.sucursal_entrega_id "
+                + "  JOIN productos.producto pro ON pro.id = rmi.producto_id "
+                + "  LEFT JOIN productos.presentacion pre ON pre.id = rmi.presentacion_recibida_id "
+                + "  LEFT JOIN productos.codigo cod ON cod.presentacion_id = pre.id AND cod.principal = true AND cod.activo = true "
+                + "  LEFT JOIN personas.usuario u ON u.id = rmi.usuario_id "
+                + "  LEFT JOIN inv_snap snap ON snap.sucursal_id = s.id AND snap.presentacion_id = rmi.presentacion_recibida_id "
+                + "       AND snap.vencimiento_dia = rmi.vencimiento_recibido "
+                + "  WHERE rmi.vencimiento_recibido IS NOT NULL "
+                + "    AND rm.fecha > ui.fecha_inicio "
+                + "    AND COALESCE(rmi.cantidad_rechazada, 0) < rmi.cantidad_recibida "
+                + filtros.filtroVencimientoGenerico("CAST(rmi.vencimiento_recibido AS timestamp)")
+                + filtros.filtroSucursal("s.id")
+                + filtros.filtroUsuario("u.id")
+                + filtros.filtroProducto("pro.id");
+    }
+
+    private String construirSqlTransferenciaSalida(FiltrosProductosVencidos filtros) {
+        if (filtros.tieneFiltroSectorOZona()) {
+            return construirSqlVacio();
+        }
+        return "  SELECT ti.id, 'TRANSFERENCIA', ti.presentacion_pre_transferencia_id, pro.id, pro.descripcion, cod.codigo, "
+                + "         pre.cantidad, ti.cantidad_pre_transferencia, ti.vencimiento_pre_transferencia, CAST(NULL AS bigint), "
+                + "         s.id, s.nombre, NULL, NULL, u.id, u.nickname, ui.inventario_id, t.creado_en, t.id, "
+                + "         snap.cantidad_inventario, snap.vencimiento_inventario, 'SALIDA' "
+                + "  FROM operaciones.transferencia_item ti "
+                + "  JOIN operaciones.transferencia t ON t.id = ti.transferencia_id "
+                + "  JOIN ultimo_inv ui ON ui.sucursal_id = t.sucursal_origen_id "
+                + "  JOIN empresarial.sucursal s ON s.id = t.sucursal_origen_id "
+                + "  JOIN productos.presentacion pre ON pre.id = ti.presentacion_pre_transferencia_id "
+                + "  JOIN productos.producto pro ON pro.id = pre.producto_id "
+                + "  LEFT JOIN productos.codigo cod ON cod.presentacion_id = pre.id AND cod.principal = true AND cod.activo = true "
+                + "  LEFT JOIN personas.usuario u ON u.id = ti.usuario_id "
+                + "  LEFT JOIN inv_snap snap ON snap.sucursal_id = s.id AND snap.presentacion_id = ti.presentacion_pre_transferencia_id "
+                + "       AND snap.vencimiento_dia = DATE(ti.vencimiento_pre_transferencia) "
+                + "  WHERE ti.posee_vencimiento = true AND ti.activo = true "
+                + "    AND CAST(t.estado AS text) <> 'CANCELADA' "
+                + "    AND t.creado_en > ui.fecha_inicio "
+                + "    AND ti.vencimiento_pre_transferencia IS NOT NULL "
+                + filtros.filtroVencimientoGenerico("ti.vencimiento_pre_transferencia")
+                + filtros.filtroSucursal("s.id")
+                + filtros.filtroUsuario("u.id")
+                + filtros.filtroProducto("pro.id");
+    }
+
+    private String construirSqlTransferenciaIngreso(FiltrosProductosVencidos filtros) {
+        if (filtros.tieneFiltroSectorOZona()) {
+            return construirSqlVacio();
+        }
+        return "  SELECT ti.id, 'TRANSFERENCIA', COALESCE(ti.presentacion_recepcion_id, ti.presentacion_pre_transferencia_id), "
+                + "         pro.id, pro.descripcion, cod.codigo, pre.cantidad, "
+                + "         COALESCE(ti.cantidad_recepcion, ti.cantidad_transporte, ti.cantidad_preparacion, ti.cantidad_pre_transferencia), "
+                + "         COALESCE(ti.vencimiento_recepcion, ti.vencimiento_transporte, ti.vencimiento_preparacion, ti.vencimiento_pre_transferencia), "
+                + "         CAST(NULL AS bigint), s.id, s.nombre, NULL, NULL, u.id, u.nickname, ui.inventario_id, t.creado_en, t.id, "
+                + "         snap.cantidad_inventario, snap.vencimiento_inventario, 'INGRESO' "
+                + "  FROM operaciones.transferencia_item ti "
+                + "  JOIN operaciones.transferencia t ON t.id = ti.transferencia_id "
+                + "  JOIN ultimo_inv ui ON ui.sucursal_id = t.sucursal_destino_id "
+                + "  JOIN empresarial.sucursal s ON s.id = t.sucursal_destino_id "
+                + "  LEFT JOIN productos.presentacion pre ON pre.id = COALESCE(ti.presentacion_recepcion_id, ti.presentacion_pre_transferencia_id) "
+                + "  LEFT JOIN productos.producto pro ON pro.id = pre.producto_id "
+                + "  LEFT JOIN productos.codigo cod ON cod.presentacion_id = pre.id AND cod.principal = true AND cod.activo = true "
+                + "  LEFT JOIN personas.usuario u ON u.id = ti.usuario_id "
+                + "  LEFT JOIN inv_snap snap ON snap.sucursal_id = s.id "
+                + "       AND snap.presentacion_id = COALESCE(ti.presentacion_recepcion_id, ti.presentacion_pre_transferencia_id) "
+                + "       AND snap.vencimiento_dia = DATE(COALESCE(ti.vencimiento_recepcion, ti.vencimiento_transporte, ti.vencimiento_preparacion, ti.vencimiento_pre_transferencia)) "
+                + "  WHERE ti.posee_vencimiento = true AND ti.activo = true "
+                + "    AND CAST(t.estado AS text) <> 'CANCELADA' "
+                + "    AND t.creado_en > ui.fecha_inicio "
+                + "    AND COALESCE(ti.vencimiento_recepcion, ti.vencimiento_transporte, ti.vencimiento_preparacion, ti.vencimiento_pre_transferencia) IS NOT NULL "
+                + "    AND t.sucursal_destino_id <> t.sucursal_origen_id "
+                + filtros.filtroVencimientoGenerico(
+                        "COALESCE(ti.vencimiento_recepcion, ti.vencimiento_transporte, ti.vencimiento_preparacion, ti.vencimiento_pre_transferencia)")
+                + filtros.filtroSucursal("s.id")
+                + filtros.filtroUsuario("u.id")
+                + filtros.filtroProducto("pro.id");
+    }
+
+    private String construirSqlVacio() {
+        return "  SELECT CAST(NULL AS bigint), 'INVENTARIO', CAST(NULL AS bigint), CAST(NULL AS bigint), CAST(NULL AS varchar), CAST(NULL AS varchar), "
+                + "         CAST(NULL AS numeric), CAST(NULL AS numeric), CAST(NULL AS timestamp), CAST(NULL AS bigint), CAST(NULL AS bigint), CAST(NULL AS varchar), "
+                + "         CAST(NULL AS varchar), CAST(NULL AS varchar), CAST(NULL AS bigint), CAST(NULL AS varchar), CAST(NULL AS bigint), CAST(NULL AS timestamp), CAST(NULL AS bigint), "
+                + "         CAST(NULL AS numeric), CAST(NULL AS timestamp), CAST(NULL AS text) "
+                + "  WHERE 1 = 0 ";
+    }
+
+    private void aplicarParametros(Query query, Map<String, Object> params) {
+        for (Map.Entry<String, Object> entry : params.entrySet()) {
+            query.setParameter(entry.getKey(), entry.getValue());
+        }
+    }
+
+    private ProductoVencidoViewDTO mapearFila(Object[] row) {
+        ProductoVencidoViewDTO dto = new ProductoVencidoViewDTO();
+        dto.setId(toLong(row[0]));
+        dto.setFuenteVerdad(FuenteVerdadVencimiento.valueOf(Objects.toString(row[1], "INVENTARIO")));
+        dto.setPresentacionId(toLong(row[2]));
+        dto.setProductoId(toLong(row[3]));
+        dto.setProductoDescripcion(Objects.toString(row[4], null));
+        dto.setCodigoBarras(Objects.toString(row[5], null));
+        dto.setPresentacionCantidad(toDouble(row[6]));
+        dto.setCantidad(toDouble(row[7]));
+        dto.setVencimiento(toLocalDateTime(row[8]));
+        dto.setInventarioProductoId(toLong(row[9]));
+        dto.setSucursalId(toLong(row[10]));
+        dto.setSucursalNombre(Objects.toString(row[11], null));
+        dto.setSectorDescripcion(Objects.toString(row[12], null));
+        dto.setZonaDescripcion(Objects.toString(row[13], null));
+        dto.setUsuarioId(toLong(row[14]));
+        dto.setUsuarioNickname(Objects.toString(row[15], null));
+        dto.setInventarioId(toLong(row[16]));
+        dto.setFechaFuente(toLocalDateTime(row[17]));
+        dto.setOrigenId(toLong(row[18]));
+        dto.setCantidadInventario(toDouble(row[19]));
+        dto.setVencimientoInventario(toLocalDateTime(row[20]));
+        dto.setDetalleFuente(construirDetalleFuente(dto, Objects.toString(row[21], null)));
+        return dto;
+    }
+
+    private ProductoVencidoViewDTO enriquecer(ProductoVencidoViewDTO dto) {
+        if (dto.getVencimiento() != null) {
+            long dias = ChronoUnit.DAYS.between(LocalDate.now(), dto.getVencimiento().toLocalDate());
+            dto.setDiasVencimiento((int) dias);
+            dto.setDiasVencimientoTexto(construirDiasVencimientoTexto(dias));
+            dto.setDiasVencimientoClase(construirDiasVencimientoClase(dias));
+            dto.setVencimientoColor(construirVencimientoColor(dias));
+        }
+        if (dto.getFuenteVerdad() != FuenteVerdadVencimiento.INVENTARIO
+                && dto.getCantidadInventario() != null
+                && dto.getVencimientoInventario() != null) {
+            dto.setReferenciaInventario(String.format(
+                    "Según inventario: %.0f uds vencen %s",
+                    dto.getCantidadInventario(),
+                    dto.getVencimientoInventario().toLocalDate().format(FECHA_FORMATO)));
+        }
+        return dto;
+    }
+
+    private String construirDetalleFuente(ProductoVencidoViewDTO dto, @Nullable String tipoMovimiento) {
+        String fecha = dto.getFechaFuente() != null ? dto.getFechaFuente().toLocalDate().format(FECHA_FORMATO) : "-";
+        switch (dto.getFuenteVerdad()) {
+            case COMPRA:
+                return String.format("Nota de compra #%s (%s)", dto.getOrigenId(), fecha);
+            case TRANSFERENCIA:
+                if ("SALIDA".equals(tipoMovimiento)) {
+                    return String.format("Transferencia #%s - retiro (%s)", dto.getOrigenId(), fecha);
+                }
+                return String.format("Transferencia #%s - ingreso (%s)", dto.getOrigenId(), fecha);
+            case INVENTARIO:
+            default:
+                return String.format("Inventario #%s (%s)", dto.getInventarioId(), fecha);
+        }
+    }
+
+    private String construirDiasVencimientoTexto(long dias) {
+        if (dias < 0) {
+            long abs = Math.abs(dias);
+            return "Vencido hace " + abs + (abs == 1 ? " día" : " días");
+        }
+        if (dias == 0) {
+            return "Vence hoy";
+        }
+        return dias + (dias == 1 ? " día restante" : " días restantes");
+    }
+
+    private String construirDiasVencimientoClase(long dias) {
+        if (dias < 0) {
+            return "dias-vencimiento-cell vencido";
+        }
+        if (dias <= 7) {
+            return "dias-vencimiento-cell por-vencer";
+        }
+        return "dias-vencimiento-cell vigente";
+    }
+
+    private String construirVencimientoColor(long dias) {
+        if (dias < 0) {
+            return COLOR_DANGER;
+        }
+        if (dias <= 7) {
+            return COLOR_WARNING;
+        }
+        return COLOR_SUCCESS;
+    }
+
+    private Long toLong(Object value) {
+        if (value == null) {
+            return null;
+        }
+        return ((Number) value).longValue();
+    }
+
+    private Double toDouble(Object value) {
+        if (value == null) {
+            return null;
+        }
+        return ((Number) value).doubleValue();
+    }
+
+    private LocalDateTime toLocalDateTime(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof LocalDateTime) {
+            return (LocalDateTime) value;
+        }
+        if (value instanceof Timestamp) {
+            return ((Timestamp) value).toLocalDateTime();
+        }
+        if (value instanceof java.util.Date) {
+            return new Timestamp(((java.util.Date) value).getTime()).toLocalDateTime();
+        }
+        return null;
+    }
+
+    private static final class FiltrosProductosVencidos {
+        private final LocalDateTime startDate;
+        private final LocalDateTime endDate;
+        private final List<Long> sucursalIdList;
+        private final List<Long> sectorIdList;
+        private final List<Long> zonaIdList;
+        private final List<Long> usuarioIdList;
+        private final List<Long> productoIdList;
+        private final List<String> fuenteVerdadList;
+        private final Boolean soloRealmenteVencidos;
+
+        private FiltrosProductosVencidos(
+                LocalDateTime startDate,
+                LocalDateTime endDate,
+                List<Long> sucursalIdList,
+                List<Long> sectorIdList,
+                List<Long> zonaIdList,
+                List<Long> usuarioIdList,
+                List<Long> productoIdList,
+                List<String> fuenteVerdadList,
+                Boolean soloRealmenteVencidos) {
+            this.startDate = startDate;
+            this.endDate = endDate;
+            this.sucursalIdList = sucursalIdList;
+            this.sectorIdList = sectorIdList;
+            this.zonaIdList = zonaIdList;
+            this.usuarioIdList = usuarioIdList;
+            this.productoIdList = productoIdList;
+            this.fuenteVerdadList = fuenteVerdadList;
+            this.soloRealmenteVencidos = soloRealmenteVencidos;
+        }
+
+        Map<String, Object> parametros() {
+            Map<String, Object> params = new HashMap<>();
+            if (startDate != null && endDate != null) {
+                params.put("startDate", startDate);
+                params.put("endDate", endDate);
+            }
+            if (sucursalIdList != null && !sucursalIdList.isEmpty()) {
+                params.put("sucursalIds", sucursalIdList);
+            }
+            if (sectorIdList != null && !sectorIdList.isEmpty()) {
+                params.put("sectorIds", sectorIdList);
+            }
+            if (zonaIdList != null && !zonaIdList.isEmpty()) {
+                params.put("zonaIds", zonaIdList);
+            }
+            if (usuarioIdList != null && !usuarioIdList.isEmpty()) {
+                params.put("usuarioIds", usuarioIdList);
+            }
+            if (productoIdList != null && !productoIdList.isEmpty()) {
+                params.put("productoIds", productoIdList);
+            }
+            if (fuenteVerdadList != null && !fuenteVerdadList.isEmpty()) {
+                params.put("fuenteVerdadList", fuenteVerdadList);
+            }
+            return params;
+        }
+
+        String filtroFuenteVerdad() {
+            if (fuenteVerdadList == null || fuenteVerdadList.isEmpty()) {
+                return "";
+            }
+            return " AND fuente_verdad IN (:fuenteVerdadList) ";
+        }
+
+        boolean tieneFiltroSectorOZona() {
+            return (sectorIdList != null && !sectorIdList.isEmpty())
+                    || (zonaIdList != null && !zonaIdList.isEmpty());
+        }
+
+        String filtroVencimientoInventario() {
+            if (startDate != null && endDate != null) {
+                return " AND ipi.vencimiento BETWEEN :startDate AND :endDate ";
+            }
+            if (Boolean.TRUE.equals(soloRealmenteVencidos)) {
+                return " AND (ipi.vencimiento < CURRENT_TIMESTAMP OR CAST(ipi.estado AS text) = 'VENCIDO') ";
+            }
+            return "";
+        }
+
+        String filtroVencimientoGenerico(String columna) {
+            if (startDate != null && endDate != null) {
+                return " AND " + columna + " BETWEEN :startDate AND :endDate ";
+            }
+            if (Boolean.TRUE.equals(soloRealmenteVencidos)) {
+                return " AND " + columna + " < CURRENT_TIMESTAMP ";
+            }
+            return "";
+        }
+
+        String filtroSucursal(String columna) {
+            if (sucursalIdList == null || sucursalIdList.isEmpty()) {
+                return "";
+            }
+            return " AND " + columna + " IN (:sucursalIds) ";
+        }
+
+        String filtroSectorInventario() {
+            if (sectorIdList == null || sectorIdList.isEmpty()) {
+                return "";
+            }
+            return " AND COALESCE(sec_item.id, sec_inv.id) IN (:sectorIds) ";
+        }
+
+        String filtroZonaInventario() {
+            if (zonaIdList == null || zonaIdList.isEmpty()) {
+                return "";
+            }
+            return " AND COALESCE(z_item.id, z_inv.id) IN (:zonaIds) ";
+        }
+
+        String filtroUsuario(String columna) {
+            if (usuarioIdList == null || usuarioIdList.isEmpty()) {
+                return "";
+            }
+            return " AND " + columna + " IN (:usuarioIds) ";
+        }
+
+        String filtroProducto(String columna) {
+            if (productoIdList == null || productoIdList.isEmpty()) {
+                return "";
+            }
+            return " AND " + columna + " IN (:productoIds) ";
+        }
+    }
+}

--- a/src/main/java/com/franco/dev/service/operaciones/TransferenciaItemAlertaService.java
+++ b/src/main/java/com/franco/dev/service/operaciones/TransferenciaItemAlertaService.java
@@ -1,0 +1,241 @@
+package com.franco.dev.service.operaciones;
+
+import com.franco.dev.domain.operaciones.Transferencia;
+import com.franco.dev.domain.operaciones.TransferenciaItem;
+import com.franco.dev.domain.operaciones.enums.InventarioProductoEstado;
+import com.franco.dev.domain.productos.Presentacion;
+import com.franco.dev.graphql.operaciones.dto.InventarioAlertaProjectionDTO;
+import com.franco.dev.graphql.operaciones.dto.ProductoVencimientoCompraProjectionDTO;
+import com.franco.dev.graphql.operaciones.dto.TransferenciaItemAlertaDTO;
+import com.franco.dev.repository.operaciones.InventarioProductoItemRepository;
+import com.franco.dev.repository.operaciones.NotaRecepcionItemRepository;
+import com.franco.dev.repository.operaciones.TransferenciaItemRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TransferenciaItemAlertaService {
+
+    private final TransferenciaService transferenciaService;
+    private final TransferenciaItemRepository transferenciaItemRepository;
+    private final InventarioProductoItemRepository inventarioProductoItemRepository;
+    private final NotaRecepcionItemRepository notaRecepcionItemRepository;
+
+    @Transactional(readOnly = true)
+    public List<TransferenciaItemAlertaDTO> calcularAlertas(Long transferenciaId, List<Long> itemIds) {
+        if (transferenciaId == null || itemIds == null || itemIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        Transferencia transferencia = transferenciaService.findById(transferenciaId).orElse(null);
+        if (transferencia == null
+                || transferencia.getSucursalOrigen() == null
+                || transferencia.getSucursalOrigen().getId() == null) {
+            return Collections.emptyList();
+        }
+
+        List<TransferenciaItem> items = transferenciaItemRepository
+                .findByIdInAndTransferenciaId(itemIds, transferenciaId);
+        if (items.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        Long sucursalOrigenId = transferencia.getSucursalOrigen().getId();
+
+        List<Long> productoIds = items.stream()
+                .map(TransferenciaItem::getPresentacionPreTransferencia)
+                .filter(Objects::nonNull)
+                .map(Presentacion::getProducto)
+                .filter(Objects::nonNull)
+                .map(producto -> producto.getId())
+                .filter(Objects::nonNull)
+                .distinct()
+                .collect(Collectors.toList());
+
+        Map<Long, List<InventarioAlertaProjectionDTO>> inventarioPorProducto =
+                cargarInventarioAlertas(sucursalOrigenId, productoIds);
+        Map<Long, LocalDate> compraPorProducto = cargarVencimientoCompra(productoIds);
+
+        LocalDate hoy = LocalDate.now();
+        List<TransferenciaItemAlertaDTO> resultado = new ArrayList<>();
+
+        for (TransferenciaItem item : items) {
+            resultado.add(construirAlerta(item, inventarioPorProducto, compraPorProducto, hoy));
+        }
+
+        return resultado;
+    }
+
+    private TransferenciaItemAlertaDTO construirAlerta(
+            TransferenciaItem item,
+            Map<Long, List<InventarioAlertaProjectionDTO>> inventarioPorProducto,
+            Map<Long, LocalDate> compraPorProducto,
+            LocalDate hoy) {
+        TransferenciaItemAlertaDTO dto = new TransferenciaItemAlertaDTO();
+        dto.setTransferenciaItemId(item.getId());
+        dto.setAlertaVencido(false);
+        dto.setAlertaAveriado(false);
+        dto.setFechaVencimientoReferencia(null);
+
+        Presentacion presentacion = item.getPresentacionPreTransferencia();
+        if (presentacion == null || presentacion.getProducto() == null) {
+            return dto;
+        }
+
+        Long presentacionId = presentacion.getId();
+        Long productoId = presentacion.getProducto().getId();
+
+        InventarioAlertaProjectionDTO inventario = productoId != null
+                ? resolverInventarioProducto(productoId, presentacionId, inventarioPorProducto)
+                : null;
+
+        boolean averiado = tieneEstadoInventario(inventarioPorProducto.get(productoId), InventarioProductoEstado.AVERIADO)
+                || (inventario != null && InventarioProductoEstado.AVERIADO == inventario.getEstado());
+
+        LocalDate fechaReferencia = resolverFechaReferencia(
+                item,
+                inventario,
+                productoId != null ? compraPorProducto.get(productoId) : null);
+
+        boolean vencido = tieneEstadoInventario(inventarioPorProducto.get(productoId), InventarioProductoEstado.VENCIDO)
+                || (inventario != null && InventarioProductoEstado.VENCIDO == inventario.getEstado())
+                || (fechaReferencia != null && fechaReferencia.isBefore(hoy));
+
+        dto.setAlertaAveriado(averiado);
+        dto.setAlertaVencido(vencido && !averiado);
+        if (fechaReferencia != null) {
+            dto.setFechaVencimientoReferencia(fechaReferencia.atStartOfDay());
+        }
+
+        return dto;
+    }
+
+    private InventarioAlertaProjectionDTO resolverInventarioProducto(
+            Long productoId,
+            Long presentacionId,
+            Map<Long, List<InventarioAlertaProjectionDTO>> inventarioPorProducto) {
+        List<InventarioAlertaProjectionDTO> registros = inventarioPorProducto.get(productoId);
+        if (registros == null || registros.isEmpty()) {
+            return null;
+        }
+
+        if (presentacionId != null) {
+            for (InventarioAlertaProjectionDTO registro : registros) {
+                if (presentacionId.equals(registro.getPresentacionId())) {
+                    return registro;
+                }
+            }
+        }
+
+        return consolidarRegistrosInventario(productoId, registros);
+    }
+
+    private InventarioAlertaProjectionDTO consolidarRegistrosInventario(
+            Long productoId,
+            List<InventarioAlertaProjectionDTO> registros) {
+        InventarioAlertaProjectionDTO consolidado = new InventarioAlertaProjectionDTO();
+        consolidado.setProductoId(productoId);
+
+        boolean averiado = tieneEstadoInventario(registros, InventarioProductoEstado.AVERIADO);
+        boolean vencido = tieneEstadoInventario(registros, InventarioProductoEstado.VENCIDO);
+
+        if (averiado) {
+            consolidado.setEstado(InventarioProductoEstado.AVERIADO);
+        } else if (vencido) {
+            consolidado.setEstado(InventarioProductoEstado.VENCIDO);
+        } else {
+            consolidado.setEstado(InventarioProductoEstado.BUENO);
+        }
+
+        consolidado.setVencimiento(registros.stream()
+                .map(InventarioAlertaProjectionDTO::getVencimiento)
+                .filter(Objects::nonNull)
+                .min(Comparator.naturalOrder())
+                .orElse(null));
+
+        return consolidado;
+    }
+
+    private boolean tieneEstadoInventario(
+            List<InventarioAlertaProjectionDTO> registros,
+            InventarioProductoEstado estado) {
+        if (registros == null || registros.isEmpty()) {
+            return false;
+        }
+        return registros.stream().anyMatch(registro -> estado == registro.getEstado());
+    }
+
+    private Map<Long, List<InventarioAlertaProjectionDTO>> cargarInventarioAlertas(
+            Long sucursalOrigenId,
+            List<Long> productoIds) {
+        if (productoIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        Map<Long, List<InventarioAlertaProjectionDTO>> resultado = new HashMap<>();
+        for (InventarioAlertaProjectionDTO dto : inventarioProductoItemRepository
+                .findAlertasBySucursalAndProductoIds(sucursalOrigenId, productoIds)) {
+            resultado.computeIfAbsent(dto.getProductoId(), key -> new ArrayList<>()).add(dto);
+        }
+        return resultado;
+    }
+
+    private Map<Long, LocalDate> cargarVencimientoCompra(List<Long> productoIds) {
+        if (productoIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        Map<Long, LocalDate> resultado = new HashMap<>();
+        for (ProductoVencimientoCompraProjectionDTO dto : notaRecepcionItemRepository
+                .findUltimoVencimientoEnNotaByProductoIds(productoIds)) {
+            resultado.put(dto.getProductoId(), dto.getVencimientoEnNota());
+        }
+        return resultado;
+    }
+
+    private LocalDate resolverFechaReferencia(
+            TransferenciaItem item,
+            InventarioAlertaProjectionDTO inventario,
+            LocalDate vencimientoCompra) {
+        LocalDate itemVencimiento = toLocalDate(primerVencimientoItem(item));
+        if (itemVencimiento != null) {
+            return itemVencimiento;
+        }
+
+        if (inventario != null && inventario.getVencimiento() != null) {
+            return inventario.getVencimiento().toLocalDate();
+        }
+
+        return vencimientoCompra;
+    }
+
+    private LocalDateTime primerVencimientoItem(TransferenciaItem item) {
+        if (item.getVencimientoPreTransferencia() != null) {
+            return item.getVencimientoPreTransferencia();
+        }
+        if (item.getVencimientoPreparacion() != null) {
+            return item.getVencimientoPreparacion();
+        }
+        if (item.getVencimientoTransporte() != null) {
+            return item.getVencimientoTransporte();
+        }
+        return item.getVencimientoRecepcion();
+    }
+
+    private LocalDate toLocalDate(LocalDateTime value) {
+        return value != null ? value.toLocalDate() : null;
+    }
+}

--- a/src/main/resources/graphql/operaciones/inventario-producto-item.graphqls
+++ b/src/main/resources/graphql/operaciones/inventario-producto-item.graphqls
@@ -96,10 +96,11 @@ extend type Query {
         zonaIdList: [Int],
         usuarioIdList: [ID],
         productoIdList: [ID],
+        fuenteVerdadList: [FuenteVerdadVencimiento],
         soloRealmenteVencidos: Boolean,
         page: Int,
         size: Int
-    ): InventarioProductoItemPage
+    ): ProductoVencidoViewPage
 
     productosVencidosPorSucursal(
         sucursalId: ID!,

--- a/src/main/resources/graphql/operaciones/producto-vencido.graphqls
+++ b/src/main/resources/graphql/operaciones/producto-vencido.graphqls
@@ -1,0 +1,47 @@
+enum FuenteVerdadVencimiento {
+    INVENTARIO
+    COMPRA
+    TRANSFERENCIA
+}
+
+type ProductoVencidoView {
+    id: ID!
+    presentacionId: ID
+    presentacionCantidad: Float
+    productoId: ID
+    productoDescripcion: String
+    codigoBarras: String
+    cantidad: Float
+    vencimiento: Date
+    inventarioProductoId: ID
+    sucursalId: ID
+    sucursalNombre: String
+    sectorDescripcion: String
+    zonaDescripcion: String
+    usuarioId: ID
+    usuarioNickname: String
+    fuenteVerdad: FuenteVerdadVencimiento
+    origenId: ID
+    fechaFuente: Date
+    inventarioId: ID
+    cantidadInventario: Float
+    vencimientoInventario: Date
+    referenciaInventario: String
+    detalleFuente: String
+    diasVencimiento: Int
+    diasVencimientoTexto: String
+    vencimientoColor: String
+    diasVencimientoClase: String
+}
+
+type ProductoVencidoViewPage {
+    getTotalPages: Int
+    getTotalElements: Int
+    getNumberOfElements: Int
+    isFirst: Boolean
+    isLast: Boolean
+    hasNext: Boolean
+    hasPrevious: Boolean
+    getContent: [ProductoVencidoView]
+    getPageable: Pageable
+}

--- a/src/main/resources/graphql/operaciones/transferencia-item.graphqls
+++ b/src/main/resources/graphql/operaciones/transferencia-item.graphqls
@@ -32,6 +32,13 @@ type TransferenciaItem {
     vencimientoVerificado: Boolean
 }
 
+type TransferenciaItemAlerta {
+    transferenciaItemId: ID!
+    alertaVencido: Boolean
+    alertaAveriado: Boolean
+    fechaVencimientoReferencia: Date
+}
+
 input TransferenciaItemInput {
     id:ID
     transferenciaId: Int
@@ -83,6 +90,7 @@ extend type Query {
     transferenciaItems(page:Int = 0, size:Int = 10):[TransferenciaItem]!
     transferenciaItensPorTransferenciaId(id: ID!, page:Int = 0, size:Int = 10):TransferenciaItemPage!
     transferenciaItensPorTransferenciaIdWithFilter(id: ID, name: String, page:Int = 0, size:Int = 10):TransferenciaItemPage!
+    alertasTransferenciaItems(transferenciaId: ID!, itemIds: [ID!]!): [TransferenciaItemAlerta]!
 }
 
 extend type Mutation {


### PR DESCRIPTION
## Summary
- Unifica productos vencidos desde inventario, compras (nota de recepción) y transferencias con prioridad por fecha.
- Expone DTO plano, enum `FuenteVerdadVencimiento` y filtro `fuenteVerdadList` en GraphQL.
- Agrega alertas de productos vencidos y averiados en ítems de transferencia.
- Corrige listado de productos vencidos para no filtrar por stock en sucursal.

## Test plan
- [ ] Levantar backend y consultar `productosVencidos` con y sin filtro de fuente.
- [ ] Verificar registros COMPRA desde nota de recepción en bodega3.
- [ ] Confirmar que compra/transferencia anterior al último inventario muestra fuente INVENTARIO.
- [ ] Validar alertas de vencimiento/averiado en ítems de transferencia.

Made with [Cursor](https://cursor.com)