### PR TITLE
fix(empresarial): separar puerto HTTP de filial del puerto de Postgres

### DIFF
--- a/src/main/java/com/franco/dev/domain/empresarial/Sucursal.java
+++ b/src/main/java/com/franco/dev/domain/empresarial/Sucursal.java
@@ -63,4 +63,7 @@ public class Sucursal implements Identifiable<Long> {
 
         private Integer puerto;
 
+        @Column(name = "puerto_servidor")
+        private Integer puertoServidor;
+
 }

--- a/src/main/java/com/franco/dev/graphql/empresarial/input/SucursalInput.java
+++ b/src/main/java/com/franco/dev/graphql/empresarial/input/SucursalInput.java
@@ -18,6 +18,7 @@ public class SucursalInput {
     private String creadoEn;
     private String ip;
     private Integer puerto;
+    private Integer puertoServidor;
     private Boolean activo;
 
 }

--- a/src/main/java/com/franco/dev/graphql/financiero/MaletinGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/MaletinGraphQL.java
@@ -95,8 +95,7 @@ public class MaletinGraphQL implements GraphQLQueryResolver, GraphQLMutationReso
                 log.error("Sucursal no encontrada o sin IP configurado.");
                 return null;
             }
-            // El servidor GraphQL de las filiales siempre usa el puerto 8082
-            Integer puerto = 8082;
+            Integer puerto = sucursal.getPuertoServidor() != null ? sucursal.getPuertoServidor() : 8082;
             String url = "http://" + sucursal.getIp() + ":" + puerto + "/graphql";
 
             HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/com/franco/dev/service/financiero/FacturaLegalFilialService.java
+++ b/src/main/java/com/franco/dev/service/financiero/FacturaLegalFilialService.java
@@ -52,11 +52,12 @@ public class FacturaLegalFilialService {
         Sucursal sucursal = sucursalService.findById(sucursalId)
                 .orElseThrow(() -> new RuntimeException("Sucursal no encontrada: " + sucursalId));
 
-        if (sucursal.getIp() == null || sucursal.getPuerto() == null) {
-            throw new RuntimeException("La sucursal no tiene IP o puerto configurado");
+        if (sucursal.getIp() == null) {
+            throw new RuntimeException("La sucursal no tiene IP configurada");
         }
 
-        String url = String.format("http://%s:%d/api/facturas-legales", sucursal.getIp(), sucursal.getPuerto());
+        Integer puertoServidor = sucursal.getPuertoServidor() != null ? sucursal.getPuertoServidor() : 8082;
+        String url = String.format("http://%s:%d/api/facturas-legales", sucursal.getIp(), puertoServidor);
 
         FacturaLegalFilialRequest request = mapearRequest(facturaInput, items, timbradoDetalleId);
 

--- a/src/main/java/com/franco/dev/service/financiero/FilialCajaProxyService.java
+++ b/src/main/java/com/franco/dev/service/financiero/FilialCajaProxyService.java
@@ -26,7 +26,7 @@ import java.util.Map;
 public class FilialCajaProxyService {
 
     private static final Logger log = LoggerFactory.getLogger(FilialCajaProxyService.class);
-    private static final int FILIAL_PORT = 8082;
+    private static final int DEFAULT_FILIAL_PORT = 8082;
 
     private static final String CAJA_FIELDS =
             "id descripcion activo estado tuvoProblema fechaApertura fechaCierre observacion sucursalId creadoEn "
@@ -146,7 +146,8 @@ public class FilialCajaProxyService {
     }
 
     public String buildFilialUrl(Sucursal sucursal) {
-        return "http://" + sucursal.getIp() + ":" + FILIAL_PORT + "/graphql";
+        Integer puerto = sucursal.getPuertoServidor() != null ? sucursal.getPuertoServidor() : DEFAULT_FILIAL_PORT;
+        return "http://" + sucursal.getIp() + ":" + puerto + "/graphql";
     }
 
     public HttpHeaders buildAuthHeaders() {

--- a/src/main/java/com/franco/dev/service/impresion/PrintRouterService.java
+++ b/src/main/java/com/franco/dev/service/impresion/PrintRouterService.java
@@ -41,7 +41,7 @@ import java.util.Map;
 public class PrintRouterService {
 
     private static final Logger log = LoggerFactory.getLogger(PrintRouterService.class);
-    private static final int FILIAL_PORT = 8082;
+    private static final int DEFAULT_FILIAL_PORT = 8082;
 
     @Value("${sucursalId:0}")
     private Long miSucursalId;
@@ -133,7 +133,8 @@ public class PrintRouterService {
             log.warn("[PRINT] Sucursal dueña sin IP para impresora id={}", impresoraId);
             return false;
         }
-        String url = "http://" + owner.getIp() + ":" + FILIAL_PORT + "/graphql";
+        Integer puerto = owner.getPuertoServidor() != null ? owner.getPuertoServidor() : DEFAULT_FILIAL_PORT;
+        String url = "http://" + owner.getIp() + ":" + puerto + "/graphql";
         String payloadBase64 = Base64.getEncoder().encodeToString(payload);
         String query = "mutation($id: ID!, $payload: String!) { "
                 + "imprimirEnDestino(impresoraId: $id, payloadBase64: $payload) }";

--- a/src/main/resources/db/migration/V145.1__add_puerto_servidor_to_sucursal.sql
+++ b/src/main/resources/db/migration/V145.1__add_puerto_servidor_to_sucursal.sql
@@ -1,0 +1,11 @@
+-- El campo existente empresarial.sucursal.puerto se usa como puerto de PostgreSQL
+-- para la replicacion logica (ver LogicalReplicationService). Varios servicios que
+-- necesitan hablarle por HTTP a la app de la filial (FilialCajaProxyService,
+-- PrintRouterService, MaletinGraphQL, FacturaLegalFilialService) reutilizaban ese
+-- mismo campo o un puerto hardcodeado (8082), lo cual falla cuando el puerto de
+-- Postgres y el de la app HTTP de la filial no coinciden.
+--
+-- puerto_servidor almacena el puerto HTTP/GraphQL de la app de la filial,
+-- independiente del puerto de Postgres usado para la replicacion.
+ALTER TABLE empresarial.sucursal
+    ADD COLUMN IF NOT EXISTS puerto_servidor INTEGER;

--- a/src/main/resources/graphql/empresarial/sucursal.graphqls
+++ b/src/main/resources/graphql/empresarial/sucursal.graphqls
@@ -15,6 +15,7 @@ type Sucursal {
     activo: Boolean
     ip: String
     puerto: Int
+    puertoServidor: Int
     activo: Boolean
 }
 
@@ -34,6 +35,7 @@ input SucursalInput {
     creadoEn: String
     ip: String
     puerto: Int
+    puertoServidor: Int
     activo: Boolean
 }
 


### PR DESCRIPTION
## Que resuelve

`empresarial.sucursal.puerto` se usaba con dos significados incompatibles:

- **Puerto de PostgreSQL** para configurar la replicacion logica (`LogicalReplicationService`, uso extensivo).
- **Puerto HTTP** de la app de la filial en `FacturaLegalFilialService` (`http://{ip}:{puerto}/api/facturas-legales`).

Ademas, `FilialCajaProxyService` y `PrintRouterService` ni siquiera leian el campo: tenian el puerto HTTP hardcodeado (`8082`).

Esto rompe en cualquier entorno donde el puerto de Postgres de la filial y el puerto HTTP de su app no coincidan (caso real detectado: filial alpha con Postgres en `5552` y app corriendo en `8080`, mientras el resto del codigo asume `8082`). Sintoma concreto: el mobile mostraba "No tiene una caja abierta" pese a tener una caja abierta real, porque la consulta en vivo del central hacia la filial (`cajasAbiertasPorUsuarioDesdeFiliales`) fallaba silenciosamente por conectar al puerto equivocado.

## Cambio

- Nueva columna `empresarial.sucursal.puerto_servidor` (migracion `V145.1`), dedicada exclusivamente al puerto HTTP/GraphQL de la app de la filial. `puerto` queda sin cambios, siempre referido a Postgres/replicacion.
- `FilialCajaProxyService`, `PrintRouterService`, `MaletinGraphQL` y `FacturaLegalFilialService` ahora usan `sucursal.getPuertoServidor()`, con fallback a `8082` si no esta configurado (preserva el comportamiento actual para filiales existentes que no seteen el campo nuevo).
- Campo expuesto en el schema GraphQL (`Sucursal` type + `SucursalInput`) para poder configurarlo desde el frontend de administracion de sucursales.

## Como probarlo

1. Aplicar la migracion (`V145.1`).
2. Configurar `puerto_servidor` en una sucursal cuyo puerto HTTP real difiera de 8082 (ej. entorno de prueba alpha, puerto 8080).
3. Verificar desde el mobile que "cajas abiertas desde filiales" ahora encuentra la caja abierta de esa sucursal.
4. Confirmar que una sucursal sin `puerto_servidor` configurado sigue funcionando igual que antes (fallback a 8082).

## Impacto en DB

Migracion aditiva (`ALTER TABLE ADD COLUMN`, nullable). Retrocompatible, no requiere backfill para que el sistema siga funcionando (fallback a 8082).

## Riesgo

Bajo-medio. Toca 4 servicios que hablan HTTP con las filiales, pero todos con fallback al valor anterior. Sin el fallback, cualquier sucursal sin el campo configurado se rompería — se evito ese escenario a proposito.

🤖 Generated with [Claude Code](https://claude.com/claude-code)