### PR TITLE
fix(financiero): reintentar busqueda de venta al guardar venta_tarjeta

### DIFF
--- a/src/main/java/com/franco/dev/graphql/financiero/VentaTarjetaGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/VentaTarjetaGraphQL.java
@@ -16,6 +16,7 @@ import com.franco.dev.service.impresion.ImpresionService;
 import com.franco.dev.service.operaciones.VentaService;
 import com.franco.dev.service.personas.UsuarioService;
 import com.franco.dev.utilitarios.DateUtils;
+import graphql.GraphQLException;
 import graphql.kickstart.tools.GraphQLMutationResolver;
 import graphql.kickstart.tools.GraphQLQueryResolver;
 import org.modelmapper.ModelMapper;
@@ -67,13 +68,31 @@ public class VentaTarjetaGraphQL implements GraphQLQueryResolver, GraphQLMutatio
         return count != null ? count : 0L;
     }
 
+    private static final int VENTA_LOOKUP_MAX_INTENTOS = 5;
+    private static final long VENTA_LOOKUP_ESPERA_MS = 300;
+
     public VentaTarjeta saveVentaTarjeta(VentaTarjetaInput input) {
         ModelMapper m = new ModelMapper();
         m.getConfiguration().setAmbiguityIgnored(true);
         VentaTarjeta entity = m.map(input, VentaTarjeta.class);
 
         if (input.getVentaId() != null && input.getSucursalId() != null) {
-            Venta venta = ventaService.findByIdAndSucursalId(input.getVentaId(), input.getSucursalId());
+            Venta venta = null;
+            for (int intento = 1; intento <= VENTA_LOOKUP_MAX_INTENTOS && venta == null; intento++) {
+                venta = ventaService.findByIdAndSucursalId(input.getVentaId(), input.getSucursalId());
+                if (venta == null && intento < VENTA_LOOKUP_MAX_INTENTOS) {
+                    try {
+                        Thread.sleep(VENTA_LOOKUP_ESPERA_MS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        break;
+                    }
+                }
+            }
+            if (venta == null) {
+                throw new GraphQLException(
+                        "La venta aún no se sincronizó con el central, intente nuevamente en unos segundos.");
+            }
             entity.setVenta(venta);
         }
 


### PR DESCRIPTION
## Que resuelve

Al escanear el pago con tarjeta (flujo `scan-terminal-pos-dialog` -> `pago-touch` -> `venta-touch`), la venta se crea en el filial (`servidor=false`) y replica al central de forma asincrona via logical replication. Inmediatamente despues, `saveVentaTarjeta` intenta guardar el registro `venta_tarjeta` **en el central**, buscando esa venta por `(ventaId, sucursalId)`.

Si la replicacion filial -> central todavia no habia llegado (lag normal de la logica de replicacion, tipicamente milisegundos), la busqueda devolvia `null`, y el codigo hacia `entity.setVenta(null)` explicitamente, disparando un `NOT NULL constraint` crudo en `venta_id` al momento del insert (`DataIntegrityViolationException`).

## Cambio

En `VentaTarjetaGraphQL.saveVentaTarjeta`: reintenta la busqueda de la venta hasta 5 veces con 300ms de espera entre intentos (~1.5s total) antes de rendirse. Si tras los reintentos sigue sin encontrarla, lanza un `GraphQLException` con mensaje claro en vez del error de base de datos crudo.

## Como probarlo

1. Crear una venta en un filial con pago con tarjeta escaneando una terminal POS (`terminal_pos`).
2. Verificar que `venta_tarjeta` se guarda correctamente en el central sin error, incluso bajo lag normal de replicacion.
3. Confirmar que el mensaje de error (si la replicacion tarda mas de ~1.5s) es claro y no un stacktrace de Hibernate.

## Impacto en DB

Ninguno — no hay cambios de schema ni migraciones.

## Riesgo

Bajo. Cambio acotado a un solo metodo, no toca el modelo de datos ni el frontend. Peor caso: hasta 1.5s adicionales de latencia en el guardado de `venta_tarjeta` cuando hay lag de replicacion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)