### PR TITLE
feat(financiero): configuracion global para habilitar venta con tarjeta

### DIFF
--- a/src/main/java/com/franco/dev/domain/financiero/ConfiguracionVentaTarjeta.java
+++ b/src/main/java/com/franco/dev/domain/financiero/ConfiguracionVentaTarjeta.java
@@ -1,0 +1,37 @@
+package com.franco.dev.domain.financiero;
+
+import com.franco.dev.config.Identifiable;
+import com.franco.dev.domain.personas.Usuario;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "configuracion_venta_tarjeta", schema = "financiero")
+public class ConfiguracionVentaTarjeta implements Identifiable<Long> {
+
+    @Id
+    @GenericGenerator(name = "assigned-identity", strategy = "com.franco.dev.config.AssignedIdentityGenerator")
+    @GeneratedValue(generator = "assigned-identity", strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "habilitado", nullable = false)
+    private Boolean habilitado = false;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "usuario_id", nullable = true)
+    private Usuario usuario;
+
+    @Column(name = "creado_en")
+    private LocalDateTime creadoEn;
+
+    @Column(name = "modificado_en")
+    private LocalDateTime modificadoEn;
+}

--- a/src/main/java/com/franco/dev/graphql/financiero/ConfiguracionVentaTarjetaGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/ConfiguracionVentaTarjetaGraphQL.java
@@ -1,0 +1,36 @@
+package com.franco.dev.graphql.financiero;
+
+import com.franco.dev.domain.financiero.ConfiguracionVentaTarjeta;
+import com.franco.dev.graphql.financiero.input.ConfiguracionVentaTarjetaInput;
+import com.franco.dev.service.financiero.ConfiguracionVentaTarjetaService;
+import com.franco.dev.service.personas.UsuarioService;
+import graphql.kickstart.tools.GraphQLMutationResolver;
+import graphql.kickstart.tools.GraphQLQueryResolver;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+@AllArgsConstructor
+public class ConfiguracionVentaTarjetaGraphQL implements GraphQLQueryResolver, GraphQLMutationResolver {
+
+    private final ConfiguracionVentaTarjetaService service;
+    private final UsuarioService usuarioService;
+
+    public ConfiguracionVentaTarjeta configuracionVentaTarjeta() {
+        return service.findOrCreate();
+    }
+
+    public ConfiguracionVentaTarjeta saveConfiguracionVentaTarjeta(ConfiguracionVentaTarjetaInput input) {
+        ConfiguracionVentaTarjeta config = service.findOrCreate();
+        if (input.getHabilitado() != null) {
+            config.setHabilitado(input.getHabilitado());
+        }
+        if (input.getUsuarioId() != null) {
+            config.setUsuario(usuarioService.findById(input.getUsuarioId()).orElse(null));
+        }
+        config.setModificadoEn(LocalDateTime.now());
+        return service.save(config);
+    }
+}

--- a/src/main/java/com/franco/dev/graphql/financiero/input/ConfiguracionVentaTarjetaInput.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/input/ConfiguracionVentaTarjetaInput.java
@@ -1,0 +1,10 @@
+package com.franco.dev.graphql.financiero.input;
+
+import lombok.Data;
+
+@Data
+public class ConfiguracionVentaTarjetaInput {
+    private Long id;
+    private Boolean habilitado;
+    private Long usuarioId;
+}

--- a/src/main/java/com/franco/dev/repository/financiero/ConfiguracionVentaTarjetaRepository.java
+++ b/src/main/java/com/franco/dev/repository/financiero/ConfiguracionVentaTarjetaRepository.java
@@ -1,0 +1,13 @@
+package com.franco.dev.repository.financiero;
+
+import com.franco.dev.domain.financiero.ConfiguracionVentaTarjeta;
+import com.franco.dev.repository.HelperRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ConfiguracionVentaTarjetaRepository extends HelperRepository<ConfiguracionVentaTarjeta, Long> {
+
+    default Class<ConfiguracionVentaTarjeta> getEntityClass() {
+        return ConfiguracionVentaTarjeta.class;
+    }
+}

--- a/src/main/java/com/franco/dev/service/financiero/ConfiguracionVentaTarjetaService.java
+++ b/src/main/java/com/franco/dev/service/financiero/ConfiguracionVentaTarjetaService.java
@@ -1,0 +1,37 @@
+package com.franco.dev.service.financiero;
+
+import com.franco.dev.domain.financiero.ConfiguracionVentaTarjeta;
+import com.franco.dev.repository.financiero.ConfiguracionVentaTarjetaRepository;
+import com.franco.dev.service.CrudService;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@AllArgsConstructor
+public class ConfiguracionVentaTarjetaService extends CrudService<ConfiguracionVentaTarjeta, ConfiguracionVentaTarjetaRepository, Long> {
+
+    private final ConfiguracionVentaTarjetaRepository repository;
+
+    @Override
+    public ConfiguracionVentaTarjetaRepository getRepository() {
+        return repository;
+    }
+
+    /**
+     * Devuelve el registro único de configuración. Si no existe, lo crea con valores por defecto.
+     */
+    public ConfiguracionVentaTarjeta findOrCreate() {
+        List<ConfiguracionVentaTarjeta> list = repository.findAllByOrderByIdAsc();
+        if (!list.isEmpty()) {
+            return list.get(0);
+        }
+        ConfiguracionVentaTarjeta config = new ConfiguracionVentaTarjeta();
+        config.setHabilitado(false);
+        config.setCreadoEn(LocalDateTime.now());
+        config.setModificadoEn(LocalDateTime.now());
+        return repository.save(config);
+    }
+}

--- a/src/main/resources/db/migration/V146.1__add_configuracion_venta_tarjeta_table.sql
+++ b/src/main/resources/db/migration/V146.1__add_configuracion_venta_tarjeta_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS financiero.configuracion_venta_tarjeta (
+    id BIGSERIAL PRIMARY KEY,
+    habilitado BOOLEAN NOT NULL DEFAULT FALSE,
+    usuario_id BIGINT,
+    creado_en TIMESTAMP DEFAULT NOW(),
+    modificado_en TIMESTAMP DEFAULT NOW(),
+    CONSTRAINT fk_configuracion_venta_tarjeta_usuario FOREIGN KEY (usuario_id) REFERENCES personas.usuario(id)
+);
+
+INSERT INTO financiero.configuracion_venta_tarjeta (habilitado, creado_en, modificado_en)
+SELECT FALSE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM financiero.configuracion_venta_tarjeta);

--- a/src/main/resources/graphql/financiero/configuracion-venta-tarjeta.graphqls
+++ b/src/main/resources/graphql/financiero/configuracion-venta-tarjeta.graphqls
@@ -1,0 +1,21 @@
+type ConfiguracionVentaTarjeta {
+    id: ID!
+    habilitado: Boolean!
+    usuario: Usuario
+    creadoEn: Date
+    modificadoEn: Date
+}
+
+input ConfiguracionVentaTarjetaInput {
+    id: ID
+    habilitado: Boolean
+    usuarioId: ID
+}
+
+extend type Query {
+    configuracionVentaTarjeta: ConfiguracionVentaTarjeta!
+}
+
+extend type Mutation {
+    saveConfiguracionVentaTarjeta(input: ConfiguracionVentaTarjetaInput!): ConfiguracionVentaTarjeta!
+}


### PR DESCRIPTION
## Que resuelve

El flujo de venta con tarjeta (escaneo de terminal POS, generacion de QR, registro desde la app mobile) es una feature nueva que todavia se esta probando en el entorno alpha. Se necesita poder activarla/desactivarla globalmente sin necesidad de un deploy de codigo, para poder rolear el feature de forma controlada a produccion mas adelante.

## Cambio

Mismo patron que `ConfiguracionTransferencia` (permitir stock negativo):

- Nueva entidad singleton `financiero.configuracion_venta_tarjeta` (migracion `V146.1`), campo `habilitado` (default `false`).
- `ConfiguracionVentaTarjetaService.findOrCreate()` — crea el registro unico si no existe.
- GraphQL: query `configuracionVentaTarjeta()`, mutation `saveConfiguracionVentaTarjeta(input)`.

Este PR es la pieza backend. El desktop (dialog de administracion + enforcement en el flujo de cobro) y el mobile (guard de rutas + ocultamiento de UI) van en PRs separados de sus respectivos repos.

## Como probarlo

1. Query `{ configuracionVentaTarjeta { id habilitado } }` debe devolver un registro con `habilitado: false` por defecto (se crea solo en el primer query).
2. Mutation `saveConfiguracionVentaTarjeta(input: { habilitado: true })` debe persistir el cambio.

## Impacto en DB

Migracion aditiva (`CREATE TABLE IF NOT EXISTS` + seed). Retrocompatible.

## Riesgo

Bajo. Entidad nueva aislada, no modifica flujos existentes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)