### PR TITLE
ci: actualizar actions/checkout de v4 a v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up JDK 11
         uses: actions/setup-java@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
     environment: ${{ inputs.instance == 'bodega' && 'production' || (inputs.instance == 'farmacia' || inputs.instance == 'beta') && 'beta' || 'alpha' }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           sparse-checkout: .github/scripts/deploy.sh
           sparse-checkout-cone-mode: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           persist-credentials: false


### PR DESCRIPTION
## Contexto
El último Deploy a `alpha` (run [#103](https://github.com/GabFrank/franco-system-backend-servidor/actions/runs/28886757081)) mostró una advertencia de deprecación:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/checkout@v4`.

## Cambios
Actualiza `actions/checkout@v4` → `@v5` en los tres workflows que lo usan:

- `.github/workflows/ci.yml`
- `.github/workflows/deploy.yml`
- `.github/workflows/release.yml`

`checkout@v5` corre nativamente en Node 24, eliminando la advertencia. No hay cambios funcionales ni de lógica de despliegue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)