### PR TITLE
fix(compras): persistir ultimo_precio_compra en guaraníes

### DIFF
--- a/src/main/java/com/franco/dev/service/productos/CostosPorProductoService.java
+++ b/src/main/java/com/franco/dev/service/productos/CostosPorProductoService.java
@@ -128,7 +128,9 @@ public class CostosPorProductoService extends CrudService<CostoPorProducto, Cost
      *   stock anterior > 0, costo medio anterior > 0 y costo de la compra > 0. En cualquier otro caso
      *   (stock negativo o cero, sin costo previo válido) NO hay forma de ponderar y el costo medio se
      *   resetea al costo de esta compra — que es lo contable-correcto.
-     * - ultimoPrecioCompra: precio de la compra en moneda original (sin convertir).
+     * - ultimoPrecioCompra: precio de la compra normalizado a Gs (igual que costoMedio). moneda/cotizacion
+     *   quedan como referencia de la moneda original de la compra. Todos los consumidores leen este campo
+     *   como Gs, así que se persiste ya convertido para no depender de que cada lector aplique la cotización.
      * - Dedup: si el costo resultante es idéntico al último registro (mismo costoMedio, ultimoPrecioCompra
      *   y moneda), NO se inserta una fila nueva. Evita inflar la tabla con compras al mismo precio.
      *
@@ -159,7 +161,7 @@ public class CostosPorProductoService extends CrudService<CostoPorProducto, Cost
         double nuevoCostoMedio = CostoMedioCalculator.calcular(stockReal, cantidadEntrada, costoMedioAnterior,
                 costoEnGs);
 
-        return guardarSiCambia(producto, nuevoCostoMedio, costoUnitario, moneda, cotiz, sucursal, usuario, fecha,
+        return guardarSiCambia(producto, nuevoCostoMedio, costoEnGs, moneda, cotiz, sucursal, usuario, fecha,
                 costoAnterior);
     }
 

--- a/src/test/java/com/franco/dev/service/productos/CostosPorProductoServiceTest.java
+++ b/src/test/java/com/franco/dev/service/productos/CostosPorProductoServiceTest.java
@@ -103,7 +103,7 @@ class CostosPorProductoServiceTest {
 
         // (5*100 + 10*120) / 15 = 113.333
         assertEquals(1700.0 / 15.0, r.getCostoMedio(), DELTA);
-        assertEquals(120.0, r.getUltimoPrecioCompra(), DELTA); // moneda original, sin convertir
+        assertEquals(120.0, r.getUltimoPrecioCompra(), DELTA); // en Gs (cotizacion 1 => sin cambio)
         verify(repository, times(1)).save(any(CostoPorProducto.class));
     }
 
@@ -119,7 +119,9 @@ class CostosPorProductoServiceTest {
 
         // (5*100000 + 10*72000) / 15 = 1_220_000 / 15
         assertEquals(1_220_000.0 / 15.0, r.getCostoMedio(), DELTA);
-        assertEquals(10.0, r.getUltimoPrecioCompra(), DELTA); // en moneda original
+        assertEquals(72000.0, r.getUltimoPrecioCompra(), DELTA); // normalizado a Gs (USD 10 * 7200)
+        assertEquals(2L, r.getMoneda().getId()); // moneda original queda como referencia
+        assertEquals(7200.0, r.getCotizacion(), DELTA);
         verify(repository, times(1)).save(any(CostoPorProducto.class));
     }
 


### PR DESCRIPTION
## Qué resuelve
En compras en moneda extranjera, `aplicarCostoCompra` guardaba `ultimo_precio_compra` con el valor **crudo en la moneda original** (ej. 6 US$) mientras `costo_medio` ya se convertía a Gs. Todos los consumidores del campo (`VentaItemService`, `ProductoService`, `ProductoResolver`) lo leen como Gs, por lo que se mostraba "6 Gs." en vez del costo real (~36.480 Gs.).

Ahora se persiste `costoEnGs` (ya normalizado). `moneda`/`cotizacion` quedan como referencia de la compra original. Invariante nuevo: **todo en `costo_por_producto` está en Gs**.

## Cómo probar
- Cargar una recepción/compra en DÓLARES → verificar que `costo_por_producto.ultimo_precio_compra` queda en Gs (≈ precio × cotización), igual que `costo_medio`.
- Compra en guaraníes: sin cambios (cotización 1 → sin conversión).
- `CostosPorProductoServiceTest` cubre ambos casos (10/10 verde).

## Impacto DB
Ninguna migración. Solo cambia el valor insertado en `ultimo_precio_compra` de nuevas compras. Data histórica en dólares (2 filas) ya corregida manualmente en farmacia prod; bodega no tenía filas en dólares.

## Impacto rollback
Bajo. Revertir el código vuelve al comportamiento anterior (crudo). No hay cambio de schema, no requiere restore. Filas ya escritas en Gs quedan en Gs (correctas).

## Riesgo
**Bajo.** Cambio de una línea + test. Sin Flyway, sin auto-deploy (central es manual).

## PR acoplado
Depende del cambio de frontend en `frc-sistemas-integrados-angular` (branch `fix/compras-costo-dolar`) que unifica el display de costo. Deployar **central alpha primero**, luego desktop.