### PR TITLE
feat(impresoras): paginacion en listado + registrar impresora en replication_table

### DIFF
--- a/src/main/java/com/franco/dev/graphql/empresarial/ImpresoraGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/empresarial/ImpresoraGraphQL.java
@@ -9,9 +9,13 @@ import graphql.kickstart.tools.GraphQLMutationResolver;
 import graphql.kickstart.tools.GraphQLQueryResolver;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
+
+import com.franco.dev.config.multitenant.CustomPage;
+import com.franco.dev.config.multitenant.CustomPageImpl;
 
 import javax.print.PrintService;
 import javax.print.PrintServiceLookup;
@@ -42,6 +46,14 @@ public class ImpresoraGraphQL implements GraphQLQueryResolver, GraphQLMutationRe
 
     public List<Impresora> impresorasPorSucursalId(Long id) {
         return service.findBySucursalId(id);
+    }
+
+    public CustomPage<Impresora> impresoraSearchPage(String texto, Integer page, Integer size) {
+        int p = (page == null || page < 0) ? 0 : page;
+        int s = (size == null || size <= 0) ? 10 : size;
+        Pageable pageable = PageRequest.of(p, s);
+        Page<Impresora> pageResult = service.buscarConPagina(texto, p, s);
+        return new CustomPageImpl<>(pageResult.getContent(), pageable, pageResult.getTotalElements(), null);
     }
 
     public List<Impresora> impresorasActivas() {

--- a/src/main/java/com/franco/dev/repository/empresarial/ImpresoraRepository.java
+++ b/src/main/java/com/franco/dev/repository/empresarial/ImpresoraRepository.java
@@ -5,6 +5,10 @@ import com.franco.dev.repository.HelperRepository;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+
 public interface ImpresoraRepository extends HelperRepository<Impresora, Long> {
 
     default Class<Impresora> getEntityClass() {
@@ -12,6 +16,13 @@ public interface ImpresoraRepository extends HelperRepository<Impresora, Long> {
     }
 
     List<Impresora> findBySucursalId(Long id);
+
+    @Query("select i from Impresora i left join i.sucursal s where " +
+            "(CAST(i.id as text) like concat('%', ?1, '%') or " +
+            "UPPER(i.nombre) like UPPER(concat('%', ?1, '%')) or " +
+            "UPPER(s.nombre) like UPPER(concat('%', ?1, '%'))) " +
+            "order by i.id desc")
+    Page<Impresora> findByAllWithPage(String texto, Pageable pageable);
 
     List<Impresora> findByActivoTrueOrderByIdAsc();
 }

--- a/src/main/java/com/franco/dev/service/empresarial/ImpresoraService.java
+++ b/src/main/java/com/franco/dev/service/empresarial/ImpresoraService.java
@@ -4,6 +4,8 @@ import com.franco.dev.domain.empresarial.Impresora;
 import com.franco.dev.repository.empresarial.ImpresoraRepository;
 import com.franco.dev.service.CrudService;
 import lombok.AllArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -21,6 +23,12 @@ public class ImpresoraService extends CrudService<Impresora, ImpresoraRepository
 
     public List<Impresora> findBySucursalId(Long id) {
         return repository.findBySucursalId(id);
+    }
+
+    public Page<Impresora> buscarConPagina(String texto, Integer page, Integer size) {
+        texto = texto == null ? "" : texto;
+        Pageable pageable = org.springframework.data.domain.PageRequest.of(page, size);
+        return repository.findByAllWithPage(texto, pageable);
     }
 
     public List<Impresora> findActivas() {

--- a/src/main/resources/db/migration/V144.3__registrar_replicacion_impresora.sql
+++ b/src/main/resources/db/migration/V144.3__registrar_replicacion_impresora.sql
@@ -1,0 +1,22 @@
+-- Registrar empresarial.impresora en configuraciones.replication_table para que el scheduler de
+-- replicacion la gestione automaticamente. Sin esto, la tabla se creo (V143.3) y se agrego a mano
+-- a central_pub, pero al NO estar registrada en replication_table el scheduler
+-- (ReplicationPublicationSyncScheduler -> LogicalReplicationService.syncPublicationsWithReplicationTable)
+-- no la considera y por lo tanto no refresca las suscripciones de las filiales via JDBC.
+-- Resultado: las impresoras creadas en el central no bajan a las sucursales (ej. km2).
+--
+-- Direccion MAIN_TO_ALL (unidireccional central -> todas las filiales): el registro de impresoras
+-- se administra y escribe SOLO en el servidor central (la filial no tiene mutation saveImpresora ni
+-- generador de id; el desktop guarda siempre con clientName="servidor") y se replica completo a cada
+-- filial, que lo necesita para el routing de impresion (la impresora "sabe" en que sucursal esta).
+-- Patron identico a V142.1__registrar_replicacion_terminal_pos.sql.
+--
+-- Nota ops: REFRESH PUBLICATION usa copy_data = false, asi que las filas de impresora YA existentes
+-- en el central no se copian retroactivamente; solo se replican los cambios (INSERT/UPDATE/DELETE)
+-- posteriores al refresh. Para bajar impresoras preexistentes a una filial, re-guardar el registro
+-- en el central (dispara un UPDATE que se replica) o hacer una copia puntual.
+INSERT INTO configuraciones.replication_table
+    (table_name, direction, description, enabled, replicate_central_to_branch_with_filter, creado_en)
+VALUES
+    ('empresarial.impresora', 'MAIN_TO_ALL', 'Impresoras', true, false, NOW())
+ON CONFLICT (table_name) DO NOTHING;

--- a/src/main/resources/graphql/empresarial/impresora.graphqls
+++ b/src/main/resources/graphql/empresarial/impresora.graphqls
@@ -51,6 +51,14 @@ type Impresora {
     usuario: Usuario
 }
 
+type ImpresoraPage {
+    content: [Impresora]
+    totalElements: Int
+    totalPages: Int
+    size: Int
+    number: Int
+}
+
 input ImpresoraInput {
     id: ID
     nombre: String
@@ -75,6 +83,7 @@ input ImpresoraInput {
 extend type Query {
     impresora(id: ID!): Impresora
     impresoras(page: Int, size: Int = 20): [Impresora]!
+    impresoraSearchPage(texto: String, page: Int, size: Int): ImpresoraPage
     impresorasPorSucursalId(id: Int): [Impresora]
     impresorasActivas: [Impresora]
     impresorasDelSistema: [String]


### PR DESCRIPTION
## Qué resuelve

- **Paginación** en el listado de impresoras del servidor.
- **Fix replicación**: registra `empresarial.impresora` en `configuraciones.replication_table` (migración `V144.3`). La tabla se había creado (V143.3) y agregado a mano a `central_pub`, pero al no estar en `replication_table` el scheduler no refrescaba las suscripciones de las filiales → las impresoras del central no bajaban a las sucursales. Dirección `MAIN_TO_ALL`, patrón idéntico a `terminal_pos`.

## Cómo probarlo

1. Listado de impresoras del servidor: verificar paginación.
2. Crear/actualizar una impresora en el central y confirmar que baja a una filial (tras el REFRESH del scheduler). Nota: `copy_data=false`, solo replica cambios posteriores al refresh.

## Impacto en DB

Migración aditiva `V144.3` (un `INSERT ... ON CONFLICT DO NOTHING` en `replication_table`). Sin DROP/RENAME.

## Impacto en rollback

Bajo. La migración es idempotente y aditiva.

## Riesgo

Bajo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)