### PR TITLE
feat(impresoras): compartir cola CUPS de una sucursal al central

### DIFF
--- a/src/main/java/com/franco/dev/graphql/impresion/CupsAdminGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/impresion/CupsAdminGraphQL.java
@@ -27,4 +27,12 @@ public class CupsAdminGraphQL implements GraphQLQueryResolver, GraphQLMutationRe
     public Boolean instalarImpresoraCups(String nombreCola, String uri, Boolean raw) {
         return cupsAdminService.instalarImpresora(nombreCola, uri, raw == null || raw);
     }
+
+    /**
+     * Comparte una cola CUPS ya instalada en este host (filial o central) via IPP, para que otro
+     * host pueda instalar una cola proxy que reenvie hacia ella (ver {@code instalarImpresoraCups}).
+     */
+    public Boolean compartirColaCups(String nombreCola, String ipDestino) {
+        return cupsAdminService.compartirCola(nombreCola, ipDestino);
+    }
 }

--- a/src/main/java/com/franco/dev/service/impresion/CupsAdminService.java
+++ b/src/main/java/com/franco/dev/service/impresion/CupsAdminService.java
@@ -10,6 +10,7 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -88,6 +89,86 @@ public class CupsAdminService {
                 "lpadmin", "-p", cola, "-E", "-v", uri, "-m", raw ? "raw" : "everywhere",
                 "-o", "printer-error-policy=retry-current-job"));
         return ejecutar(cmd);
+    }
+
+    /**
+     * Comparte una cola ya instalada en ESTE host (filial o central) para que sea alcanzable por
+     * red via IPP: habilita {@code cupsctl --share-printers --remote-any} (si no estaba ya) y
+     * marca la cola con {@code printer-is-shared=true}. Se usa para exponer una impresora de una
+     * sucursal a otro host (ej. el central instala ahi una cola proxy que reenvia por IPP).
+     * Best-effort: si hay firewalld, restringe el puerto 631 solo a {@code ipDestino}.
+     */
+    public boolean compartirCola(String nombreCola, String ipDestino) {
+        String cola = sanearNombre(nombreCola);
+        if (cola.isEmpty()) {
+            log.warn("[CUPS] Nombre de cola invalido para compartir");
+            return false;
+        }
+        Resultado estado = ejecutarConFallbackSudo(Collections.singletonList("cupsctl"));
+        boolean yaCompartido = estado.salida.contains("_share_printers=1") && estado.salida.contains("_remote_any=1");
+        if (!yaCompartido) {
+            Resultado c1 = ejecutarConFallbackSudo(Arrays.asList("cupsctl", "--share-printers", "--remote-any"));
+            if (c1.codigo != 0) {
+                log.warn("[CUPS] cupsctl --share-printers fallo: {}", c1.salida.trim());
+                return false;
+            }
+            esperar(1000); // cupsd puede reiniciarse tras el cambio de config
+        }
+        // Marcamos la cola como compartida; reintentamos si cupsd esta reiniciando (Service unavailable).
+        Resultado ultimo = new Resultado(1, "");
+        for (int i = 0; i < 6; i++) {
+            ultimo = ejecutarConFallbackSudo(Arrays.asList("lpadmin", "-p", cola, "-o", "printer-is-shared=true"));
+            if (ultimo.codigo == 0) {
+                break;
+            }
+            if (!requiereReintento(ultimo.salida)) {
+                break; // error real (no es el reinicio) -> no tiene sentido reintentar
+            }
+            esperar(800);
+        }
+        if (ultimo.codigo != 0) {
+            log.warn("[CUPS] lpadmin -o printer-is-shared=true fallo para '{}': {}", cola, ultimo.salida.trim());
+            return false;
+        }
+        restringirCupsA(ipDestino);
+        return true;
+    }
+
+    /** Heuristica: la salida sugiere que cupsd esta reiniciando (conviene reintentar). */
+    private boolean requiereReintento(String salida) {
+        if (salida == null) {
+            return false;
+        }
+        return salida.toLowerCase().matches("(?s).*(no disponible|unavailable|503|refus|connect).*");
+    }
+
+    /**
+     * Best-effort: restringe el acceso al CUPS local (puerto 631) SOLO a la IP destino via
+     * firewalld. No es fatal si falla o no hay firewalld: el compartir ya funciono igual.
+     */
+    private void restringirCupsA(String ip) {
+        if (ip == null || !ip.matches("\\d{1,3}(\\.\\d{1,3}){3}")) {
+            return;
+        }
+        Resultado cual = ejecutarConFallbackSudo(Arrays.asList("sh", "-c", "command -v firewall-cmd || true"));
+        if (cual.salida == null || cual.salida.trim().isEmpty()) {
+            return;
+        }
+        String regla = "rule family=\"ipv4\" source address=\"" + ip + "\" port port=\"631\" protocol=\"tcp\" accept";
+        Resultado add = ejecutarConFallbackSudo(Arrays.asList("firewall-cmd", "--permanent", "--add-rich-rule=" + regla));
+        if (add.codigo != 0) {
+            log.warn("[CUPS] No se pudo restringir firewall a {}: {}", ip, add.salida.trim());
+            return;
+        }
+        ejecutarConFallbackSudo(Arrays.asList("firewall-cmd", "--reload"));
+    }
+
+    private void esperar(long ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
     }
 
     // ---- helpers ----

--- a/src/main/resources/graphql/empresarial/cups-admin.graphqls
+++ b/src/main/resources/graphql/empresarial/cups-admin.graphqls
@@ -12,4 +12,5 @@ extend type Query {
 
 extend type Mutation {
     instalarImpresoraCups(nombreCola: String!, uri: String!, raw: Boolean): Boolean
+    compartirColaCups(nombreCola: String!, ipDestino: String): Boolean
 }


### PR DESCRIPTION
## Resumen
- Nueva mutation `compartirColaCups(nombreCola: String!, ipDestino: String): Boolean` en `CupsAdminGraphQL`.
- `CupsAdminService.compartirCola()`: habilita `cupsctl --share-printers --remote-any` (si no estaba activo) y marca la cola con `lpadmin -o printer-is-shared=true`, con reintentos si cupsd está reiniciando. Best-effort: si hay firewalld, restringe el puerto 631 solo al `ipDestino` indicado.
- Es la contraparte de la misma mutation en `franco-system-backend-filial` (PR https://github.com/GabFrank/franco-system-backend-filial/pull/71): se llama en el host donde vive físicamente la cola (sucursal), no en el central, pero se agrega también acá porque `CupsAdminService`/`CupsAdminGraphQL` son idénticos en ambos repos y este mismo mecanismo también sirve para compartir una cola que esté instalada directamente en el host central hacia otra filial.
- Contraparte del backend para el botón "Compartir" agregado en el desktop (`agregar-desde-sucursal-dialog`, PR relacionado en `frc-sistemas-integrados-angular`).

## Cómo probarlo
1. Levantar este backend en un host con CUPS y una cola ya instalada.
2. Llamar `compartirColaCups(nombreCola: "<cola>", ipDestino: "<ip-destino>")` vía GraphQL.
3. Verificar `lpstat -p`: la cola debe figurar como compartida (`is shared`).
4. Desde otro host, instalar una cola proxy apuntando a `ipp://<ip-de-este-host>:631/printers/<cola>` (mutation `instalarImpresoraCups`, ya existente) y confirmar que imprime.

## Riesgo
Bajo. No toca schema de datos ni migraciones; agrega un mutation nuevo aislado en el módulo `impresion`, mismo patrón que `instalarImpresoraCups` ya existente. Requiere que el usuario del servicio tenga permiso de `sudo -n` sobre `cupsctl`/`lpadmin`/`firewall-cmd`, igual que ya documenta este archivo para `lpadmin`/`lpinfo`.