### PR TITLE
fix(impresion)/feat: routing de impresión hacia sucursal + imprimir facturas remoto

### DIFF
--- a/src/main/java/com/franco/dev/graphql/financiero/FacturaLegalGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/FacturaLegalGraphQL.java
@@ -273,6 +273,17 @@ public class FacturaLegalGraphQL implements GraphQLQueryResolver, GraphQLMutatio
 
     public void printTicket58mmFactura(Venta venta, FacturaLegal facturaLegal,
             List<FacturaLegalItem> facturaLegalItemList, String printerName) throws Exception {
+        printTicket58mmFactura(venta, facturaLegal, facturaLegalItemList, printerName, null);
+    }
+
+    /**
+     * Igual a {@link #printTicket58mmFactura(Venta, FacturaLegal, List, String)}, pero si se pasa
+     * un {@code destino} no nulo escribe el ESC/POS ahí en vez de abrir la impresora local (usado
+     * para rutear la impresión a otra sucursal vía PrintRouterService). Con destino=null el
+     * comportamiento es idéntico al método original.
+     */
+    public void printTicket58mmFactura(Venta venta, FacturaLegal facturaLegal,
+            List<FacturaLegalItem> facturaLegalItemList, String printerName, OutputStream destino) throws Exception {
         // Verificar si es moneda extranjera y redirigir al método correspondiente
         boolean esMonedaExtranjera = facturaLegal.getMonedaExtranjera() != null
                 && !facturaLegal.getMonedaExtranjera().trim().isEmpty()
@@ -284,7 +295,7 @@ public class FacturaLegalGraphQL implements GraphQLQueryResolver, GraphQLMutatio
             }
             printTicket58mmFacturaMonedaExtranjera(venta, facturaLegal,
                     facturaLegalItemList, printerName,
-                    facturaLegal.getMonedaExtranjera(), facturaLegal.getTipoCambio());
+                    facturaLegal.getMonedaExtranjera(), facturaLegal.getTipoCambio(), destino);
             return;
         }
 
@@ -292,7 +303,9 @@ public class FacturaLegalGraphQL implements GraphQLQueryResolver, GraphQLMutatio
             facturaLegalItemList = facturaLegalItemService.findByFacturaLegalId(facturaLegal.getId());
         }
 
-        printService = PrinterOutputStream.getPrintServiceByName(printerName);
+        if (destino == null) {
+            printService = PrinterOutputStream.getPrintServiceByName(printerName);
+        }
         Sucursal sucursal = sucursalService.findById(facturaLegal.getSucursalId()).orElse(null);
         Delivery delivery = null;
         if (venta != null)
@@ -323,9 +336,13 @@ public class FacturaLegalGraphQL implements GraphQLQueryResolver, GraphQLMutatio
             precioDeliveryDs = precioDeliveryGs / cambioDs;
         }
 
-        if (printService != null) {
-            printerOutputStream = this.printerOutputStream != null ? this.printerOutputStream
-                    : new PrinterOutputStream(printService);
+        if (destino != null || printService != null) {
+            OutputStream salida = destino;
+            if (salida == null) {
+                printerOutputStream = this.printerOutputStream != null ? this.printerOutputStream
+                        : new PrinterOutputStream(printService);
+                salida = printerOutputStream;
+            }
             // creating the EscPosImage, need buffered image and algorithm.
             // Styles
             Style center = new Style().setJustification(EscPosConst.Justification.Center);
@@ -336,7 +353,7 @@ public class FacturaLegalGraphQL implements GraphQLQueryResolver, GraphQLMutatio
             BufferedImage imageBufferedImage = ImageIO.read(new File(imageService.getImagePath() + "logo.png"));
             imageBufferedImage = resize(imageBufferedImage, 200, 100);
             BitImageWrapper imageWrapper = new BitImageWrapper();
-            EscPos escpos = new EscPos(printerOutputStream);
+            EscPos escpos = new EscPos(salida);
             Bitonal algorithm = new BitonalThreshold();
             EscPosImage escposImage = new EscPosImage(new CoffeeImageImpl(imageBufferedImage), algorithm);
             imageWrapper.setJustification(EscPosConst.Justification.Center);
@@ -615,8 +632,10 @@ public class FacturaLegalGraphQL implements GraphQLQueryResolver, GraphQLMutatio
             try {
                 if (true) {
                     escpos.close();
-                    printerOutputStream.close();
-                    this.printerOutputStream = null;
+                    if (destino == null) {
+                        printerOutputStream.close();
+                        this.printerOutputStream = null;
+                    }
                 } else {
                     this.printerOutputStream = printerOutputStream;
                 }
@@ -660,12 +679,28 @@ public class FacturaLegalGraphQL implements GraphQLQueryResolver, GraphQLMutatio
     public void printTicket58mmFacturaMonedaExtranjera(Venta venta, FacturaLegal facturaLegal,
             List<FacturaLegalItem> facturaLegalItemList, String printerName, String monedaExtranjera, Double tipoCambio)
             throws Exception {
+        printTicket58mmFacturaMonedaExtranjera(venta, facturaLegal, facturaLegalItemList, printerName,
+                monedaExtranjera, tipoCambio, null);
+    }
+
+    /**
+     * Igual a {@link #printTicket58mmFacturaMonedaExtranjera(Venta, FacturaLegal, List, String, String, Double)},
+     * pero si se pasa un {@code destino} no nulo escribe el ESC/POS ahí en vez de abrir la impresora
+     * local (usado para rutear la impresión a otra sucursal vía PrintRouterService). Con destino=null
+     * el comportamiento es idéntico al método original.
+     */
+    public void printTicket58mmFacturaMonedaExtranjera(Venta venta, FacturaLegal facturaLegal,
+            List<FacturaLegalItem> facturaLegalItemList, String printerName, String monedaExtranjera,
+            Double tipoCambio, OutputStream destino)
+            throws Exception {
 
         if (facturaLegalItemList == null) {
             facturaLegalItemList = facturaLegalItemService.findByFacturaLegalId(facturaLegal.getId());
         }
 
-        printService = PrinterOutputStream.getPrintServiceByName(printerName);
+        if (destino == null) {
+            printService = PrinterOutputStream.getPrintServiceByName(printerName);
+        }
         Sucursal sucursal = sucursalService.findById(facturaLegal.getSucursalId()).orElse(null);
         Delivery delivery = null;
         if (venta != null)
@@ -690,15 +725,19 @@ public class FacturaLegalGraphQL implements GraphQLQueryResolver, GraphQLMutatio
         Double totalParcial0Extranjera = (facturaLegal.getTotalParcial0() != null ? facturaLegal.getTotalParcial0()
                 : 0.0) / tipoCambio;
 
-        if (printService != null) {
-            printerOutputStream = this.printerOutputStream != null ? this.printerOutputStream
-                    : new PrinterOutputStream(printService);
+        if (destino != null || printService != null) {
+            OutputStream salida = destino;
+            if (salida == null) {
+                printerOutputStream = this.printerOutputStream != null ? this.printerOutputStream
+                        : new PrinterOutputStream(printService);
+                salida = printerOutputStream;
+            }
             // Styles
             Style center = new Style().setJustification(EscPosConst.Justification.Center);
             Style factura = new Style().setJustification(EscPosConst.Justification.Center)
                     .setFontSize(Style.FontSize._1, Style.FontSize._1);
 
-            EscPos escpos = new EscPos(printerOutputStream);
+            EscPos escpos = new EscPos(salida);
             BitImageWrapper imageWrapper = new BitImageWrapper();
             Bitonal algorithm = new BitonalThreshold();
 
@@ -1113,8 +1152,10 @@ public class FacturaLegalGraphQL implements GraphQLQueryResolver, GraphQLMutatio
             try {
                 if (true) {
                     escpos.close();
-                    printerOutputStream.close();
-                    this.printerOutputStream = null;
+                    if (destino == null) {
+                        printerOutputStream.close();
+                        this.printerOutputStream = null;
+                    }
                 } else {
                     this.printerOutputStream = printerOutputStream;
                 }

--- a/src/main/java/com/franco/dev/graphql/impresion/FacturaPrintRouterGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/impresion/FacturaPrintRouterGraphQL.java
@@ -1,0 +1,69 @@
+package com.franco.dev.graphql.impresion;
+
+import com.franco.dev.domain.financiero.FacturaLegal;
+import com.franco.dev.domain.financiero.FacturaLegalItem;
+import com.franco.dev.graphql.financiero.FacturaLegalGraphQL;
+import com.franco.dev.service.financiero.FacturaLegalItemService;
+import com.franco.dev.service.financiero.FacturaLegalService;
+import com.franco.dev.service.impresion.PrintRouterService;
+import graphql.kickstart.tools.GraphQLMutationResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Base64;
+import java.util.List;
+
+/**
+ * "Imprimir en la sucursal" para facturas: aditivo, no reemplaza Reimprimir / Descargar PDF /
+ * Abrir PDF. Reusa la generación de contenido existente (ticket y PDF) y la pasa por
+ * {@link PrintRouterService}, que ya sabe rutear a la impresora elegida esté donde esté.
+ */
+@Component
+public class FacturaPrintRouterGraphQL implements GraphQLMutationResolver {
+
+    private static final Logger log = LoggerFactory.getLogger(FacturaPrintRouterGraphQL.class);
+
+    @Autowired
+    private FacturaLegalGraphQL facturaLegalGraphQL;
+
+    @Autowired
+    private FacturaLegalService facturaLegalService;
+
+    @Autowired
+    private FacturaLegalItemService facturaLegalItemService;
+
+    @Autowired
+    private PrintRouterService printRouterService;
+
+    /** Genera el mismo PDF A4 que "Descargar PDF"/"Abrir PDF" y lo rutea a la impresora elegida. */
+    public Boolean imprimirPdfFacturaEnImpresora(Long facturaId, Long sucId, Long impresoraId) {
+        String base64 = facturaLegalGraphQL.descargarPdfFacturaElectronica(facturaId, sucId);
+        if (base64 == null || base64.isBlank()) {
+            log.warn("[PRINT] No se pudo generar el PDF de la factura id={} sucId={}", facturaId, sucId);
+            return false;
+        }
+        byte[] pdfBytes = Base64.getDecoder().decode(base64);
+        return printRouterService.imprimir(impresoraId, pdfBytes);
+    }
+
+    /** Genera el mismo ticket ESC/POS que "Reimprimir" (en memoria) y lo rutea a la impresora elegida. */
+    public Boolean imprimirTicketFacturaEnImpresora(Long facturaId, Long sucId, Long impresoraId) {
+        FacturaLegal facturaLegal = facturaLegalService.findByIdAndSucursalId(facturaId, sucId);
+        if (facturaLegal == null) {
+            log.warn("[PRINT] Factura id={} sucId={} no encontrada", facturaId, sucId);
+            return false;
+        }
+        List<FacturaLegalItem> items = facturaLegalItemService.findByFacturaLegalId(facturaId, sucId);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try {
+            facturaLegalGraphQL.printTicket58mmFactura(facturaLegal.getVenta(), facturaLegal, items, null, baos);
+        } catch (Exception e) {
+            log.error("[PRINT] Error generando ticket de factura id={}: {}", facturaId, e.getMessage(), e);
+            return false;
+        }
+        return printRouterService.imprimir(impresoraId, baos.toByteArray());
+    }
+}

--- a/src/main/java/com/franco/dev/service/impresion/PrintRouterService.java
+++ b/src/main/java/com/franco/dev/service/impresion/PrintRouterService.java
@@ -146,8 +146,21 @@ public class PrintRouterService {
             body.put("query", query);
             body.put("variables", variables);
             HttpEntity<String> request = new HttpEntity<>(objectMapper.writeValueAsString(body), buildAuthHeaders());
-            restTemplate.postForEntity(url, request, Map.class);
-            log.info("[PRINT] Reenviado a {} (impresora id={})", url, impresoraId);
+            Map<?, ?> responseBody = restTemplate.postForEntity(url, request, Map.class).getBody();
+            if (responseBody != null && responseBody.get("errors") != null) {
+                log.error("[PRINT] La filial {} devolvio errores GraphQL (impresora id={}): {}",
+                        url, impresoraId, responseBody.get("errors"));
+                return false;
+            }
+            Object data = responseBody != null ? responseBody.get("data") : null;
+            boolean impreso = data instanceof Map
+                    && Boolean.TRUE.equals(((Map<?, ?>) data).get("imprimirEnDestino"));
+            if (!impreso) {
+                log.warn("[PRINT] La filial {} respondio pero no confirmo la impresion (impresora id={}): {}",
+                        url, impresoraId, responseBody);
+                return false;
+            }
+            log.info("[PRINT] Reenviado y confirmado en {} (impresora id={})", url, impresoraId);
             return true;
         } catch (Exception e) {
             log.error("[PRINT] Error reenviando impresion a {}: {}", url, e.getMessage(), e);

--- a/src/main/resources/graphql/impresion/factura-print-router.graphqls
+++ b/src/main/resources/graphql/impresion/factura-print-router.graphqls
@@ -1,0 +1,6 @@
+# "Imprimir en la sucursal" para facturas (aditivo, no reemplaza reimprimirFacturaLegal /
+# descargarPdfFacturaElectronica). Genera el mismo contenido y lo rutea vía PrintRouterService.
+extend type Mutation {
+    imprimirPdfFacturaEnImpresora(facturaId: ID!, sucId: ID!, impresoraId: ID!): Boolean
+    imprimirTicketFacturaEnImpresora(facturaId: ID!, sucId: ID!, impresoraId: ID!): Boolean
+}


### PR DESCRIPTION
## Summary
- Fix: `PrintRouterService.proxyImprimir` devolvía `true` con que el POST HTTP no tirara excepción, sin revisar el body de la respuesta GraphQL del destino. Ahora valida `errors` y `imprimirEnDestino: true` antes de reportar éxito — evita falsos positivos cuando la filial no puede imprimir (cola inexistente, etc).
- Nuevo resolver aditivo `FacturaPrintRouterGraphQL` (`imprimirTicketFacturaEnImpresora`, `imprimirPdfFacturaEnImpresora`): reusa `descargarPdfFacturaElectronica` (sin tocar) y una nueva sobrecarga de `printTicket58mmFactura`/`printTicket58mmFacturaMonedaExtranjera` con un `OutputStream destino` opcional (con `null` el comportamiento es idéntico al actual — ningún call-site existente cambia), y pasa el contenido a `PrintRouterService.imprimir()`.
- `Sucursal.puertoServidor` ya estaba completo end-to-end en este backend (query/input/resolver) — el frontend solo no lo usaba.

## Riesgo
Bajo. El cambio en `printTicket58mmFactura`/`MonedaExtranjera` es puramente estructural (parametriza el destino del stream), sin tocar ninguna línea del formato del ticket. `reimprimirFacturaLegal` (el call-site existente) sigue llamando exactamente el mismo camino de código.

## Test plan
- [ ] `./mvnw -o compile -Dflyway.skip=true` (ya corrido en la sesión, sin errores)
- [ ] Repetir "Reimprimir" de una factura existente y confirmar que el ticket sale igual que antes
- [ ] Desde el desktop (PR compañero en frc-sistemas-integrados-angular), probar "Imprimir ticket/PDF en sucursal" contra una filial real

Depende de/relacionado con el PR equivalente en `franco-system-backend-filial` (mismo nombre de branch, solo el fix de `proxyImprimir`) y con el PR en `frc-sistemas-integrados-angular`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)