### PR TITLE
fix(impresoras): detectar colas CUPS remotas (IPP) al buscar en sucursal

### DIFF
--- a/src/main/java/com/franco/dev/graphql/empresarial/ImpresoraGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/empresarial/ImpresoraGraphQL.java
@@ -4,6 +4,7 @@ import com.franco.dev.domain.empresarial.Impresora;
 import com.franco.dev.graphql.empresarial.input.ImpresoraInput;
 import com.franco.dev.service.empresarial.ImpresoraService;
 import com.franco.dev.service.empresarial.SucursalService;
+import com.franco.dev.service.impresion.CupsAdminService;
 import com.franco.dev.service.personas.UsuarioService;
 import graphql.kickstart.tools.GraphQLMutationResolver;
 import graphql.kickstart.tools.GraphQLQueryResolver;
@@ -17,9 +18,6 @@ import org.springframework.stereotype.Component;
 import com.franco.dev.config.multitenant.CustomPage;
 import com.franco.dev.config.multitenant.CustomPageImpl;
 
-import javax.print.PrintService;
-import javax.print.PrintServiceLookup;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -34,6 +32,9 @@ public class ImpresoraGraphQL implements GraphQLQueryResolver, GraphQLMutationRe
 
     @Autowired
     private SucursalService sucursalService;
+
+    @Autowired
+    private CupsAdminService cupsAdminService;
 
     public Optional<Impresora> impresora(Long id) {
         return service.findById(id);
@@ -62,15 +63,12 @@ public class ImpresoraGraphQL implements GraphQLQueryResolver, GraphQLMutationRe
 
     /**
      * Colas de impresion visibles localmente en el host que atiende esta consulta
-     * (en Linux, las colas CUPS). Sirve para descubrir impresoras del servidor/filial
-     * al dar de alta, no solo las del desktop.
+     * (en Linux, las colas CUPS, incluyendo las que apuntan a un device-uri remoto
+     * via IPP). Sirve para descubrir impresoras del servidor/filial al dar de alta,
+     * no solo las del desktop.
      */
     public List<String> impresorasDelSistema() {
-        List<String> nombres = new ArrayList<>();
-        for (PrintService p : PrintServiceLookup.lookupPrintServices(null, null)) {
-            nombres.add(p.getName());
-        }
-        return nombres;
+        return cupsAdminService.listarColasInstaladas();
     }
 
     public Impresora saveImpresora(ImpresoraInput input) {

--- a/src/main/java/com/franco/dev/service/impresion/CupsAdminService.java
+++ b/src/main/java/com/franco/dev/service/impresion/CupsAdminService.java
@@ -46,6 +46,30 @@ public class CupsAdminService {
     }
 
     /**
+     * Lista los nombres de las colas CUPS ya instaladas en el sistema (locales y remotas)
+     * via {@code lpstat -p}. A diferencia de {@code javax.print.PrintServiceLookup} (que en
+     * Linux excluye las colas marcadas {@code CUPS_PRINTER_REMOTE}), esto trae tambien las
+     * colas que apuntan a un {@code device-uri ipp://...} de otro host.
+     */
+    public List<String> listarColasInstaladas() {
+        List<String> nombres = new ArrayList<>();
+        Resultado r = ejecutarConFallbackSudo(Arrays.asList("lpstat", "-p"));
+        for (String linea : r.salida.split("\\R")) {
+            String l = linea.trim();
+            if (!l.startsWith("printer ")) {
+                continue;
+            }
+            String resto = l.substring("printer ".length());
+            int sp = resto.indexOf(' ');
+            String nombre = (sp >= 0 ? resto.substring(0, sp) : resto).trim();
+            if (!nombre.isEmpty()) {
+                nombres.add(nombre);
+            }
+        }
+        return nombres;
+    }
+
+    /**
      * Instala una cola CUPS nueva.
      * @param nombreCola nombre deseado (se sanea a [A-Za-z0-9_-]).
      * @param uri URI del dispositivo (de {@link #detectarDispositivos()}).


### PR DESCRIPTION
## Resumen
- `impresorasDelSistema()` (endpoint que usa el diálogo "Agregar desde sucursal" al presionar "Buscar colas del sistema") usaba `javax.print.PrintServiceLookup`, que en Linux excluye las colas CUPS marcadas como remotas (`CUPS_PRINTER_REMOTE`).
- Esto hacía que colas con `device-uri ipp://<otro-host>:631/printers/<nombre>` (ej. "ultron") no aparecieran, mientras que colas locales USB sí (ej. "ticket_soporte").
- Se reemplaza por `CupsAdminService.listarColasInstaladas()`, un método nuevo que ejecuta `lpstat -p` (con el mismo fallback a `sudo -n` que ya usaba `detectarDispositivos()`) y parsea los nombres de cola. `lpstat -p` lista todas las colas registradas en el cupsd local, sean locales o remotas.

## Cómo probarlo
1. Levantar el server con una filial/host que tenga al menos una cola CUPS remota configurada vía IPP (ej. `ultron`, apuntando a `ipp://172.25.0.88:631/printers/ultron`) y otra local (USB).
2. Ejecutar la query GraphQL `impresorasDelSistema` (o el flujo "Impresoras" → "Agregar desde sucursal" → "Buscar colas del sistema" en el frontend).
3. Verificar que la respuesta incluya ambas colas, no solo la USB.

## Impacto en DB
Ninguno.

## Impacto en rollback
Ninguno — es lectura de estado del sistema (CUPS), no persiste nada. Revertir el commit alcanza.

## Riesgo
Bajo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)