### PR TITLE
feat(usuarios): mejorar búsqueda paginada de usuarios en servidor

### DIFF
--- a/src/main/java/com/franco/dev/repository/personas/UsuarioRepository.java
+++ b/src/main/java/com/franco/dev/repository/personas/UsuarioRepository.java
@@ -21,10 +21,16 @@ public interface UsuarioRepository extends HelperRepository<Usuario, Long> {
             "where CAST(u.id as text) like %?1% or UPPER(p.nombre) like %?1% or UPPER(u.nickname) like %?1% or p.documento like %?1% or CAST(p.id as text) like %?1%")
     public List<Usuario> findbyIdOrPersona(String texto);
 
-    @Query("select u from Usuario u " +
-            "join u.persona p " +
-            "where CAST(u.id as text) like %?1% or UPPER(p.nombre) like %?1% or UPPER(u.nickname) like %?1% or p.documento like %?1% or CAST(p.id as text) like %?1%")
-    public org.springframework.data.domain.Page<Usuario> findbyIdOrPersonaPaginated(String texto, org.springframework.data.domain.Pageable pageable);
+    @Query(
+            value = "select u from Usuario u " +
+                    "join u.persona p " +
+                    "where CAST(u.id as text) like %?1% or UPPER(p.nombre) like %?1% or UPPER(u.nickname) like %?1% or p.documento like %?1% or CAST(p.id as text) like %?1% " +
+                    "order by u.id asc",
+            countQuery = "select count(u) from Usuario u " +
+                    "join u.persona p " +
+                    "where CAST(u.id as text) like %?1% or UPPER(p.nombre) like %?1% or UPPER(u.nickname) like %?1% or p.documento like %?1% or CAST(p.id as text) like %?1%"
+    )
+    org.springframework.data.domain.Page<Usuario> findbyIdOrPersonaPaginated(String texto, org.springframework.data.domain.Pageable pageable);
 
     public boolean existsByEmail(String email);
 

--- a/src/main/java/com/franco/dev/service/personas/UsuarioService.java
+++ b/src/main/java/com/franco/dev/service/personas/UsuarioService.java
@@ -82,9 +82,29 @@ public class UsuarioService extends CrudService<Usuario, UsuarioRepository, Long
 
     public org.springframework.data.domain.Page<Usuario> findbyIdOrPersonaPaginated(String texto, Integer page, Integer size) {
         if (texto == null) texto = "";
+        texto = texto.trim();
         if (page == null) page = 0;
         if (size == null) size = 15;
-        org.springframework.data.domain.Pageable pageable = org.springframework.data.domain.PageRequest.of(page, size);
+        org.springframework.data.domain.Pageable pageable = org.springframework.data.domain.PageRequest.of(
+                page,
+                size,
+                org.springframework.data.domain.Sort.by("id").ascending()
+        );
+
+        if (!texto.isEmpty() && texto.chars().allMatch(Character::isDigit)) {
+            try {
+                Long personaId = Long.valueOf(texto);
+                Usuario usuario = repository.findByPersonaId(personaId);
+                if (usuario != null) {
+                    List<Usuario> resultado = new ArrayList<>();
+                    resultado.add(usuario);
+                    return new org.springframework.data.domain.PageImpl<>(resultado, pageable, 1);
+                }
+            } catch (NumberFormatException ignored) {
+            }
+        }
+
+        texto = texto.replace(' ', '%');
         return repository.findbyIdOrPersonaPaginated(texto.toUpperCase(), pageable);
     }
 


### PR DESCRIPTION
## Summary
- Mejora `findbyIdOrPersonaPaginated` para alinearla con la búsqueda existente de usuarios.
- Agrega orden por `id`, `countQuery` dedicado y filtros consistentes (trim, espacios y búsqueda numérica por persona).
- Soporta la paginación de la lista de usuarios en frontend mediante `usuarioSearchPaginated`.

## Test plan
- [ ] Consultar `usuarioSearchPaginated` sin texto y validar paginación con `getTotalElements` y `getContent`.
- [ ] Buscar por nombre, nickname y documento y confirmar resultados paginados.
- [ ] Buscar por ID numérico de persona y validar coincidencia exacta.
- [ ] Verificar que `usuarioSearch` y demás endpoints de usuarios no cambiaron su comportamiento.


Made with [Cursor](https://cursor.com)