### PR TITLE
fix(impresoras): instalar cola cups con retry-current-job (no pausar ante error)

### DIFF
--- a/src/main/java/com/franco/dev/service/impresion/CupsAdminService.java
+++ b/src/main/java/com/franco/dev/service/impresion/CupsAdminService.java
@@ -58,8 +58,11 @@ public class CupsAdminService {
             log.warn("[CUPS] Parametros invalidos para instalar (cola='{}', uri='{}')", cola, uri);
             return false;
         }
+        // printer-error-policy=retry-current-job: ante un error del backend la cola NO se pausa
+        // (evita el "stop-printer" por defecto, que deja la impresora inactiva y los jobs pendientes).
         List<String> cmd = new ArrayList<>(Arrays.asList(
-                "lpadmin", "-p", cola, "-E", "-v", uri, "-m", raw ? "raw" : "everywhere"));
+                "lpadmin", "-p", cola, "-E", "-v", uri, "-m", raw ? "raw" : "everywhere",
+                "-o", "printer-error-policy=retry-current-job"));
         return ejecutar(cmd);
     }
 


### PR DESCRIPTION
## Qué resuelve

`CupsAdminService.instalarImpresora` agrega `-o printer-error-policy=retry-current-job` al `lpadmin`: ante un error del backend la cola no se pausa (evita el `stop-printer` por defecto, que deja la impresora inactiva y los trabajos pendientes).

> Reemplaza al PR #134 (cerrado por un problema de recomputación de GitHub tras un force-push). Esta rama es **solo** el cambio de `retry-current-job` sobre develop — se descartó la eliminación del print-router para no pisar el fix de puerto de `PrintRouterService` (commit de Maurolando en develop).

## Cómo probarlo

Compartir/instalar una impresora → `lpstat -p <cola> -l` muestra la política `retry-current-job`; ante un error el trabajo se reintenta en vez de pausar la cola.

## Impacto en DB

Ninguno.

## Riesgo

Bajo. Cambio aditivo de una opción de `lpadmin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)