### PR TITLE
feat(financiero): registrar terminal_pos en tabla de replicacion via migracion

### DIFF
--- a/src/main/resources/db/migration/V142.1__registrar_replicacion_terminal_pos.sql
+++ b/src/main/resources/db/migration/V142.1__registrar_replicacion_terminal_pos.sql
@@ -1,0 +1,5 @@
+INSERT INTO configuraciones.replication_table
+    (table_name, direction, description, enabled, replicate_central_to_branch_with_filter, creado_en)
+VALUES
+    ('financiero.terminal_pos', 'MAIN_TO_ALL', 'Terminal Pos', true, false, NOW())
+ON CONFLICT (table_name) DO NOTHING;


### PR DESCRIPTION
## Que resuelve

Registra `financiero.terminal_pos` en `configuraciones.replication_table` (direccion `MAIN_TO_ALL`) mediante una migracion Flyway, en lugar de depender de que un administrador la de de alta manualmente desde el dialogo de UI de replicacion despues del deploy.

Esto surge del trabajo de agregar la tabla `terminal_pos` (compartida entre central y filial via replicacion logica): sin este registro, aunque el schema/entidad este correcto en ambos lados, la tabla nunca se replica porque el servicio de replicacion no sabe que debe incluirla en la publicacion. Hacerlo via migracion asegura que el registro quede activo en todos los ambientes (dev/alpha/beta/prod) apenas se despliega el codigo, sin pasos manuales adicionales ni riesgo de que se olvide en algun ambiente.

## Como probarlo

1. Levantar el backend central en local con la migracion aplicada.
2. Verificar en `configuraciones.replication_table` que existe una fila con `table_name = 'financiero.terminal_pos'`, `direction = MAIN_TO_ALL`, `enabled = true`, `description = 'Terminal Pos'`.
3. Confirmar que la migracion es idempotente: si la fila ya existia previamente (por ejemplo, creada a mano desde el dialogo de UI antes de este PR), la migracion no falla ni duplica el registro (`ON CONFLICT (table_name) DO NOTHING`). Probado localmente contra una DB que ya tenia la fila registrada manualmente: la migracion corrio sin error y dejo el registro existente intacto.
4. Confirmar que el proceso de sync de publicaciones (`replication.sync.enabled`) toma la tabla y la incluye en la publicacion hacia las filiales.

## Impacto DB

Migracion `V142.1__registrar_replicacion_terminal_pos.sql`: un `INSERT` sobre `configuraciones.replication_table`, con `ON CONFLICT (table_name) DO NOTHING` para ser segura ante reejecucion o filas preexistentes. No modifica estructura de tablas, no requiere backfill de otras tablas.

## Riesgo

Bajo. Es un INSERT aditivo sobre una tabla de configuracion, protegido contra duplicados. El efecto practico es habilitar la replicacion de `terminal_pos` hacia las filiales automaticamente al desplegar, en vez de requerir un paso manual.