### PR TITLE
fix(precios): notificar tipo de precio duplicado

### DIFF
--- a/src/main/java/com/franco/dev/graphql/productos/PrecioPorSucursalGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/productos/PrecioPorSucursalGraphQL.java
@@ -101,9 +101,8 @@ public class PrecioPorSucursalGraphQL implements GraphQLQueryResolver, GraphQLMu
             PrecioPorSucursal existente = service.findBySucursalIdAndPresentacionIdAndTipoPrecioId(
                     input.getSucursalId(), input.getPresentacionId(), input.getTipoPrecioId());
             if (existente != null) {
-                e.setId(existente.getId());
-                e.setCreadoEn(existente.getCreadoEn());
-                precioAnterior = existente.getPrecio();
+                throw new IllegalArgumentException(
+                        "Ya existe un precio con ese tipo de precio para esta presentación y sucursal");
             }
         }
 


### PR DESCRIPTION
### Qué resuelve
Notifica cuando se crea un nuevo precio cuyo tipo de precio ya está en uso para esa misma presentación.

### Como probarlo

1. Ir al módulo de productos.
2. Acceder al apartado de editar productos.
3. Clicar en una presentación.
4. Adicionar nuevo precio.
5. Crear nuevo precio cuyo tipo de precio ya esté siendo utilizado.
6. Saltará una notificación que impedirá la acción.