### PR TITLE
feat(impresoras): módulo de registro, motor parametrizable y routing de impresión

### DIFF
--- a/src/main/java/com/franco/dev/domain/empresarial/Impresora.java
+++ b/src/main/java/com/franco/dev/domain/empresarial/Impresora.java
@@ -1,0 +1,94 @@
+package com.franco.dev.domain.empresarial;
+
+import com.franco.dev.config.Identifiable;
+import com.franco.dev.domain.empresarial.enums.PerfilPapel;
+import com.franco.dev.domain.empresarial.enums.TipoConexion;
+import com.franco.dev.domain.empresarial.enums.TipoImpresora;
+import com.franco.dev.domain.empresarial.enums.UsoImpresora;
+import com.franco.dev.domain.personas.Usuario;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+/**
+ * Registro unico de impresoras (termicas y normales) administrable desde la app.
+ * La impresora "sabe" en que sucursal/host esta conectada (campo {@link #sucursal}),
+ * lo que habilita el routing filial <-> central.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "impresora", schema = "empresarial")
+public class Impresora implements Identifiable<Long> {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GenericGenerator(
+            name = "assigned-identity",
+            strategy = "com.franco.dev.config.AssignedIdentityGenerator"
+    )
+    @GeneratedValue(
+            generator = "assigned-identity",
+            strategy = GenerationType.IDENTITY
+    )
+    private Long id;
+
+    private String nombre;
+
+    private Boolean activo;
+
+    private Boolean esPredeterminada;
+
+    /** Host donde esta conectada fisicamente la impresora (routing). */
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "sucursal_id", nullable = true)
+    private Sucursal sucursal;
+
+    @Enumerated(EnumType.STRING)
+    private TipoImpresora tipo;
+
+    @Enumerated(EnumType.STRING)
+    private UsoImpresora uso;
+
+    @Enumerated(EnumType.STRING)
+    private TipoConexion conexion;
+
+    /** Nombre de cola CUPS (conexion CUPS/USB/BLUETOOTH). */
+    private String colaCups;
+
+    /** Direccion IP (conexion RED / inalambrica). */
+    private String ip;
+
+    /** Puerto RAW/JetDirect (default 9100) para conexion RED. */
+    private Integer puerto;
+
+    @Enumerated(EnumType.STRING)
+    private PerfilPapel perfilPapel;
+
+    /** Columnas de caracteres para termicas (derivado del perfil, editable). */
+    private Integer columnas;
+
+    /** Ancho/alto en mm para hoja/custom (impresoras normales). */
+    private Integer anchoMm;
+    private Integer altoMm;
+
+    /** Marca: EPSON | STAR | BEMATECH | HP | ... */
+    private String marca;
+
+    /** Code-page ESC/POS. */
+    private String codepage;
+
+    @CreationTimestamp
+    private LocalDateTime creadoEn;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "usuario_id", nullable = true)
+    private Usuario usuario;
+}

--- a/src/main/java/com/franco/dev/domain/empresarial/enums/PerfilPapel.java
+++ b/src/main/java/com/franco/dev/domain/empresarial/enums/PerfilPapel.java
@@ -1,0 +1,15 @@
+package com.franco.dev.domain.empresarial.enums;
+
+/**
+ * Perfil de papel de la impresora. Para termicas define el ancho (y las columnas
+ * de caracteres por defecto); para normales define el tamanho de hoja.
+ */
+public enum PerfilPapel {
+    MM_48,
+    MM_58,
+    MM_72,
+    MM_80,
+    A4,
+    CARTA,
+    CUSTOM
+}

--- a/src/main/java/com/franco/dev/domain/empresarial/enums/TipoConexion.java
+++ b/src/main/java/com/franco/dev/domain/empresarial/enums/TipoConexion.java
@@ -1,0 +1,8 @@
+package com.franco.dev.domain.empresarial.enums;
+
+public enum TipoConexion {
+    CUPS,
+    USB,
+    RED,
+    BLUETOOTH
+}

--- a/src/main/java/com/franco/dev/domain/empresarial/enums/TipoImpresora.java
+++ b/src/main/java/com/franco/dev/domain/empresarial/enums/TipoImpresora.java
@@ -1,0 +1,7 @@
+package com.franco.dev.domain.empresarial.enums;
+
+public enum TipoImpresora {
+    TERMICA,
+    NORMAL,
+    ETIQUETA
+}

--- a/src/main/java/com/franco/dev/domain/empresarial/enums/UsoImpresora.java
+++ b/src/main/java/com/franco/dev/domain/empresarial/enums/UsoImpresora.java
@@ -1,0 +1,9 @@
+package com.franco.dev.domain.empresarial.enums;
+
+public enum UsoImpresora {
+    TICKET,
+    FACTURA,
+    REPORTE,
+    ETIQUETA,
+    COMANDA
+}

--- a/src/main/java/com/franco/dev/graphql/empresarial/ImpresoraGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/empresarial/ImpresoraGraphQL.java
@@ -1,0 +1,83 @@
+package com.franco.dev.graphql.empresarial;
+
+import com.franco.dev.domain.empresarial.Impresora;
+import com.franco.dev.graphql.empresarial.input.ImpresoraInput;
+import com.franco.dev.service.empresarial.ImpresoraService;
+import com.franco.dev.service.empresarial.SucursalService;
+import com.franco.dev.service.personas.UsuarioService;
+import graphql.kickstart.tools.GraphQLMutationResolver;
+import graphql.kickstart.tools.GraphQLQueryResolver;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import javax.print.PrintService;
+import javax.print.PrintServiceLookup;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Component
+public class ImpresoraGraphQL implements GraphQLQueryResolver, GraphQLMutationResolver {
+
+    @Autowired
+    private ImpresoraService service;
+
+    @Autowired
+    private UsuarioService usuarioService;
+
+    @Autowired
+    private SucursalService sucursalService;
+
+    public Optional<Impresora> impresora(Long id) {
+        return service.findById(id);
+    }
+
+    public List<Impresora> impresoras(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        return service.findAll(pageable);
+    }
+
+    public List<Impresora> impresorasPorSucursalId(Long id) {
+        return service.findBySucursalId(id);
+    }
+
+    public List<Impresora> impresorasActivas() {
+        return service.findActivas();
+    }
+
+    /**
+     * Colas de impresion visibles localmente en el host que atiende esta consulta
+     * (en Linux, las colas CUPS). Sirve para descubrir impresoras del servidor/filial
+     * al dar de alta, no solo las del desktop.
+     */
+    public List<String> impresorasDelSistema() {
+        List<String> nombres = new ArrayList<>();
+        for (PrintService p : PrintServiceLookup.lookupPrintServices(null, null)) {
+            nombres.add(p.getName());
+        }
+        return nombres;
+    }
+
+    public Impresora saveImpresora(ImpresoraInput input) {
+        ModelMapper m = new ModelMapper();
+        Impresora e = m.map(input, Impresora.class);
+        if (input.getSucursalId() != null) {
+            e.setSucursal(sucursalService.findById(input.getSucursalId()).orElse(null));
+        }
+        if (input.getUsuarioId() != null) {
+            e.setUsuario(usuarioService.findById(input.getUsuarioId()).orElse(null));
+        }
+        return service.save(e);
+    }
+
+    public Boolean deleteImpresora(Long id) {
+        return service.deleteById(id);
+    }
+
+    public Long countImpresora() {
+        return service.count();
+    }
+}

--- a/src/main/java/com/franco/dev/graphql/empresarial/input/ImpresoraInput.java
+++ b/src/main/java/com/franco/dev/graphql/empresarial/input/ImpresoraInput.java
@@ -1,0 +1,29 @@
+package com.franco.dev.graphql.empresarial.input;
+
+import com.franco.dev.domain.empresarial.enums.PerfilPapel;
+import com.franco.dev.domain.empresarial.enums.TipoConexion;
+import com.franco.dev.domain.empresarial.enums.TipoImpresora;
+import com.franco.dev.domain.empresarial.enums.UsoImpresora;
+import lombok.Data;
+
+@Data
+public class ImpresoraInput {
+    private Long id;
+    private String nombre;
+    private Boolean activo;
+    private Boolean esPredeterminada;
+    private Long sucursalId;
+    private TipoImpresora tipo;
+    private UsoImpresora uso;
+    private TipoConexion conexion;
+    private String colaCups;
+    private String ip;
+    private Integer puerto;
+    private PerfilPapel perfilPapel;
+    private Integer columnas;
+    private Integer anchoMm;
+    private Integer altoMm;
+    private String marca;
+    private String codepage;
+    private Long usuarioId;
+}

--- a/src/main/java/com/franco/dev/graphql/impresion/CupsAdminGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/impresion/CupsAdminGraphQL.java
@@ -1,0 +1,30 @@
+package com.franco.dev.graphql.impresion;
+
+import com.franco.dev.service.impresion.CupsAdminService;
+import com.franco.dev.service.impresion.DispositivoDetectado;
+import graphql.kickstart.tools.GraphQLMutationResolver;
+import graphql.kickstart.tools.GraphQLQueryResolver;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Detectar-para-instalar impresoras a nivel CUPS (Linux) en esta filial.
+ */
+@Component
+public class CupsAdminGraphQL implements GraphQLQueryResolver, GraphQLMutationResolver {
+
+    @Autowired
+    private CupsAdminService cupsAdminService;
+
+    /** Dispositivos conectables (USB/red/serial) aunque no tengan cola creada. */
+    public List<DispositivoDetectado> dispositivosParaInstalar() {
+        return cupsAdminService.detectarDispositivos();
+    }
+
+    /** Instala una cola CUPS (raw por defecto, ideal para termicas ESC/POS). */
+    public Boolean instalarImpresoraCups(String nombreCola, String uri, Boolean raw) {
+        return cupsAdminService.instalarImpresora(nombreCola, uri, raw == null || raw);
+    }
+}

--- a/src/main/java/com/franco/dev/graphql/impresion/PrintRouterGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/impresion/PrintRouterGraphQL.java
@@ -1,0 +1,54 @@
+package com.franco.dev.graphql.impresion;
+
+import com.franco.dev.domain.empresarial.Impresora;
+import com.franco.dev.service.empresarial.ImpresoraService;
+import com.franco.dev.service.impresion.PrintRouterService;
+import graphql.kickstart.tools.GraphQLMutationResolver;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Base64;
+
+/**
+ * Endpoints de impresion con routing (Fase 3).
+ */
+@Component
+public class PrintRouterGraphQL implements GraphQLMutationResolver {
+
+    @Autowired
+    private PrintRouterService printRouterService;
+
+    @Autowired
+    private ImpresoraService impresoraService;
+
+    /**
+     * HOJA del routing: ejecuta la impresion LOCAL en este host. Lo invoca el proxy
+     * desde otro host; no vuelve a rutear (evita loops).
+     */
+    public Boolean imprimirEnDestino(Long impresoraId, String payloadBase64) {
+        byte[] payload = Base64.getDecoder().decode(payloadBase64);
+        return printRouterService.imprimirLocalPorId(impresoraId, payload);
+    }
+
+    /**
+     * ENTRADA con routing: imprime local si la impresora es de este host o reenvia al
+     * host dueño.
+     */
+    public Boolean imprimirEnImpresora(Long impresoraId, String payloadBase64) {
+        byte[] payload = Base64.getDecoder().decode(payloadBase64);
+        return printRouterService.imprimir(impresoraId, payload);
+    }
+
+    /**
+     * Imprime un ticket de prueba (generado server-side, respetando el ancho de la
+     * impresora) y lo rutea al host correspondiente.
+     */
+    public Boolean imprimirPruebaEnImpresora(Long impresoraId) {
+        Impresora impresora = impresoraService.findById(impresoraId).orElse(null);
+        if (impresora == null) {
+            return false;
+        }
+        byte[] payload = printRouterService.generarTicketPrueba(impresora);
+        return printRouterService.imprimir(impresoraId, payload);
+    }
+}

--- a/src/main/java/com/franco/dev/repository/empresarial/ImpresoraRepository.java
+++ b/src/main/java/com/franco/dev/repository/empresarial/ImpresoraRepository.java
@@ -1,0 +1,17 @@
+package com.franco.dev.repository.empresarial;
+
+import com.franco.dev.domain.empresarial.Impresora;
+import com.franco.dev.repository.HelperRepository;
+
+import java.util.List;
+
+public interface ImpresoraRepository extends HelperRepository<Impresora, Long> {
+
+    default Class<Impresora> getEntityClass() {
+        return Impresora.class;
+    }
+
+    List<Impresora> findBySucursalId(Long id);
+
+    List<Impresora> findByActivoTrueOrderByIdAsc();
+}

--- a/src/main/java/com/franco/dev/service/empresarial/ImpresoraService.java
+++ b/src/main/java/com/franco/dev/service/empresarial/ImpresoraService.java
@@ -1,0 +1,29 @@
+package com.franco.dev.service.empresarial;
+
+import com.franco.dev.domain.empresarial.Impresora;
+import com.franco.dev.repository.empresarial.ImpresoraRepository;
+import com.franco.dev.service.CrudService;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@AllArgsConstructor
+public class ImpresoraService extends CrudService<Impresora, ImpresoraRepository, Long> {
+
+    private final ImpresoraRepository repository;
+
+    @Override
+    public ImpresoraRepository getRepository() {
+        return repository;
+    }
+
+    public List<Impresora> findBySucursalId(Long id) {
+        return repository.findBySucursalId(id);
+    }
+
+    public List<Impresora> findActivas() {
+        return repository.findByActivoTrueOrderByIdAsc();
+    }
+}

--- a/src/main/java/com/franco/dev/service/impresion/CupsAdminService.java
+++ b/src/main/java/com/franco/dev/service/impresion/CupsAdminService.java
@@ -1,0 +1,160 @@
+package com.franco.dev.service.impresion;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Administracion de impresoras a nivel de CUPS (Linux) via los comandos {@code lpinfo}
+ * y {@code lpadmin}. Permite:
+ * <ul>
+ *   <li>Detectar dispositivos conectables (USB/red/serial) aunque no tengan cola creada.</li>
+ *   <li>Instalar una cola nueva (RAW para termicas ESC/POS, o driverless para normales).</li>
+ * </ul>
+ *
+ * REQUISITO OPERATIVO: el proceso del backend debe tener permisos de administracion de
+ * CUPS. {@code lpinfo} suele requerir root; {@code lpadmin} requiere pertenecer al grupo
+ * de administracion de CUPS (SystemGroup en cupsd.conf). Si el backend corre como
+ * servicio systemd, agregar su usuario a ese grupo (o ejecutarlo con privilegios).
+ */
+@Service
+public class CupsAdminService {
+
+    private static final Logger log = LoggerFactory.getLogger(CupsAdminService.class);
+    private static final long TIMEOUT_SEG = 20;
+
+    /** Detecta dispositivos conectables via {@code lpinfo -v}. */
+    public List<DispositivoDetectado> detectarDispositivos() {
+        List<DispositivoDetectado> lista = new ArrayList<>();
+        try {
+            Process proceso = new ProcessBuilder("lpinfo", "-v")
+                    .redirectErrorStream(true)
+                    .start();
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(proceso.getInputStream(), StandardCharsets.UTF_8))) {
+                String linea;
+                while ((linea = reader.readLine()) != null) {
+                    DispositivoDetectado d = parsearLinea(linea);
+                    if (d != null) {
+                        lista.add(d);
+                    }
+                }
+            }
+            proceso.waitFor(TIMEOUT_SEG, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            log.error("[CUPS] Error ejecutando lpinfo -v: {}", e.getMessage(), e);
+        }
+        return lista;
+    }
+
+    /**
+     * Instala una cola CUPS nueva.
+     * @param nombreCola nombre deseado (se sanea a [A-Za-z0-9_-]).
+     * @param uri URI del dispositivo (de {@link #detectarDispositivos()}).
+     * @param raw true = cola RAW (termicas ESC/POS); false = driverless (everywhere).
+     * @return true si {@code lpadmin} termino con exito.
+     */
+    public boolean instalarImpresora(String nombreCola, String uri, boolean raw) {
+        String cola = sanearNombre(nombreCola);
+        if (cola.isEmpty() || uri == null || uri.isBlank()) {
+            log.warn("[CUPS] Parametros invalidos para instalar (cola='{}', uri='{}')", cola, uri);
+            return false;
+        }
+        List<String> cmd = new ArrayList<>(Arrays.asList(
+                "lpadmin", "-p", cola, "-E", "-v", uri, "-m", raw ? "raw" : "everywhere"));
+        return ejecutar(cmd);
+    }
+
+    // ---- helpers ----
+
+    private DispositivoDetectado parsearLinea(String lineaRaw) {
+        if (lineaRaw == null) {
+            return null;
+        }
+        String linea = lineaRaw.trim();
+        if (linea.isEmpty()) {
+            return null;
+        }
+        int sp = linea.indexOf(' ');
+        if (sp < 0) {
+            return null;
+        }
+        String clase = linea.substring(0, sp).trim();
+        String uri = linea.substring(sp + 1).trim();
+        // Ignoramos entradas sin dispositivo concreto (esquemas base).
+        if (uri.isEmpty() || !uri.contains("://") && !uri.contains(":")) {
+            return null;
+        }
+        DispositivoDetectado d = new DispositivoDetectado();
+        d.setClase(clase);
+        d.setUri(uri);
+        d.setNombre(nombreDesdeUri(uri));
+        d.setDescripcion(uri);
+        return d;
+    }
+
+    private String nombreDesdeUri(String uri) {
+        try {
+            if (uri.startsWith("usb://")) {
+                String resto = uri.substring("usb://".length());
+                int q = resto.indexOf('?');
+                if (q >= 0) {
+                    resto = resto.substring(0, q);
+                }
+                resto = resto.replace('/', ' ').trim();
+                return URLDecoder.decode(resto, StandardCharsets.UTF_8.name());
+            }
+            if (uri.startsWith("socket://") || uri.startsWith("ipp://")
+                    || uri.startsWith("ipps://") || uri.startsWith("lpd://")) {
+                return "Red " + uri.replaceAll("^\\w+://", "");
+            }
+            if (uri.startsWith("serial:")) {
+                return "Serial " + uri.substring("serial:".length());
+            }
+        } catch (Exception e) {
+            // fallback abajo
+        }
+        return uri;
+    }
+
+    private boolean ejecutar(List<String> cmd) {
+        try {
+            Process proceso = new ProcessBuilder(cmd).redirectErrorStream(true).start();
+            StringBuilder salida = new StringBuilder();
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(proceso.getInputStream(), StandardCharsets.UTF_8))) {
+                String linea;
+                while ((linea = reader.readLine()) != null) {
+                    salida.append(linea).append('\n');
+                }
+            }
+            boolean termino = proceso.waitFor(TIMEOUT_SEG, TimeUnit.SECONDS);
+            int codigo = termino ? proceso.exitValue() : -1;
+            if (codigo != 0) {
+                log.warn("[CUPS] Comando {} terminó con código {}: {}", cmd, codigo, salida.toString().trim());
+            } else {
+                log.info("[CUPS] Comando {} OK", cmd);
+            }
+            return codigo == 0;
+        } catch (Exception e) {
+            log.error("[CUPS] Error ejecutando {}: {}", cmd, e.getMessage(), e);
+            return false;
+        }
+    }
+
+    private String sanearNombre(String nombre) {
+        if (nombre == null) {
+            return "";
+        }
+        return nombre.trim().replaceAll("\\s+", "_").replaceAll("[^A-Za-z0-9_-]", "");
+    }
+}

--- a/src/main/java/com/franco/dev/service/impresion/DispositivoDetectado.java
+++ b/src/main/java/com/franco/dev/service/impresion/DispositivoDetectado.java
@@ -1,0 +1,23 @@
+package com.franco.dev.service.impresion;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Dispositivo de impresion detectado por CUPS (lpinfo -v) que todavia puede no tener
+ * una cola creada. Se usa para "detectar para instalar".
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class DispositivoDetectado {
+    /** Clase reportada por lpinfo: direct | network | serial | file. */
+    private String clase;
+    /** URI del dispositivo, ej: usb://EPSON/L575%20Series?serial=... o socket://192.168.0.50 */
+    private String uri;
+    /** Nombre legible derivado de la URI. */
+    private String nombre;
+    /** Descripcion (la URI completa). */
+    private String descripcion;
+}

--- a/src/main/java/com/franco/dev/service/impresion/ImpresionService.java
+++ b/src/main/java/com/franco/dev/service/impresion/ImpresionService.java
@@ -141,10 +141,21 @@ public class ImpresionService {
 
     public void printReport(JasperPrint jasperPrint, String filename, String printerName, Boolean silent)
             throws GraphQLException {
+        printReport(jasperPrint, filename, printerName, silent, MediaSizeName.ISO_A4);
+    }
+
+    /**
+     * Overload que permite elegir el tamanho de hoja (A4, Carta, etc.) segun el perfil
+     * de papel de la impresora, en vez de fijar siempre A4.
+     * @see com.franco.dev.utilitarios.print.PerfilPapelHelper#mediaSize
+     */
+    public void printReport(JasperPrint jasperPrint, String filename, String printerName, Boolean silent,
+                            MediaSizeName mediaSize)
+            throws GraphQLException {
         if (silent == null)
             silent = false;
         PrintRequestAttributeSet printRequestAttributeSet = new HashPrintRequestAttributeSet();
-        printRequestAttributeSet.add(MediaSizeName.ISO_A4);
+        printRequestAttributeSet.add(mediaSize != null ? mediaSize : MediaSizeName.ISO_A4);
         if (jasperPrint.getOrientationValue() == net.sf.jasperreports.engine.type.OrientationEnum.LANDSCAPE) {
             printRequestAttributeSet.add(OrientationRequested.LANDSCAPE);
         } else {

--- a/src/main/java/com/franco/dev/service/impresion/ImpresoraPrintService.java
+++ b/src/main/java/com/franco/dev/service/impresion/ImpresoraPrintService.java
@@ -1,0 +1,65 @@
+package com.franco.dev.service.impresion;
+
+import com.franco.dev.domain.empresarial.Impresora;
+import com.franco.dev.domain.empresarial.enums.TipoConexion;
+import com.franco.dev.utilitarios.print.PerfilPapelHelper;
+import com.franco.dev.utilitarios.print.TicketFormato;
+import com.franco.dev.utilitarios.print.escpos.EscPos;
+import com.franco.dev.utilitarios.print.output.PrinterOutputStream;
+import com.franco.dev.utilitarios.print.output.TcpIpOutputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import javax.print.PrintService;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Abre el destino de impresion correcto a partir de una {@link Impresora} del registro:
+ * <ul>
+ *   <li>CUPS / USB / BLUETOOTH: cola local del sistema via {@link PrinterOutputStream}.</li>
+ *   <li>RED / inalambrica: socket a IP:puerto via {@link TcpIpOutputStream} (RAW/JetDirect).</li>
+ * </ul>
+ * Devuelve un {@link EscPos} listo para escribir y el {@link TicketFormato} con las
+ * columnas correspondientes al perfil de papel.
+ *
+ * NOTA: este servicio es la capa de ejecucion local. El ruteo filial<->central (decidir
+ * si imprime local o reenvia a otro host segun {@code impresora.sucursal}) es Fase 3.
+ */
+@Service
+public class ImpresoraPrintService {
+
+    private static final Logger log = LoggerFactory.getLogger(ImpresoraPrintService.class);
+    private static final int PUERTO_RAW_POR_DEFECTO = 9100;
+
+    /** Abre el OutputStream crudo hacia la impresora (CUPS o TCP/IP). */
+    public OutputStream abrirOutput(Impresora impresora) throws IOException {
+        if (impresora == null) {
+            throw new IllegalArgumentException("Impresora nula");
+        }
+        if (impresora.getConexion() == TipoConexion.RED) {
+            int puerto = impresora.getPuerto() != null ? impresora.getPuerto() : PUERTO_RAW_POR_DEFECTO;
+            log.info("Imprimiendo por RED a {}:{}", impresora.getIp(), puerto);
+            return new TcpIpOutputStream(impresora.getIp(), puerto);
+        }
+        // CUPS / USB / BLUETOOTH: cola local por nombre.
+        PrintService ps = PrinterOutputStream.getPrintServiceByName(impresora.getColaCups());
+        log.info("Imprimiendo por cola local '{}'", impresora.getColaCups());
+        return new PrinterOutputStream(ps);
+    }
+
+    /** Abre un EscPos listo para escribir sobre el destino de la impresora. */
+    public EscPos abrirEscPos(Impresora impresora) throws IOException {
+        return new EscPos(abrirOutput(impresora));
+    }
+
+    /** Formato de columnas de la impresora (campo {@code columnas} o el default del perfil). */
+    public TicketFormato formato(Impresora impresora) {
+        Integer columnas = impresora != null ? impresora.getColumnas() : null;
+        if (columnas == null && impresora != null) {
+            columnas = PerfilPapelHelper.columnas(impresora.getPerfilPapel());
+        }
+        return new TicketFormato(columnas);
+    }
+}

--- a/src/main/java/com/franco/dev/service/impresion/PrintRouterService.java
+++ b/src/main/java/com/franco/dev/service/impresion/PrintRouterService.java
@@ -1,0 +1,174 @@
+package com.franco.dev.service.impresion;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.franco.dev.domain.empresarial.Impresora;
+import com.franco.dev.domain.empresarial.Sucursal;
+import com.franco.dev.service.empresarial.ImpresoraService;
+import com.franco.dev.utilitarios.print.TicketFormato;
+import com.franco.dev.utilitarios.print.escpos.EscPos;
+import com.franco.dev.utilitarios.print.escpos.EscPosConst;
+import com.franco.dev.utilitarios.print.escpos.Style;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Router de impresion (Fase 3). Decide si una impresion se ejecuta localmente en este
+ * host o se reenvia por GraphQL al host donde esta conectada la impresora.
+ *
+ * Regla: cada {@link Impresora} pertenece a una sucursal ({@code impresora.sucursal}).
+ * Si esa sucursal es la de este host ({@code sucursalId} de application.properties) se
+ * imprime local; si no, se hace proxy a la filial dueña (puerto 8082).
+ *
+ * En el servidor central ({@code sucursalId=0}) el proxy solo aplica hacia filiales.
+ */
+@Service
+public class PrintRouterService {
+
+    private static final Logger log = LoggerFactory.getLogger(PrintRouterService.class);
+    private static final int FILIAL_PORT = 8082;
+
+    @Value("${sucursalId:0}")
+    private Long miSucursalId;
+
+    @Autowired
+    private ImpresoraService impresoraService;
+
+    @Autowired
+    private ImpresoraPrintService impresoraPrintService;
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    /**
+     * Punto de entrada con routing: imprime local si la impresora es de este host, o
+     * reenvia al host dueño.
+     */
+    public Boolean imprimir(Long impresoraId, byte[] payload) {
+        Impresora impresora = impresoraService.findById(impresoraId).orElse(null);
+        if (impresora == null) {
+            log.warn("[PRINT] Impresora id={} no encontrada", impresoraId);
+            return false;
+        }
+        Long ownerId = impresora.getSucursal() != null ? impresora.getSucursal().getId() : miSucursalId;
+        if (ownerId.equals(miSucursalId)) {
+            return imprimirLocal(impresora, payload);
+        }
+        return proxyImprimir(impresora.getSucursal(), impresoraId, payload);
+    }
+
+    /**
+     * Ejecuta la impresion LOCAL en este host (hoja del routing; no reenvia).
+     */
+    public Boolean imprimirLocal(Impresora impresora, byte[] payload) {
+        try (OutputStream out = impresoraPrintService.abrirOutput(impresora)) {
+            out.write(payload);
+            out.flush();
+            return true;
+        } catch (Exception e) {
+            log.error("[PRINT] Error imprimiendo local en impresora id={}: {}",
+                    impresora.getId(), e.getMessage(), e);
+            return false;
+        }
+    }
+
+    public Boolean imprimirLocalPorId(Long impresoraId, byte[] payload) {
+        Impresora impresora = impresoraService.findById(impresoraId).orElse(null);
+        if (impresora == null) {
+            log.warn("[PRINT] Impresora id={} no encontrada (local)", impresoraId);
+            return false;
+        }
+        return imprimirLocal(impresora, payload);
+    }
+
+    /**
+     * Genera un ticket ESC/POS de prueba respetando el ancho (columnas) de la impresora.
+     */
+    public byte[] generarTicketPrueba(Impresora impresora) {
+        TicketFormato f = impresoraPrintService.formato(impresora);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try {
+            EscPos escpos = new EscPos(baos);
+            Style center = new Style().setJustification(EscPosConst.Justification.Center);
+            escpos.writeLF(center.setBold(true), "PRUEBA DE IMPRESION");
+            escpos.writeLF(f.separador());
+            escpos.writeLF("Impresora: " + safe(impresora.getNombre()));
+            if (impresora.getSucursal() != null) {
+                escpos.writeLF("Sucursal: " + safe(impresora.getSucursal().getNombre()));
+            }
+            escpos.writeLF("Conexion: " + impresora.getConexion());
+            escpos.writeLF(f.izqDer("Columnas:", String.valueOf(f.getColumnas())));
+            escpos.writeLF(f.izqDer("Perfil:", String.valueOf(impresora.getPerfilPapel())));
+            escpos.writeLF(f.separador());
+            escpos.feed(3);
+            escpos.cut(EscPos.CutMode.FULL);
+        } catch (Exception e) {
+            log.error("[PRINT] Error generando ticket de prueba: {}", e.getMessage(), e);
+        }
+        return baos.toByteArray();
+    }
+
+    // ---- proxy hacia el host dueño ----
+
+    private Boolean proxyImprimir(Sucursal owner, Long impresoraId, byte[] payload) {
+        if (owner == null || owner.getIp() == null || owner.getIp().isBlank()) {
+            log.warn("[PRINT] Sucursal dueña sin IP para impresora id={}", impresoraId);
+            return false;
+        }
+        String url = "http://" + owner.getIp() + ":" + FILIAL_PORT + "/graphql";
+        String payloadBase64 = Base64.getEncoder().encodeToString(payload);
+        String query = "mutation($id: ID!, $payload: String!) { "
+                + "imprimirEnDestino(impresoraId: $id, payloadBase64: $payload) }";
+        Map<String, Object> variables = new HashMap<>();
+        variables.put("id", impresoraId);
+        variables.put("payload", payloadBase64);
+        try {
+            Map<String, Object> body = new HashMap<>();
+            body.put("query", query);
+            body.put("variables", variables);
+            HttpEntity<String> request = new HttpEntity<>(objectMapper.writeValueAsString(body), buildAuthHeaders());
+            restTemplate.postForEntity(url, request, Map.class);
+            log.info("[PRINT] Reenviado a {} (impresora id={})", url, impresoraId);
+            return true;
+        } catch (Exception e) {
+            log.error("[PRINT] Error reenviando impresion a {}: {}", url, e.getMessage(), e);
+            return false;
+        }
+    }
+
+    private HttpHeaders buildAuthHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        if (attributes != null) {
+            HttpServletRequest currentRequest = attributes.getRequest();
+            String authHeader = currentRequest.getHeader("Authorization");
+            if (authHeader != null) {
+                headers.set("Authorization", authHeader);
+            }
+        }
+        return headers;
+    }
+
+    private static String safe(String s) {
+        return s == null ? "" : s;
+    }
+}

--- a/src/main/java/com/franco/dev/utilitarios/print/PerfilPapelHelper.java
+++ b/src/main/java/com/franco/dev/utilitarios/print/PerfilPapelHelper.java
@@ -1,0 +1,51 @@
+package com.franco.dev.utilitarios.print;
+
+import com.franco.dev.domain.empresarial.enums.PerfilPapel;
+
+import javax.print.attribute.standard.MediaSizeName;
+
+/**
+ * Mapea el perfil de papel de una impresora a: cantidad de columnas de caracteres
+ * (para termicas ESC/POS) y tamanho de media (para impresoras normales via Jasper).
+ *
+ * Las columnas son los defaults tipicos en fuente A; se pueden sobreescribir por
+ * impresora con el campo {@code columnas}.
+ */
+public final class PerfilPapelHelper {
+
+    private PerfilPapelHelper() {
+    }
+
+    /** Columnas de caracteres por defecto segun el perfil (fuente A). */
+    public static int columnas(PerfilPapel perfil) {
+        if (perfil == null) {
+            return TicketFormato.COLUMNAS_POR_DEFECTO;
+        }
+        switch (perfil) {
+            case MM_48:
+                return 32;
+            case MM_58:
+                return 32;
+            case MM_72:
+                return 42;
+            case MM_80:
+                return 48;
+            default:
+                return TicketFormato.COLUMNAS_POR_DEFECTO;
+        }
+    }
+
+    /** Tamanho de media (hoja) para impresoras normales. Default A4. */
+    public static MediaSizeName mediaSize(PerfilPapel perfil) {
+        if (perfil == null) {
+            return MediaSizeName.ISO_A4;
+        }
+        switch (perfil) {
+            case CARTA:
+                return MediaSizeName.NA_LETTER;
+            case A4:
+            default:
+                return MediaSizeName.ISO_A4;
+        }
+    }
+}

--- a/src/main/java/com/franco/dev/utilitarios/print/TicketFormato.java
+++ b/src/main/java/com/franco/dev/utilitarios/print/TicketFormato.java
@@ -1,0 +1,105 @@
+package com.franco.dev.utilitarios.print;
+
+/**
+ * Helper de formateo de tickets ESC/POS parametrizado por cantidad de columnas
+ * (caracteres por linea). Reemplaza el ancho hardcodeado de 32 columnas por un valor
+ * derivado del perfil de papel de la impresora (48/58/72/80 mm...).
+ *
+ * Uso tipico:
+ * <pre>
+ *   TicketFormato f = new TicketFormato(48);   // 80mm
+ *   escpos.writeLF(f.separador());
+ *   escpos.writeLF(f.izqDer("Total:", "150.000"));
+ * </pre>
+ */
+public class TicketFormato {
+
+    public static final int COLUMNAS_POR_DEFECTO = 32;
+
+    private final int columnas;
+
+    public TicketFormato(Integer columnas) {
+        this.columnas = (columnas == null || columnas <= 0) ? COLUMNAS_POR_DEFECTO : columnas;
+    }
+
+    public int getColumnas() {
+        return columnas;
+    }
+
+    /** Linea separadora de guiones del ancho completo. */
+    public String separador() {
+        return repetir('-', columnas);
+    }
+
+    public String separador(char caracter) {
+        return repetir(caracter, columnas);
+    }
+
+    /** Trunca el texto al ancho de columnas. */
+    public String truncar(String texto) {
+        return truncar(texto, columnas);
+    }
+
+    public String truncar(String texto, int max) {
+        if (texto == null) {
+            return "";
+        }
+        return texto.length() > max ? texto.substring(0, max) : texto;
+    }
+
+    /** Rellena con espacios a la derecha hasta completar el ancho. */
+    public String padDerecha(String texto) {
+        return padDerecha(texto, columnas);
+    }
+
+    public String padDerecha(String texto, int ancho) {
+        String t = truncar(texto == null ? "" : texto, ancho);
+        StringBuilder sb = new StringBuilder(t);
+        while (sb.length() < ancho) {
+            sb.append(' ');
+        }
+        return sb.toString();
+    }
+
+    /** Rellena con espacios a la izquierda hasta completar el ancho. */
+    public String padIzquierda(String texto, int ancho) {
+        String t = truncar(texto == null ? "" : texto, ancho);
+        StringBuilder sb = new StringBuilder();
+        while (sb.length() < ancho - t.length()) {
+            sb.append(' ');
+        }
+        sb.append(t);
+        return sb.toString();
+    }
+
+    /**
+     * Dos columnas: {@code izquierda} alineada a la izquierda y {@code derecha} alineada
+     * a la derecha, ocupando en total el ancho de columnas. Reemplaza los bucles de
+     * padding manual de montos.
+     */
+    public String izqDer(String izquierda, String derecha) {
+        String izq = izquierda == null ? "" : izquierda;
+        String der = derecha == null ? "" : derecha;
+        int espacio = columnas - izq.length() - der.length();
+        if (espacio < 1) {
+            // No entra: truncamos la izquierda para que la derecha quede completa.
+            int maxIzq = Math.max(0, columnas - der.length() - 1);
+            izq = truncar(izq, maxIzq);
+            espacio = Math.max(1, columnas - izq.length() - der.length());
+        }
+        StringBuilder sb = new StringBuilder(izq);
+        for (int i = 0; i < espacio; i++) {
+            sb.append(' ');
+        }
+        sb.append(der);
+        return sb.toString();
+    }
+
+    private static String repetir(char caracter, int cantidad) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < cantidad; i++) {
+            sb.append(caracter);
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,7 +9,7 @@
 #spring.devtools.livereload.enabled=true
 #spring.devtools.restart.enabled=false
 #spring.devtools.restart.exclude=static/**,public/**,templates/**,META-INF/**,resources/**
-spring.profiles.active=user-dev
+
 # ----------------------------------------------------------------------------
 # DataSource Configuration
 # ----------------------------------------------------------------------------

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,7 +9,7 @@
 #spring.devtools.livereload.enabled=true
 #spring.devtools.restart.enabled=false
 #spring.devtools.restart.exclude=static/**,public/**,templates/**,META-INF/**,resources/**
-
+spring.profiles.active=user-dev
 # ----------------------------------------------------------------------------
 # DataSource Configuration
 # ----------------------------------------------------------------------------

--- a/src/main/resources/db/migration/V142.3__crear_tabla_impresora.sql
+++ b/src/main/resources/db/migration/V142.3__crear_tabla_impresora.sql
@@ -1,0 +1,59 @@
+-- Registro unico de impresoras (termicas y normales) administrable desde la app.
+-- Reemplaza la config fragmentada (config-backup.json del desktop, argumentos GraphQL,
+-- hardcodes y columnas muertas de punto_de_venta).
+-- Origen de escritura: servidor central (administrativo). Se replica MAIN->ALL a las
+-- filiales via central_pub, de modo que cada host ve el registro completo (necesario
+-- para el routing: la impresora "sabe" en que sucursal/host esta conectada).
+
+CREATE TABLE empresarial.impresora (
+    id SERIAL PRIMARY KEY,
+    nombre VARCHAR(120) NOT NULL,
+    activo BOOLEAN DEFAULT TRUE,
+    es_predeterminada BOOLEAN DEFAULT FALSE,
+    -- Host donde esta conectada fisicamente la impresora (routing filial <-> central)
+    sucursal_id BIGINT,
+    -- TERMICA | NORMAL | ETIQUETA
+    tipo VARCHAR(20) NOT NULL,
+    -- TICKET | FACTURA | REPORTE | ETIQUETA | COMANDA
+    uso VARCHAR(20),
+    -- CUPS | USB | RED | BLUETOOTH
+    conexion VARCHAR(20) NOT NULL,
+    -- Nombre de cola CUPS (conexion CUPS/USB/BLUETOOTH)
+    cola_cups VARCHAR(255),
+    -- Direccion IP y puerto (conexion RED / inalambrica), puerto RAW/JetDirect por defecto 9100
+    ip VARCHAR(60),
+    puerto INTEGER,
+    -- MM_48 | MM_58 | MM_72 | MM_80 | A4 | CARTA | CUSTOM
+    perfil_papel VARCHAR(20),
+    -- Columnas de caracteres para termicas (derivado del perfil, editable)
+    columnas INTEGER,
+    -- Ancho/alto en mm para hoja/custom (impresoras normales)
+    ancho_mm INTEGER,
+    alto_mm INTEGER,
+    -- EPSON | STAR | BEMATECH | HP | ...
+    marca VARCHAR(60),
+    -- Code-page ESC/POS
+    codepage VARCHAR(40),
+    creado_en TIMESTAMP,
+    usuario_id BIGINT,
+    CONSTRAINT fk_impresora_sucursal FOREIGN KEY (sucursal_id) REFERENCES empresarial.sucursal(id),
+    CONSTRAINT fk_impresora_usuario FOREIGN KEY (usuario_id) REFERENCES personas.usuario(id)
+);
+
+CREATE INDEX idx_impresora_sucursal_id ON empresarial.impresora(sucursal_id);
+
+-- Sumar la tabla a la publicacion central_pub (direccion MAIN_TO_ALL, sin filtro por
+-- sucursal_id) para que TODOS los hosts reciban el registro completo de impresoras.
+-- Patron identico a V119__add_replication_test_to_publications.sql.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_publication WHERE pubname = 'central_pub') THEN
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_publication_tables
+            WHERE pubname = 'central_pub' AND tablename = 'impresora'
+        ) THEN
+            EXECUTE 'ALTER PUBLICATION central_pub ADD TABLE empresarial.impresora';
+            RAISE NOTICE 'Added empresarial.impresora to central_pub';
+        END IF;
+    END IF;
+END $$;

--- a/src/main/resources/db/migration/V143.3__crear_tabla_impresora.sql
+++ b/src/main/resources/db/migration/V143.3__crear_tabla_impresora.sql
@@ -5,7 +5,7 @@
 -- filiales via central_pub, de modo que cada host ve el registro completo (necesario
 -- para el routing: la impresora "sabe" en que sucursal/host esta conectada).
 
-CREATE TABLE empresarial.impresora (
+CREATE TABLE IF NOT EXISTS empresarial.impresora (
     id SERIAL PRIMARY KEY,
     nombre VARCHAR(120) NOT NULL,
     activo BOOLEAN DEFAULT TRUE,
@@ -40,7 +40,7 @@ CREATE TABLE empresarial.impresora (
     CONSTRAINT fk_impresora_usuario FOREIGN KEY (usuario_id) REFERENCES personas.usuario(id)
 );
 
-CREATE INDEX idx_impresora_sucursal_id ON empresarial.impresora(sucursal_id);
+CREATE INDEX IF NOT EXISTS idx_impresora_sucursal_id ON empresarial.impresora(sucursal_id);
 
 -- Sumar la tabla a la publicacion central_pub (direccion MAIN_TO_ALL, sin filtro por
 -- sucursal_id) para que TODOS los hosts reciban el registro completo de impresoras.

--- a/src/main/resources/graphql/empresarial/cups-admin.graphqls
+++ b/src/main/resources/graphql/empresarial/cups-admin.graphqls
@@ -1,0 +1,15 @@
+# Detectar-para-instalar impresoras a nivel CUPS (Linux).
+type DispositivoDetectado {
+    clase: String
+    uri: String
+    nombre: String
+    descripcion: String
+}
+
+extend type Query {
+    dispositivosParaInstalar: [DispositivoDetectado]
+}
+
+extend type Mutation {
+    instalarImpresoraCups(nombreCola: String!, uri: String!, raw: Boolean): Boolean
+}

--- a/src/main/resources/graphql/empresarial/impresora.graphqls
+++ b/src/main/resources/graphql/empresarial/impresora.graphqls
@@ -1,0 +1,87 @@
+enum TipoImpresora {
+    TERMICA
+    NORMAL
+    ETIQUETA
+}
+
+enum UsoImpresora {
+    TICKET
+    FACTURA
+    REPORTE
+    ETIQUETA
+    COMANDA
+}
+
+enum TipoConexion {
+    CUPS
+    USB
+    RED
+    BLUETOOTH
+}
+
+enum PerfilPapel {
+    MM_48
+    MM_58
+    MM_72
+    MM_80
+    A4
+    CARTA
+    CUSTOM
+}
+
+type Impresora {
+    id: ID!
+    nombre: String
+    activo: Boolean
+    esPredeterminada: Boolean
+    sucursal: Sucursal
+    tipo: TipoImpresora
+    uso: UsoImpresora
+    conexion: TipoConexion
+    colaCups: String
+    ip: String
+    puerto: Int
+    perfilPapel: PerfilPapel
+    columnas: Int
+    anchoMm: Int
+    altoMm: Int
+    marca: String
+    codepage: String
+    creadoEn: Date
+    usuario: Usuario
+}
+
+input ImpresoraInput {
+    id: ID
+    nombre: String
+    activo: Boolean
+    esPredeterminada: Boolean
+    sucursalId: Int
+    tipo: TipoImpresora
+    uso: UsoImpresora
+    conexion: TipoConexion
+    colaCups: String
+    ip: String
+    puerto: Int
+    perfilPapel: PerfilPapel
+    columnas: Int
+    anchoMm: Int
+    altoMm: Int
+    marca: String
+    codepage: String
+    usuarioId: Int
+}
+
+extend type Query {
+    impresora(id: ID!): Impresora
+    impresoras(page: Int, size: Int = 20): [Impresora]!
+    impresorasPorSucursalId(id: Int): [Impresora]
+    impresorasActivas: [Impresora]
+    impresorasDelSistema: [String]
+    countImpresora: Int
+}
+
+extend type Mutation {
+    saveImpresora(impresora: ImpresoraInput!): Impresora!
+    deleteImpresora(id: ID!): Boolean!
+}

--- a/src/main/resources/graphql/empresarial/print-router.graphqls
+++ b/src/main/resources/graphql/empresarial/print-router.graphqls
@@ -1,0 +1,9 @@
+# Impresion con routing entre hosts (Fase 3).
+extend type Mutation {
+    # Hoja: ejecuta la impresion local en el host que recibe (usado por el proxy).
+    imprimirEnDestino(impresoraId: ID!, payloadBase64: String!): Boolean
+    # Entrada con routing: imprime local o reenvia al host dueño de la impresora.
+    imprimirEnImpresora(impresoraId: ID!, payloadBase64: String!): Boolean
+    # Ticket de prueba generado server-side y ruteado.
+    imprimirPruebaEnImpresora(impresoraId: ID!): Boolean
+}


### PR DESCRIPTION
## Qué resuelve

Implementa el **módulo de impresoras** en el backend central: registro único de impresoras en BD (reemplaza la config fragmentada), motor de impresión parametrizable por ancho, y routing de impresión entre hosts (central ↔ filial).

### Incluye
- **Modelo/JPA**: `Impresora` + enums (`TipoImpresora`, `UsoImpresora`, `TipoConexion`, `PerfilPapel`), `ImpresoraRepository`, `ImpresoraService`.
- **GraphQL**: CRUD (`impresora.graphqls` + `ImpresoraGraphQL`/`ImpresoraInput`), descubrimiento de colas del host (`impresorasDelSistema`).
- **Motor parametrizable**: `TicketFormato` (formateo por columnas) y `PerfilPapelHelper` (perfil → columnas / MediaSize), `ImpresoraPrintService` (CUPS/RED-IP).
- **Routing** (`PrintRouterService` + `print-router.graphqls`): imprime local si la impresora es de este host, o hace proxy GraphQL al host dueño. Ticket de prueba server-side.
- **CUPS admin** (`CupsAdminService` + `cups-admin.graphqls`): detectar dispositivos (`lpinfo -v`) e instalar colas (`lpadmin`).

## Cómo probarlo
1. `./mvnw clean verify` (o `-DskipFlyway=true` en CI).
2. Levantar el backend; en GraphiQL: `saveImpresora`, `impresoras`, `imprimirPruebaEnImpresora(impresoraId)`.
3. Desde el desktop: módulo Impresoras → alta + botón "Probar".

## Impacto en DB
- Migración **`V143.3__crear_tabla_impresora.sql`**: solo `CREATE TABLE`/índice (idempotente con `IF NOT EXISTS`) + `ALTER PUBLICATION central_pub ADD TABLE` para replicación. **Retrocompatible**, sin `DROP`/`RENAME`.
- La tabla se replica a todas las filiales (visibilidad global para el routing).

## Riesgo / rollback
- **Bajo–medio**: cambios aditivos (endpoints/entidad nuevos, no se elimina nada). `ImpresionService` solo suma un overload (default A4 preservado).
- Rollback de JAR no revierte la migración, pero al ser `CREATE`/idempotente no rompe la versión anterior.
- **Ops**: el `ALTER PUBLICATION` debe coordinarse con el líder técnico; el backend necesita permisos de CUPS para `lpinfo`/`lpadmin`.

## Notas
- El override local `spring.profiles.active=user-dev` en `application.properties` queda **fuera** del PR (cambio local, no commiteado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
