### PR TITLE
feat(financiero): add venta con tarjeta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ src/main/resources/bodega-franco-frc-18e8c6ef35cf.json
 src/main/resources/bodega-franco-frc-firebase-admin.json
 .m2/
 .m2repo/
+
+# Índices de búsqueda (Lucene/Hibernate Search) generados en runtime
+data/lucene/

--- a/src/main/java/com/franco/dev/domain/financiero/TerminalPos.java
+++ b/src/main/java/com/franco/dev/domain/financiero/TerminalPos.java
@@ -39,6 +39,10 @@ public class TerminalPos implements Identifiable<Long> {
     @JoinColumn(name = "cuenta_bancaria_id", nullable = true)
     private CuentaBancaria cuentaBancaria;
 
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "moneda_id", nullable = true)
+    private Moneda moneda;
+
     private Boolean activo;
 
     @CreationTimestamp

--- a/src/main/java/com/franco/dev/domain/financiero/VentaTarjeta.java
+++ b/src/main/java/com/franco/dev/domain/financiero/VentaTarjeta.java
@@ -1,0 +1,89 @@
+package com.franco.dev.domain.financiero;
+
+import com.franco.dev.domain.EmbebedPrimaryKey;
+import com.franco.dev.domain.empresarial.Sucursal;
+import com.franco.dev.domain.operaciones.Venta;
+import com.franco.dev.domain.personas.Usuario;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.JoinColumnOrFormula;
+import org.hibernate.annotations.JoinColumnsOrFormulas;
+import org.hibernate.annotations.JoinFormula;
+
+import javax.persistence.*;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "venta_tarjeta", schema = "financiero")
+@IdClass(EmbebedPrimaryKey.class)
+public class VentaTarjeta implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @SequenceGenerator(name = "financiero.venta_tarjeta_id_seq",
+            sequenceName = "financiero.venta_tarjeta_id_seq",
+            allocationSize = 1)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE,
+            generator = "financiero.venta_tarjeta_id_seq")
+    private Long id;
+
+    @Id
+    @Column(name = "sucursal_id", insertable = false, updatable = false)
+    private Long sucursalId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sucursal_id", insertable = false, updatable = false)
+    private Sucursal sucursal;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumnsOrFormulas(value = {
+            @JoinColumnOrFormula(formula = @JoinFormula(value = "sucursal_id", referencedColumnName = "sucursal_id")),
+            @JoinColumnOrFormula(column = @JoinColumn(name = "venta_id", referencedColumnName = "id"))
+    })
+    private Venta venta;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "terminal_pos_id", nullable = true)
+    private TerminalPos terminalPos;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumnsOrFormulas(value = {
+            @JoinColumnOrFormula(formula = @JoinFormula(value = "sucursal_id", referencedColumnName = "sucursal_id")),
+            @JoinColumnOrFormula(column = @JoinColumn(name = "caja_id", referencedColumnName = "id"))
+    })
+    private PdvCaja caja;
+
+    @Column(name = "codigo_autorizacion")
+    private String codigoAutorizacion;
+
+    @Column(name = "numero_boleta")
+    private String numeroBoleta;
+
+    @Column(nullable = false, precision = 18, scale = 2)
+    private BigDecimal monto;
+
+    @Column(name = "monto_escaneado", precision = 18, scale = 2)
+    private BigDecimal montoEscaneado;
+
+    @Column(name = "imagen_url")
+    private String imagenUrl;
+
+    @Column(nullable = false, length = 20)
+    private String estado = "PENDIENTE";
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "usuario_id", nullable = true)
+    private Usuario usuario;
+
+    @CreationTimestamp
+    @Column(name = "creado_en", nullable = false, updatable = false)
+    private LocalDateTime creadoEn;
+}

--- a/src/main/java/com/franco/dev/graphql/financiero/TerminalPosGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/TerminalPosGraphQL.java
@@ -3,6 +3,7 @@ package com.franco.dev.graphql.financiero;
 import com.franco.dev.domain.financiero.TerminalPos;
 import com.franco.dev.graphql.financiero.input.TerminalPosInput;
 import com.franco.dev.service.financiero.CuentaBancariaService;
+import com.franco.dev.service.financiero.MonedaService;
 import com.franco.dev.service.financiero.TerminalPosService;
 import com.franco.dev.service.personas.UsuarioService;
 import graphql.kickstart.tools.GraphQLMutationResolver;
@@ -26,6 +27,9 @@ public class TerminalPosGraphQL implements GraphQLQueryResolver, GraphQLMutation
 
     @Autowired
     private CuentaBancariaService cuentaBancariaService;
+
+    @Autowired
+    private MonedaService monedaService;
 
     public Optional<TerminalPos> terminalPos(Long id) {
         return service.findById(id);
@@ -55,6 +59,9 @@ public class TerminalPosGraphQL implements GraphQLQueryResolver, GraphQLMutation
         }
         if (input.getCuentaBancariaId() != null) {
             e.setCuentaBancaria(cuentaBancariaService.findById(input.getCuentaBancariaId()).orElse(null));
+        }
+        if (input.getMonedaId() != null) {
+            e.setMoneda(monedaService.findById(input.getMonedaId()).orElse(null));
         }
         return service.save(e);
     }

--- a/src/main/java/com/franco/dev/graphql/financiero/VentaTarjetaGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/VentaTarjetaGraphQL.java
@@ -1,0 +1,178 @@
+package com.franco.dev.graphql.financiero;
+
+import com.franco.dev.domain.EmbebedPrimaryKey;
+import com.franco.dev.domain.financiero.PdvCaja;
+import com.franco.dev.domain.financiero.TerminalPos;
+import com.franco.dev.domain.financiero.VentaTarjeta;
+import com.franco.dev.domain.operaciones.Venta;
+import com.franco.dev.domain.personas.Usuario;
+import com.franco.dev.graphql.financiero.input.VentaTarjetaInput;
+import com.franco.dev.domain.empresarial.Sucursal;
+import com.franco.dev.service.empresarial.SucursalService;
+import com.franco.dev.service.financiero.PdvCajaService;
+import com.franco.dev.service.financiero.TerminalPosService;
+import com.franco.dev.service.financiero.VentaTarjetaService;
+import com.franco.dev.service.impresion.ImpresionService;
+import com.franco.dev.service.operaciones.VentaService;
+import com.franco.dev.service.personas.UsuarioService;
+import com.franco.dev.utilitarios.DateUtils;
+import graphql.kickstart.tools.GraphQLMutationResolver;
+import graphql.kickstart.tools.GraphQLQueryResolver;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+public class VentaTarjetaGraphQL implements GraphQLQueryResolver, GraphQLMutationResolver {
+
+    @Autowired
+    private VentaTarjetaService service;
+
+    @Autowired
+    private VentaService ventaService;
+
+    @Autowired
+    private PdvCajaService pdvCajaService;
+
+    @Autowired
+    private TerminalPosService terminalPosService;
+
+    @Autowired
+    private UsuarioService usuarioService;
+
+    @Autowired
+    private SucursalService sucursalService;
+
+    @Autowired
+    private ImpresionService impresionService;
+
+    public VentaTarjeta ventaTarjetaPorId(Long id, Long sucId) {
+        return service.findByIdAndSucursalId(id, sucId);
+    }
+
+    public VentaTarjeta ventaTarjetaPorVentaId(Long ventaId, Long sucId) {
+        return service.findByVentaIdAndSucursalId(ventaId, sucId);
+    }
+
+    public List<VentaTarjeta> ventasTarjetaPorCaja(Long cajaId, Long sucId) {
+        return service.findByCajaIdAndSucursalId(cajaId, sucId);
+    }
+
+    public Long countVentasTarjetaSinRegistrar(Long cajaId, Long sucId) {
+        Long count = service.countVentasTarjetaSinRegistrar(cajaId, sucId);
+        return count != null ? count : 0L;
+    }
+
+    public VentaTarjeta saveVentaTarjeta(VentaTarjetaInput input) {
+        ModelMapper m = new ModelMapper();
+        m.getConfiguration().setAmbiguityIgnored(true);
+        VentaTarjeta entity = m.map(input, VentaTarjeta.class);
+
+        if (input.getVentaId() != null && input.getSucursalId() != null) {
+            Venta venta = ventaService.findByIdAndSucursalId(input.getVentaId(), input.getSucursalId());
+            entity.setVenta(venta);
+        }
+
+        if (input.getCajaId() != null && input.getSucursalId() != null) {
+            PdvCaja caja = pdvCajaService.findById(input.getCajaId(), input.getSucursalId());
+            entity.setCaja(caja);
+        }
+
+        if (input.getTerminalPosId() != null) {
+            TerminalPos terminal = terminalPosService.findById(input.getTerminalPosId()).orElse(null);
+            entity.setTerminalPos(terminal);
+        }
+
+        if (input.getUsuarioId() != null) {
+            Usuario usuario = usuarioService.findById(input.getUsuarioId()).orElse(null);
+            entity.setUsuario(usuario);
+        }
+
+        return service.save(entity);
+    }
+
+    public VentaTarjeta updateVentaTarjeta(VentaTarjetaInput input) {
+        VentaTarjeta entity = service.findByIdAndSucursalId(input.getId(), input.getSucursalId());
+        if (entity == null) return null;
+
+        if (input.getCodigoAutorizacion() != null) entity.setCodigoAutorizacion(input.getCodigoAutorizacion());
+        if (input.getNumeroBoleta() != null) entity.setNumeroBoleta(input.getNumeroBoleta());
+        if (input.getMontoEscaneado() != null) entity.setMontoEscaneado(input.getMontoEscaneado());
+        if (input.getImagenUrl() != null) entity.setImagenUrl(input.getImagenUrl());
+        if (input.getEstado() != null) entity.setEstado(input.getEstado());
+        if (input.getTerminalPosId() != null) {
+            entity.setTerminalPos(terminalPosService.findById(input.getTerminalPosId()).orElse(null));
+        }
+        if (input.getUsuarioId() != null) {
+            entity.setUsuario(usuarioService.findById(input.getUsuarioId()).orElse(null));
+        }
+
+        return service.save(entity);
+    }
+
+    public Boolean deleteVentaTarjeta(Long id, Long sucId) {
+        VentaTarjeta entity = service.findByIdAndSucursalId(id, sucId);
+        if (entity == null) return false;
+        return service.delete(entity);
+    }
+
+    public Page<VentaTarjeta> filtrarVentasTarjeta(Long id, Long ventaId, Long sucursalId,
+                                                    String terminalDescripcion, String terminalCodigo,
+                                                    String estado, String fechaDesde, String fechaHasta,
+                                                    Integer page, Integer size) {
+        LocalDateTime desde = (fechaDesde != null && !fechaDesde.isEmpty()) ? LocalDateTime.parse(fechaDesde) : null;
+        LocalDateTime hasta = (fechaHasta != null && !fechaHasta.isEmpty()) ? LocalDateTime.parse(fechaHasta) : null;
+        return service.filter(id, ventaId, sucursalId, terminalDescripcion, terminalCodigo, estado, desde, hasta,
+                page != null ? page : 0, size != null ? size : 15);
+    }
+
+    public Boolean cancelarVentaTarjetaPorVentaId(Long ventaId, Long sucId) {
+        List<VentaTarjeta> registros = service.findAllByVentaIdAndSucursalId(ventaId, sucId);
+        if (registros == null || registros.isEmpty()) return false;
+        registros.forEach(vt -> {
+            vt.setEstado("CANCELADO");
+            service.save(vt);
+        });
+        return true;
+    }
+
+    public String imprimirReporteVentaTarjeta(Long id, Long ventaId, Long sucursalId, String terminalDescripcion,
+                                               String terminalCodigo, String estado,
+                                               String fechaDesde, String fechaHasta,
+                                               Long usuarioResponsableId) {
+        LocalDateTime desde = (fechaDesde != null && !fechaDesde.isEmpty()) ? LocalDateTime.parse(fechaDesde) : null;
+        LocalDateTime hasta = (fechaHasta != null && !fechaHasta.isEmpty()) ? LocalDateTime.parse(fechaHasta) : null;
+
+        List<VentaTarjeta> ventaTarjetaList = service.filterList(id, ventaId, sucursalId, terminalDescripcion, terminalCodigo, estado, desde, hasta);
+
+        String sucursalFiltro = null;
+        if (sucursalId != null) {
+            Sucursal sucursal = sucursalService.findById(sucursalId).orElse(null);
+            sucursalFiltro = sucursal != null ? sucursal.getNombre() : null;
+        }
+
+        String terminalFiltro = null;
+        if (terminalDescripcion != null && terminalCodigo != null) {
+            terminalFiltro = terminalDescripcion + " - " + terminalCodigo;
+        } else if (terminalDescripcion != null) {
+            terminalFiltro = terminalDescripcion;
+        } else if (terminalCodigo != null) {
+            terminalFiltro = terminalCodigo;
+        }
+
+        Usuario usuarioReporte = null;
+        if (usuarioResponsableId != null) {
+            usuarioReporte = usuarioService.findById(usuarioResponsableId).orElse(null);
+        }
+
+        String fechaDesdeFormateada = desde != null ? DateUtils.toString(desde) : null;
+        String fechaHastaFormateada = hasta != null ? DateUtils.toString(hasta) : null;
+
+        return impresionService.imprimirReporteVentaTarjeta(ventaTarjetaList, sucursalFiltro, terminalFiltro,
+                estado, fechaDesdeFormateada, fechaHastaFormateada, usuarioReporte);
+    }
+}

--- a/src/main/java/com/franco/dev/graphql/financiero/input/TerminalPosInput.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/input/TerminalPosInput.java
@@ -14,6 +14,8 @@ public class TerminalPosInput {
 
     private Long cuentaBancariaId;
 
+    private Long monedaId;
+
     private Boolean activo;
 
     private LocalDateTime creadoEn;

--- a/src/main/java/com/franco/dev/graphql/financiero/input/VentaTarjetaInput.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/input/VentaTarjetaInput.java
@@ -1,0 +1,21 @@
+package com.franco.dev.graphql.financiero.input;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+@Data
+public class VentaTarjetaInput {
+    private Long id;
+    private Long sucursalId;
+    private Long ventaId;
+    private Long terminalPosId;
+    private Long cajaId;
+    private String codigoAutorizacion;
+    private String numeroBoleta;
+    private BigDecimal monto;
+    private BigDecimal montoEscaneado;
+    private String imagenUrl;
+    private Long usuarioId;
+    private String estado;
+}

--- a/src/main/java/com/franco/dev/repository/financiero/VentaTarjetaRepository.java
+++ b/src/main/java/com/franco/dev/repository/financiero/VentaTarjetaRepository.java
@@ -1,0 +1,80 @@
+package com.franco.dev.repository.financiero;
+
+import com.franco.dev.domain.EmbebedPrimaryKey;
+import com.franco.dev.domain.financiero.VentaTarjeta;
+import com.franco.dev.repository.HelperRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface VentaTarjetaRepository extends HelperRepository<VentaTarjeta, EmbebedPrimaryKey> {
+
+    default Class<VentaTarjeta> getEntityClass() {
+        return VentaTarjeta.class;
+    }
+
+    VentaTarjeta findFirstByVentaIdAndSucursalIdAndEstadoOrderByIdAsc(Long ventaId, Long sucursalId, String estado);
+
+    VentaTarjeta findFirstByVentaIdAndSucursalIdOrderByIdAsc(Long ventaId, Long sucursalId);
+
+    VentaTarjeta findByIdAndSucursalId(Long id, Long sucursalId);
+
+    List<VentaTarjeta> findByCajaIdAndSucursalIdOrderByCreadoEnDesc(Long cajaId, Long sucursalId);
+
+    List<VentaTarjeta> findByVentaIdAndSucursalIdOrderByIdAsc(Long ventaId, Long sucursalId);
+
+    Long countByCajaIdAndSucursalIdAndEstado(Long cajaId, Long sucursalId, String estado);
+
+    @Query(value = "SELECT vt FROM VentaTarjeta vt " +
+            "WHERE (:id IS NULL OR vt.id = :id) " +
+            "AND (:ventaId IS NULL OR vt.venta.id = :ventaId) " +
+            "AND (:sucursalId IS NULL OR vt.sucursalId = :sucursalId) " +
+            "AND (:terminalDescripcion IS NULL OR vt.terminalPos.descripcion = :terminalDescripcion) " +
+            "AND (:terminalCodigo IS NULL OR vt.terminalPos.codigo = :terminalCodigo) " +
+            "AND (:estado IS NULL OR vt.estado = :estado) " +
+            "AND (cast(:fechaDesde as timestamp) IS NULL OR vt.creadoEn >= :fechaDesde) " +
+            "AND (cast(:fechaHasta as timestamp) IS NULL OR vt.creadoEn <= :fechaHasta) " +
+            "ORDER BY vt.creadoEn DESC",
+            countQuery = "SELECT COUNT(vt) FROM VentaTarjeta vt " +
+            "WHERE (:id IS NULL OR vt.id = :id) " +
+            "AND (:ventaId IS NULL OR vt.venta.id = :ventaId) " +
+            "AND (:sucursalId IS NULL OR vt.sucursalId = :sucursalId) " +
+            "AND (:terminalDescripcion IS NULL OR vt.terminalPos.descripcion = :terminalDescripcion) " +
+            "AND (:terminalCodigo IS NULL OR vt.terminalPos.codigo = :terminalCodigo) " +
+            "AND (:estado IS NULL OR vt.estado = :estado) " +
+            "AND (cast(:fechaDesde as timestamp) IS NULL OR vt.creadoEn >= :fechaDesde) " +
+            "AND (cast(:fechaHasta as timestamp) IS NULL OR vt.creadoEn <= :fechaHasta)")
+    Page<VentaTarjeta> filterVentaTarjeta(
+            @Param("id") Long id,
+            @Param("ventaId") Long ventaId,
+            @Param("sucursalId") Long sucursalId,
+            @Param("terminalDescripcion") String terminalDescripcion,
+            @Param("terminalCodigo") String terminalCodigo,
+            @Param("estado") String estado,
+            @Param("fechaDesde") LocalDateTime fechaDesde,
+            @Param("fechaHasta") LocalDateTime fechaHasta,
+            Pageable pageable);
+
+    @Query("SELECT vt FROM VentaTarjeta vt " +
+            "WHERE (:id IS NULL OR vt.id = :id) " +
+            "AND (:ventaId IS NULL OR vt.venta.id = :ventaId) " +
+            "AND (:sucursalId IS NULL OR vt.sucursalId = :sucursalId) " +
+            "AND (:terminalDescripcion IS NULL OR vt.terminalPos.descripcion = :terminalDescripcion) " +
+            "AND (:terminalCodigo IS NULL OR vt.terminalPos.codigo = :terminalCodigo) " +
+            "AND (:estado IS NULL OR vt.estado = :estado) " +
+            "AND (cast(:fechaDesde as timestamp) IS NULL OR vt.creadoEn >= :fechaDesde) " +
+            "AND (cast(:fechaHasta as timestamp) IS NULL OR vt.creadoEn <= :fechaHasta) " +
+            "ORDER BY vt.creadoEn DESC")
+    List<VentaTarjeta> filterVentaTarjetaList(
+            @Param("id") Long id,
+            @Param("ventaId") Long ventaId,
+            @Param("sucursalId") Long sucursalId,
+            @Param("terminalDescripcion") String terminalDescripcion,
+            @Param("terminalCodigo") String terminalCodigo,
+            @Param("estado") String estado,
+            @Param("fechaDesde") LocalDateTime fechaDesde,
+            @Param("fechaHasta") LocalDateTime fechaHasta);
+}

--- a/src/main/java/com/franco/dev/service/empresarial/LogicalReplicationService.java
+++ b/src/main/java/com/franco/dev/service/empresarial/LogicalReplicationService.java
@@ -256,7 +256,7 @@ public class LogicalReplicationService {
      * @param branchDbName The branch database name
      * @return true if successful
      */
-    public boolean createCentralToBranchSubscription(Long sucursalId, String branchIp, 
+    public boolean createCentralToBranchSubscription(Long sucursalId, String branchIp,
                                                   int branchPort, String branchDbName) {
         try {
             logger.info("Replicación: creando suscripción central->filial sucursalId={} conectando a base de datos branchDbName={} host={} port={}", sucursalId, branchDbName, branchIp, branchPort);
@@ -264,11 +264,28 @@ public class LogicalReplicationService {
                 "dbname=%s host=%s user=%s password=%s port=%d",
                 branchDbName, branchIp, dbUsername, dbPassword, branchPort
             );
-            
-            String sql = "CREATE SUBSCRIPTION " + generateBranchSubscriptionName(sucursalId) + " " +
+            String subscriptionName = generateBranchSubscriptionName(sucursalId);
+
+            // Pre-create the replication slot on the publisher (general/filial) to avoid
+            // same-server deadlock: CREATE SUBSCRIPTION internally runs CREATE_REPLICATION_SLOT
+            // on the publisher, which waits for the subscriber's transaction to finish — circular wait.
+            JdbcTemplate publisherJdbc = createRemoteJdbcTemplate(branchIp, branchPort, branchDbName, dbUsername, dbPassword);
+            try {
+                publisherJdbc.execute("SELECT pg_create_logical_replication_slot('" + subscriptionName + "', 'pgoutput')");
+                logger.info("Replicación: slot {} creado en publisher (filial {})", subscriptionName, sucursalId);
+            } catch (Exception e) {
+                if (e.getMessage() != null && e.getMessage().contains("already exists")) {
+                    logger.info("Replicación: slot {} ya existe en filial {} (OK)", subscriptionName, sucursalId);
+                } else {
+                    throw e;
+                }
+            }
+
+            String sql = "CREATE SUBSCRIPTION " + subscriptionName + " " +
                     "CONNECTION '" + connectionString + "' " +
-                    "PUBLICATION " + generateBranchPublicationName(sucursalId) + " WITH (copy_data = false, origin = 'none')";
-            
+                    "PUBLICATION " + generateBranchPublicationName(sucursalId) +
+                    " WITH (copy_data = false, origin = 'none', create_slot = false)";
+
             jdbcTemplate.execute(sql);
             return true;
         } catch (Exception e) {
@@ -1409,11 +1426,24 @@ public class LogicalReplicationService {
                 logger.error("[Replicación] Error verificando suscripción existente en filial {}: {}", branchId, e.getMessage());
             }
 
+            // Pre-create the replication slot on the publisher (bodega/central) to avoid
+            // same-server deadlock when publisher and subscriber are on the same PG instance.
+            try {
+                jdbcTemplate.execute("SELECT pg_create_logical_replication_slot('" + subscriptionName + "', 'pgoutput')");
+                logger.info("[Replicación] Slot {} creado en publisher (central)", subscriptionName);
+            } catch (Exception e) {
+                if (e.getMessage() != null && e.getMessage().contains("already exists")) {
+                    logger.info("[Replicación] Slot {} ya existe en central (OK)", subscriptionName);
+                } else {
+                    throw e;
+                }
+            }
+
             // Build the CREATE SUBSCRIPTION command
             String sql = "CREATE SUBSCRIPTION " + subscriptionName +
                     " CONNECTION '" + connectionString + "' " +
                     " PUBLICATION " + publicationName +
-                    " WITH (copy_data = false, origin = 'none')";
+                    " WITH (copy_data = false, origin = 'none', create_slot = false)";
 
             logger.info("[Replicación] Creando suscripción {} en filial {} -> publicación {}", subscriptionName, branchId, publicationName);
             // Execute the command

--- a/src/main/java/com/franco/dev/service/financiero/VentaTarjetaService.java
+++ b/src/main/java/com/franco/dev/service/financiero/VentaTarjetaService.java
@@ -1,0 +1,61 @@
+package com.franco.dev.service.financiero;
+
+import com.franco.dev.domain.EmbebedPrimaryKey;
+import com.franco.dev.domain.financiero.VentaTarjeta;
+import com.franco.dev.repository.financiero.VentaTarjetaRepository;
+import com.franco.dev.service.CrudService;
+import lombok.AllArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@AllArgsConstructor
+public class VentaTarjetaService extends CrudService<VentaTarjeta, VentaTarjetaRepository, EmbebedPrimaryKey> {
+
+    private final VentaTarjetaRepository repository;
+
+    @Override
+    public VentaTarjetaRepository getRepository() {
+        return repository;
+    }
+
+    public VentaTarjeta findByVentaIdAndSucursalId(Long ventaId, Long sucursalId) {
+        VentaTarjeta pendiente = repository.findFirstByVentaIdAndSucursalIdAndEstadoOrderByIdAsc(ventaId, sucursalId, "PENDIENTE");
+        return pendiente != null ? pendiente : repository.findFirstByVentaIdAndSucursalIdOrderByIdAsc(ventaId, sucursalId);
+    }
+
+    public VentaTarjeta findByIdAndSucursalId(Long id, Long sucursalId) {
+        return repository.findByIdAndSucursalId(id, sucursalId);
+    }
+
+    public List<VentaTarjeta> findByCajaIdAndSucursalId(Long cajaId, Long sucursalId) {
+        return repository.findByCajaIdAndSucursalIdOrderByCreadoEnDesc(cajaId, sucursalId);
+    }
+
+    public List<VentaTarjeta> findAllByVentaIdAndSucursalId(Long ventaId, Long sucursalId) {
+        return repository.findByVentaIdAndSucursalIdOrderByIdAsc(ventaId, sucursalId);
+    }
+
+    public Long countVentasTarjetaSinRegistrar(Long cajaId, Long sucursalId) {
+        return repository.countByCajaIdAndSucursalIdAndEstado(cajaId, sucursalId, "PENDIENTE");
+    }
+
+    public Page<VentaTarjeta> filter(Long id, Long ventaId, Long sucursalId, String terminalDescripcion,
+                                     String terminalCodigo, String estado,
+                                     LocalDateTime fechaDesde, LocalDateTime fechaHasta,
+                                     int page, int size) {
+        return repository.filterVentaTarjeta(id, ventaId, sucursalId, terminalDescripcion, terminalCodigo,
+                estado, fechaDesde, fechaHasta, PageRequest.of(page, size));
+    }
+
+    public List<VentaTarjeta> filterList(Long id, Long ventaId, Long sucursalId, String terminalDescripcion,
+                                          String terminalCodigo, String estado,
+                                          LocalDateTime fechaDesde, LocalDateTime fechaHasta) {
+        return repository.filterVentaTarjetaList(id, ventaId, sucursalId, terminalDescripcion, terminalCodigo,
+                estado, fechaDesde, fechaHasta);
+    }
+}

--- a/src/main/java/com/franco/dev/service/impresion/ImpresionService.java
+++ b/src/main/java/com/franco/dev/service/impresion/ImpresionService.java
@@ -1362,6 +1362,79 @@ public class ImpresionService {
         private String turno;
     }
 
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public class VentaTarjetaItemDto {
+        private Long id;
+        private Long ventaId;
+        private String terminal;
+        private String codigo;
+        private String sucursal;
+        private java.math.BigDecimal monto;
+        private String montoFormateado;
+        private String montoEscaneado;
+        private String estado;
+        private String creadoEn;
+        private String simboloMoneda;
+    }
+
+    public String imprimirReporteVentaTarjeta(List<com.franco.dev.domain.financiero.VentaTarjeta> ventaTarjetaList,
+            String sucursalFiltro, String terminalFiltro, String estadoFiltro,
+            String fechaDesde, String fechaHasta, Usuario usuario) {
+        try {
+            List<VentaTarjetaItemDto> itemList = new ArrayList<>();
+            for (com.franco.dev.domain.financiero.VentaTarjeta vt : ventaTarjetaList) {
+                VentaTarjetaItemDto dto = new VentaTarjetaItemDto();
+                dto.setId(vt.getId());
+                dto.setVentaId(vt.getVenta() != null ? vt.getVenta().getId() : null);
+                dto.setTerminal(vt.getTerminalPos() != null ? vt.getTerminalPos().getDescripcion() : "");
+                dto.setCodigo(vt.getTerminalPos() != null ? vt.getTerminalPos().getCodigo() : "");
+                dto.setSucursal(vt.getSucursal() != null ? vt.getSucursal().getNombre() : "");
+                dto.setMonto(vt.getMonto());
+                dto.setMontoEscaneado(vt.getMontoEscaneado() != null
+                        ? new java.text.DecimalFormat("#,##0").format(vt.getMontoEscaneado())
+                        : "-");
+                dto.setEstado(vt.getEstado());
+                dto.setCreadoEn(vt.getCreadoEn() != null ? DateUtils.toString(vt.getCreadoEn()) : "");
+                String simbolo = (vt.getTerminalPos() != null && vt.getTerminalPos().getMoneda() != null)
+                        ? vt.getTerminalPos().getMoneda().getSimbolo() : "Gs.";
+                dto.setSimboloMoneda(simbolo);
+                dto.setMontoFormateado(formatMontoPorMoneda(vt.getMonto(), simbolo));
+                itemList.add(dto);
+            }
+            itemList.sort(java.util.Comparator.comparing(VentaTarjetaItemDto::getSimboloMoneda));
+
+            java.util.Map<String, java.math.BigDecimal> totalesPorMoneda = new java.util.LinkedHashMap<>();
+            for (VentaTarjetaItemDto dto : itemList) {
+                totalesPorMoneda.merge(dto.getSimboloMoneda(), dto.getMonto() != null ? dto.getMonto() : java.math.BigDecimal.ZERO, java.math.BigDecimal::add);
+            }
+            String totalPorMoneda = "Cantidad de ventas: " + itemList.size() + "\n"
+                    + totalesPorMoneda.entrySet().stream()
+                            .map(e -> "Total " + e.getKey() + ": " + formatMontoPorMoneda(e.getValue(), e.getKey()))
+                            .collect(java.util.stream.Collectors.joining("\n"));
+            JasperReport jasperReport = compileReportFromClasspath("reports/venta-tarjeta.jrxml");
+            JRBeanCollectionDataSource dataSource = new JRBeanCollectionDataSource(itemList);
+            Map<String, Object> parameters = new HashMap<>();
+            parameters.put("sucursalFiltro", sucursalFiltro != null ? sucursalFiltro : "Todas");
+            parameters.put("terminalFiltro", terminalFiltro != null ? terminalFiltro : "Todas");
+            parameters.put("estadoFiltro", estadoFiltro != null ? estadoFiltro : "Todos");
+            parameters.put("fechaDesde", fechaDesde != null ? fechaDesde : "");
+            parameters.put("fechaHasta", fechaHasta != null ? fechaHasta : "");
+            parameters.put("fechaReporte", DateUtils.toString(LocalDateTime.now()));
+            parameters.put("usuario",
+                    usuario != null && usuario.getPersona() != null ? usuario.getPersona().getNombre() : "");
+            parameters.put("totalPorMoneda", totalPorMoneda);
+            parameters.put("logo", imageService.getImagePath() + File.separator + "logo.png");
+            JasperPrint jasperPrint = JasperFillManager.fillReport(jasperReport, parameters, dataSource);
+            byte[] pdfBytes = JasperExportManager.exportReportToPdf(jasperPrint);
+            return Base64.getEncoder().encodeToString(pdfBytes);
+        } catch (JRException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
     public String imprimirSolicitudPagoPDF(
             SolicitudPago solicitudPago,
             String proveedorNombre,
@@ -1794,6 +1867,19 @@ public class ImpresionService {
             log.error("Error al generar PDF de pre-gasto: {}", e.getMessage(), e);
             throw new RuntimeException("Error al generar el PDF: " + e.getMessage(), e);
         }
+    }
+
+    /**
+     * Formatea un monto segun su moneda: guaranies sin decimales (10.000),
+     * el resto (reales, dolares, etc.) con dos decimales y coma decimal (10,00).
+     */
+    private String formatMontoPorMoneda(java.math.BigDecimal monto, String simbolo) {
+        java.math.BigDecimal valor = monto != null ? monto : java.math.BigDecimal.ZERO;
+        boolean esGuarani = simbolo != null
+                && (simbolo.trim().equalsIgnoreCase("Gs") || simbolo.trim().equalsIgnoreCase("Gs."));
+        java.text.DecimalFormatSymbols simbolos = new java.text.DecimalFormatSymbols(java.util.Locale.GERMANY);
+        java.text.DecimalFormat fmt = new java.text.DecimalFormat(esGuarani ? "#,##0" : "#,##0.00", simbolos);
+        return fmt.format(valor);
     }
 
     private String formatMonto(java.math.BigDecimal monto, String simbolo) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,7 +16,7 @@
 spring.datasource.platform=postgres
 spring.datasource.url=jdbc:postgresql://localhost:5551/bodega
 #spring.datasource.url=jdbc:postgresql://localhost:5552/central
-spring.datasource.username=francospring.profiles.active=user-dev
+spring.datasource.username=franco
 spring.datasource.password=franco
 spring.datasource.hikari.connection-timeout=60000
 gps.server.port=5521

--- a/src/main/resources/db/migration/V140.1__create_venta_tarjeta_table.sql
+++ b/src/main/resources/db/migration/V140.1__create_venta_tarjeta_table.sql
@@ -1,0 +1,21 @@
+CREATE TABLE financiero.venta_tarjeta (
+    id                  BIGSERIAL,
+    sucursal_id         BIGINT NOT NULL,
+    venta_id            BIGINT NOT NULL,
+    terminal_pos_id     BIGINT,
+    caja_id             BIGINT NOT NULL,
+    codigo_autorizacion VARCHAR(100),
+    numero_boleta       VARCHAR(100),
+    monto               NUMERIC(18,2) NOT NULL,
+    imagen_url          VARCHAR(500),
+    usuario_id          BIGINT,
+    estado              VARCHAR(20) NOT NULL DEFAULT 'PENDIENTE',
+    creado_en           TIMESTAMP NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (id, sucursal_id),
+    CONSTRAINT fk_vt_terminal_pos FOREIGN KEY (terminal_pos_id) REFERENCES financiero.terminal_pos(id),
+    CONSTRAINT fk_vt_usuario      FOREIGN KEY (usuario_id)      REFERENCES personas.usuario(id)
+);
+
+CREATE INDEX idx_venta_tarjeta_venta_id ON financiero.venta_tarjeta(venta_id, sucursal_id);
+CREATE INDEX idx_venta_tarjeta_caja_id  ON financiero.venta_tarjeta(caja_id, sucursal_id);
+CREATE INDEX idx_venta_tarjeta_estado   ON financiero.venta_tarjeta(caja_id, sucursal_id, estado);

--- a/src/main/resources/db/migration/V141.1__add_moneda_id_to_terminal_pos.sql
+++ b/src/main/resources/db/migration/V141.1__add_moneda_id_to_terminal_pos.sql
@@ -1,0 +1,3 @@
+ALTER TABLE financiero.terminal_pos
+    ADD COLUMN moneda_id BIGINT,
+    ADD CONSTRAINT fk_terminal_pos_moneda FOREIGN KEY (moneda_id) REFERENCES financiero.moneda(id);

--- a/src/main/resources/db/migration/V141.2__add_monto_escaneado_to_venta_tarjeta.sql
+++ b/src/main/resources/db/migration/V141.2__add_monto_escaneado_to_venta_tarjeta.sql
@@ -1,0 +1,2 @@
+ALTER TABLE financiero.venta_tarjeta
+    ADD COLUMN monto_escaneado NUMERIC(18,2);

--- a/src/main/resources/graphql/financiero/terminalpos.graphqls
+++ b/src/main/resources/graphql/financiero/terminalpos.graphqls
@@ -2,6 +2,7 @@ type TerminalPos {
     id:ID!
     descripcion: String
     codigo: String
+    moneda: Moneda
     activo: Boolean
     creadoEn: Date
     usuario: Usuario
@@ -23,6 +24,7 @@ input TerminalPosInput {
     descripcion: String
     codigo: String
     cuentaBancariaId: Int
+    monedaId: Int
     activo: Boolean
     creadoEn: Date
     usuarioId: Int

--- a/src/main/resources/graphql/financiero/venta-tarjeta.graphqls
+++ b/src/main/resources/graphql/financiero/venta-tarjeta.graphqls
@@ -1,0 +1,52 @@
+type VentaTarjetaPage {
+    getContent: [VentaTarjeta]
+    getTotalElements: Int
+}
+
+type VentaTarjeta {
+    id: ID!
+    sucursalId: Int
+    sucursal: Sucursal
+    venta: Venta
+    terminalPos: TerminalPos
+    caja: PdvCaja
+    codigoAutorizacion: String
+    numeroBoleta: String
+    monto: Float
+    montoEscaneado: Float
+    imagenUrl: String
+    estado: String
+    usuario: Usuario
+    creadoEn: Date
+}
+
+input VentaTarjetaInput {
+    id: ID
+    sucursalId: Int
+    ventaId: Int
+    terminalPosId: Int
+    cajaId: Int
+    codigoAutorizacion: String
+    numeroBoleta: String
+    monto: Float
+    montoEscaneado: Float
+    imagenUrl: String
+    estado: String
+    usuarioId: Int
+}
+
+extend type Query {
+    ventaTarjetaPorId(id: ID!, sucId: ID!): VentaTarjeta
+    ventaTarjetaPorVentaId(ventaId: ID!, sucId: ID!): VentaTarjeta
+    ventasTarjetaPorCaja(cajaId: ID!, sucId: ID!): [VentaTarjeta]
+    countVentasTarjetaSinRegistrar(cajaId: ID!, sucId: ID!): Int
+    filtrarVentasTarjeta(id: ID, ventaId: ID, sucursalId: ID, terminalDescripcion: String, terminalCodigo: String, estado: String, fechaDesde: String, fechaHasta: String, page: Int, size: Int): VentaTarjetaPage
+    imprimirReporteVentaTarjeta(id: ID, ventaId: ID, sucursalId: ID, terminalDescripcion: String, terminalCodigo: String, estado: String, fechaDesde: String, fechaHasta: String, usuarioResponsableId: ID): String
+}
+
+extend type Mutation {
+    saveVentaTarjeta(ventaTarjeta: VentaTarjetaInput!): VentaTarjeta!
+    updateVentaTarjeta(ventaTarjeta: VentaTarjetaInput!): VentaTarjeta!
+    deleteVentaTarjeta(id: ID!, sucId: ID!): Boolean!
+    cancelarVentaTarjetaPorVentaId(ventaId: ID!, sucId: ID!): Boolean
+}

--- a/src/main/resources/reports/venta-tarjeta.jrxml
+++ b/src/main/resources/reports/venta-tarjeta.jrxml
@@ -1,0 +1,333 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 6.21.5.final using JasperReports Library version 6.21.5-74d586df47b25dbd05bd0957999819196e59934a  -->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="venta-tarjeta" pageWidth="595" pageHeight="842" columnWidth="555" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="d3a1a2ee-7b8a-4a3d-9d3b-1a2b3c4d5e6f">
+	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="One Empty Record"/>
+	<parameter name="logo" class="java.lang.String"/>
+	<parameter name="fechaReporte" class="java.lang.String"/>
+	<parameter name="usuario" class="java.lang.String"/>
+	<parameter name="sucursalFiltro" class="java.lang.String"/>
+	<parameter name="terminalFiltro" class="java.lang.String"/>
+	<parameter name="estadoFiltro" class="java.lang.String"/>
+	<parameter name="fechaDesde" class="java.lang.String"/>
+	<parameter name="fechaHasta" class="java.lang.String"/>
+	<parameter name="totalPorMoneda" class="java.lang.String"/>
+	<field name="id" class="java.lang.Long"/>
+	<field name="ventaId" class="java.lang.Long"/>
+	<field name="terminal" class="java.lang.String"/>
+	<field name="codigo" class="java.lang.String"/>
+	<field name="sucursal" class="java.lang.String"/>
+	<field name="monto" class="java.math.BigDecimal"/>
+	<field name="montoFormateado" class="java.lang.String"/>
+	<field name="montoEscaneado" class="java.lang.String"/>
+	<field name="estado" class="java.lang.String"/>
+	<field name="creadoEn" class="java.lang.String"/>
+	<field name="simboloMoneda" class="java.lang.String"/>
+	<title>
+		<band height="140" splitType="Stretch">
+			<image hAlign="Center">
+				<reportElement x="0" y="50" width="95" height="61" uuid="8a1b2c3d-4e5f-6789-0123-456789abcdef"/>
+				<imageExpression><![CDATA[$P{logo}]]></imageExpression>
+			</image>
+			<staticText>
+				<reportElement x="80" y="0" width="400" height="27" forecolor="#000000" uuid="c0c9f5b8-f0b7-4503-9428-2d7be98aa4e7"/>
+				<textElement textAlignment="Center" verticalAlignment="Top">
+					<font fontName="Verdana" size="14" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Reporte de Ventas con Tarjeta]]></text>
+			</staticText>
+			<rectangle>
+				<reportElement x="100" y="33" width="225" height="100" uuid="e703c566-7819-4778-bdfd-f96af1fc6e09"/>
+				<graphicElement>
+					<pen lineColor="#030303"/>
+				</graphicElement>
+			</rectangle>
+			<rectangle>
+				<reportElement x="179" y="27" width="66" height="12" forecolor="#030303" backcolor="#FFFFFF" uuid="135b7210-797e-41f2-a5fd-031e40506d08"/>
+				<graphicElement>
+					<pen lineColor="#030303"/>
+				</graphicElement>
+			</rectangle>
+			<staticText>
+				<reportElement x="187" y="27" width="50" height="12" forecolor="#000000" uuid="b61efa33-0ea0-4fed-9d78-a768de817cb3"/>
+				<textElement textAlignment="Center">
+					<font fontName="Verdana" size="9" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Filtros]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="110" y="40" width="65" height="11" uuid="1a2b3c4d-0001-4001-8001-000000000001"/>
+				<box rightPadding="4"/>
+				<textElement>
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<text><![CDATA[Sucursal:]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="175" y="40" width="143" height="11" uuid="1a2b3c4d-0002-4001-8001-000000000002"/>
+				<textElement>
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{sucursalFiltro}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="110" y="51" width="65" height="11" uuid="1a2b3c4d-0003-4001-8001-000000000003"/>
+				<box rightPadding="4"/>
+				<textElement>
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<text><![CDATA[Terminal:]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="175" y="51" width="143" height="11" uuid="1a2b3c4d-0004-4001-8001-000000000004"/>
+				<textElement>
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{terminalFiltro}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="110" y="62" width="65" height="11" uuid="1a2b3c4d-0005-4001-8001-000000000005"/>
+				<box rightPadding="4"/>
+				<textElement>
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<text><![CDATA[Estado:]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="175" y="62" width="143" height="11" uuid="1a2b3c4d-0006-4001-8001-000000000006"/>
+				<textElement>
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{estadoFiltro}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="110" y="73" width="65" height="11" uuid="1a2b3c4d-0007-4001-8001-000000000007"/>
+				<box rightPadding="4"/>
+				<textElement>
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<text><![CDATA[Fecha Desde:]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="175" y="73" width="143" height="11" uuid="1a2b3c4d-0008-4001-8001-000000000008"/>
+				<textElement>
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{fechaDesde}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="110" y="84" width="65" height="11" uuid="1a2b3c4d-0009-4001-8001-000000000009"/>
+				<box rightPadding="4"/>
+				<textElement>
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<text><![CDATA[Fecha Hasta:]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="175" y="84" width="143" height="11" uuid="1a2b3c4d-0010-4001-8001-000000000010"/>
+				<textElement>
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{fechaHasta}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="110" y="95" width="65" height="11" uuid="1a2b3c4d-0011-4001-8001-000000000011"/>
+				<box rightPadding="4"/>
+				<textElement>
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<text><![CDATA[Generado en:]]></text>
+			</staticText>
+			<textField>
+				<reportElement x="175" y="95" width="143" height="11" uuid="1a2b3c4d-0012-4001-8001-000000000012"/>
+				<textElement>
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{fechaReporte}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="110" y="106" width="65" height="11" uuid="1a2b3c4d-0013-4001-8001-000000000013">
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				</reportElement>
+				<box rightPadding="4"/>
+				<textElement>
+					<font fontName="Verdana" size="8" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Responsable:]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="175" y="106" width="143" height="24" uuid="1a2b3c4d-0014-4001-8001-000000000014"/>
+				<textElement>
+					<font fontName="Verdana" size="8" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{usuario}]]></textFieldExpression>
+			</textField>
+			<rectangle>
+				<reportElement x="340" y="33" width="215" height="100" uuid="6aefecf3-cd9e-4738-a9d7-09a9578bc220"/>
+				<graphicElement>
+					<pen lineColor="#030303"/>
+				</graphicElement>
+			</rectangle>
+			<rectangle>
+				<reportElement x="415" y="27" width="75" height="12" forecolor="#030303" backcolor="#FFFFFF" uuid="bdc73c4f-d178-4c96-9c05-7fa69c270afb"/>
+				<graphicElement>
+					<pen lineColor="#030303"/>
+				</graphicElement>
+			</rectangle>
+			<staticText>
+				<reportElement x="415" y="27" width="75" height="12" forecolor="#000000" uuid="d93279d0-76e3-46ae-bd32-61f00d4dce8d"/>
+				<textElement textAlignment="Center">
+					<font fontName="Verdana" size="9" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Totales]]></text>
+			</staticText>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement x="352" y="40" width="195" height="77" uuid="1a2b3c4d-0016-4001-8001-000000000016"/>
+				<box leftPadding="4"/>
+				<textElement textAlignment="Left" verticalAlignment="Top">
+					<font fontName="Verdana" size="9" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{totalPorMoneda}]]></textFieldExpression>
+			</textField>
+		</band>
+	</title>
+	<columnHeader>
+		<band height="20">
+			<rectangle>
+				<reportElement x="0" y="0" width="555" height="18" forecolor="#9E9E9E" backcolor="#EDEDED" uuid="3006dae7-3228-4979-bda4-adc9f14e4ac8"/>
+			</rectangle>
+			<staticText>
+				<reportElement x="0" y="2" width="20" height="15" uuid="2a2b3c4d-0001-4002-8002-000000000001"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8" isBold="true"/>
+				</textElement>
+				<text><![CDATA[ID]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="20" y="2" width="40" height="15" uuid="2a2b3c4d-0002-4002-8002-000000000002"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Venta ID]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="60" y="2" width="80" height="15" uuid="2a2b3c4d-0003-4002-8002-000000000003"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Terminal]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="140" y="2" width="55" height="15" uuid="2a2b3c4d-0004-4002-8002-000000000004"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Código]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="195" y="2" width="110" height="15" uuid="2a2b3c4d-0005-4002-8002-000000000005"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Sucursal]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="305" y="2" width="60" height="15" uuid="2a2b3c4d-0006-4002-8002-000000000006"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Monto]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="365" y="2" width="60" height="15" uuid="2a2b3c4d-0007-4002-8002-000000000007"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Escaneado]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="425" y="2" width="55" height="15" uuid="2a2b3c4d-0008-4002-8002-000000000008"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Estado]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="480" y="2" width="75" height="15" uuid="2a2b3c4d-0009-4002-8002-000000000009"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Fecha]]></text>
+			</staticText>
+		</band>
+	</columnHeader>
+	<detail>
+		<band height="18">
+			<textField>
+				<reportElement x="0" y="1" width="20" height="15" uuid="3a2b3c4d-0001-4003-8003-000000000001"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="7"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{id}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="20" y="1" width="40" height="15" uuid="3a2b3c4d-0002-4003-8003-000000000002"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="7"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{ventaId}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="60" y="1" width="80" height="15" uuid="3a2b3c4d-0003-4003-8003-000000000003"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="7"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{terminal}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="140" y="1" width="55" height="15" uuid="3a2b3c4d-0004-4003-8003-000000000004"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="7"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{codigo}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="195" y="1" width="110" height="15" uuid="3a2b3c4d-0005-4003-8003-000000000005"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="7"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{sucursal}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="305" y="1" width="60" height="15" uuid="3a2b3c4d-0006-4003-8003-000000000006"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="7"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{montoFormateado}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="365" y="1" width="60" height="15" uuid="3a2b3c4d-0007-4003-8003-000000000007"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="7"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{montoEscaneado}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="425" y="1" width="55" height="15" uuid="3a2b3c4d-0008-4003-8003-000000000008"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="7"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{estado}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="480" y="1" width="75" height="15" uuid="3a2b3c4d-0009-4003-8003-000000000009"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="7"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{creadoEn}]]></textFieldExpression>
+			</textField>
+			<line>
+				<reportElement x="0" y="16" width="555" height="1" forecolor="#E0E0E0" uuid="4a2b3c4d-0001-4004-8004-000000000001"/>
+			</line>
+		</band>
+	</detail>
+</jasperReport>


### PR DESCRIPTION
## Qué resuelve

Agrega el flujo backend de venta con tarjeta: registro de la transacción (`VentaTarjeta`), catálogo de terminales POS (`TerminalPos`), reporte PDF de ventas con tarjeta, y un fix a la replicación lógica descubierto durante el desarrollo (deadlock al crear suscripciones cuando publisher y subscriber corren en la misma instancia de Postgres).

Incluye:
- `VentaTarjeta.java`, `VentaTarjetaRepository.java`, `VentaTarjetaService.java`, `VentaTarjetaGraphQL.java` (CRUD completo: `saveVentaTarjeta`, `updateVentaTarjeta`, `deleteVentaTarjeta`, `cancelarVentaTarjetaPorVentaId`, queries por venta/caja).
- Ajustes a `TerminalPos` (columna `moneda_id`) y su resolver.
- Reporte `venta-tarjeta.jrxml` (JasperReports) con cuadros de filtros y totales por moneda, incluyendo cantidad de ventas.
- `ImpresionService.imprimirReporteVentaTarjeta`: arma el PDF agrupando totales por símbolo de moneda.
- `LogicalReplicationService.java`: al crear una suscripción (central→filial o filial→central), ahora pre-crea el replication slot en el publisher antes del `CREATE SUBSCRIPTION` (`create_slot = false`), evitando el deadlock circular que ocurre cuando publisher y subscriber comparten la misma instancia de Postgres (típico en desarrollo local).
- Fix de un typo en `application.properties` (`spring.datasource.username` tenía `spring.profiles.active=user-dev` pegado sin salto de línea).

## Cómo probarlo

1. Levantar el servidor central con `./mvnw spring-boot:run` (o `compile -DskipFlyway=true` si la DB no está arriba) y confirmar que Flyway aplica `V140.1`, `V141.1`, `V141.2` sin errores.
2. Desde el POS, generar una venta con tarjeta (mutation `saveVentaTarjeta`) y confirmar el QR generado.
3. Actualizar el registro con código de autorización, boleta y monto escaneado (`updateVentaTarjeta`) y verificar persistencia.
4. Generar el reporte PDF (`imprimirReporteVentaTarjeta`) con ventas de al menos dos monedas distintas y confirmar que el cuadro de totales muestra "Cantidad de ventas" y un total por cada moneda.
5. Si tenés un entorno con central y filial en la misma instancia de Postgres (como el local de desarrollo), probar crear una suscripción nueva y confirmar que no cuelga esperando el slot (el fix de `LogicalReplicationService`).

## Impacto en DB

- `V140.1__create_venta_tarjeta_table.sql`: `CREATE TABLE financiero.venta_tarjeta` (PK compuesta `id, sucursal_id`), con FKs a `terminal_pos` y `usuario`. No toca tablas existentes.
- `V141.1__add_moneda_id_to_terminal_pos.sql`: `ALTER TABLE ADD COLUMN moneda_id` (nullable, con FK a `financiero.moneda`). Retrocompatible.
- `V141.2__add_monto_escaneado_to_venta_tarjeta.sql`: `ALTER TABLE ADD COLUMN monto_escaneado` (nullable). Retrocompatible.
- No hay `DROP`/`RENAME`/cambio de tipo. Estrategia de dos versiones no aplica porque son columnas nuevas.
- No incluye replicación de `financiero.venta_tarjeta` ni `financiero.terminal_pos` hacia filiales — quedó fuera de este PR a propósito (ver discusión de arquitectura: el flujo de venta con tarjeta hoy es central-only).

## Riesgo

Bajo.

- Tablas y columnas nuevas, sin tocar entidades existentes.
- El cambio en `LogicalReplicationService` es aditivo (agrega un paso de pre-creación de slot con manejo de "already exists"); no cambia la firma pública de los métodos ni el comportamiento en el caso normal (publisher y subscriber en instancias separadas, como en producción).
- Nota para el reviewer: en un primer commit se habían colado sin querer una modificación a una migración ya aplicada (`V111.2`), la deshabilitación global de los schedulers de replicación en `application.properties`, y binarios de un índice Lucene local — todo eso se revirtió antes de abrir el PR.
