### PR TITLE
feat(financiero): configuración global ConfiguracionFacturaConVenta

### DIFF
--- a/src/main/java/com/franco/dev/domain/financiero/ConfiguracionFacturaConVenta.java
+++ b/src/main/java/com/franco/dev/domain/financiero/ConfiguracionFacturaConVenta.java
@@ -1,0 +1,37 @@
+package com.franco.dev.domain.financiero;
+
+import com.franco.dev.config.Identifiable;
+import com.franco.dev.domain.personas.Usuario;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "configuracion_factura_venta", schema = "financiero")
+public class ConfiguracionFacturaConVenta implements Identifiable<Long> {
+
+    @Id
+    @GenericGenerator(name = "assigned-identity", strategy = "com.franco.dev.config.AssignedIdentityGenerator")
+    @GeneratedValue(generator = "assigned-identity", strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "habilitado", nullable = false)
+    private Boolean habilitado = false;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "usuario_id", nullable = true)
+    private Usuario usuario;
+
+    @Column(name = "creado_en")
+    private LocalDateTime creadoEn;
+
+    @Column(name = "modificado_en")
+    private LocalDateTime modificadoEn;
+}

--- a/src/main/java/com/franco/dev/graphql/financiero/ConfiguracionFacturaConVentaGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/ConfiguracionFacturaConVentaGraphQL.java
@@ -1,0 +1,36 @@
+package com.franco.dev.graphql.financiero;
+
+import com.franco.dev.domain.financiero.ConfiguracionFacturaConVenta;
+import com.franco.dev.graphql.financiero.input.ConfiguracionFacturaConVentaInput;
+import com.franco.dev.service.financiero.ConfiguracionFacturaConVentaService;
+import com.franco.dev.service.personas.UsuarioService;
+import graphql.kickstart.tools.GraphQLMutationResolver;
+import graphql.kickstart.tools.GraphQLQueryResolver;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+@AllArgsConstructor
+public class ConfiguracionFacturaConVentaGraphQL implements GraphQLQueryResolver, GraphQLMutationResolver {
+
+    private final ConfiguracionFacturaConVentaService service;
+    private final UsuarioService usuarioService;
+
+    public ConfiguracionFacturaConVenta configuracionFacturaConVenta() {
+        return service.findOrCreate();
+    }
+
+    public ConfiguracionFacturaConVenta saveConfiguracionFacturaConVenta(ConfiguracionFacturaConVentaInput input) {
+        ConfiguracionFacturaConVenta config = service.findOrCreate();
+        if (input.getHabilitado() != null) {
+            config.setHabilitado(input.getHabilitado());
+        }
+        if (input.getUsuarioId() != null) {
+            config.setUsuario(usuarioService.findById(input.getUsuarioId()).orElse(null));
+        }
+        config.setModificadoEn(LocalDateTime.now());
+        return service.save(config);
+    }
+}

--- a/src/main/java/com/franco/dev/graphql/financiero/input/ConfiguracionFacturaConVentaInput.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/input/ConfiguracionFacturaConVentaInput.java
@@ -1,0 +1,10 @@
+package com.franco.dev.graphql.financiero.input;
+
+import lombok.Data;
+
+@Data
+public class ConfiguracionFacturaConVentaInput {
+    private Long id;
+    private Boolean habilitado;
+    private Long usuarioId;
+}

--- a/src/main/java/com/franco/dev/repository/financiero/ConfiguracionFacturaConVentaRepository.java
+++ b/src/main/java/com/franco/dev/repository/financiero/ConfiguracionFacturaConVentaRepository.java
@@ -1,0 +1,13 @@
+package com.franco.dev.repository.financiero;
+
+import com.franco.dev.domain.financiero.ConfiguracionFacturaConVenta;
+import com.franco.dev.repository.HelperRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ConfiguracionFacturaConVentaRepository extends HelperRepository<ConfiguracionFacturaConVenta, Long> {
+
+    default Class<ConfiguracionFacturaConVenta> getEntityClass() {
+        return ConfiguracionFacturaConVenta.class;
+    }
+}

--- a/src/main/java/com/franco/dev/service/financiero/ConfiguracionFacturaConVentaService.java
+++ b/src/main/java/com/franco/dev/service/financiero/ConfiguracionFacturaConVentaService.java
@@ -1,0 +1,37 @@
+package com.franco.dev.service.financiero;
+
+import com.franco.dev.domain.financiero.ConfiguracionFacturaConVenta;
+import com.franco.dev.repository.financiero.ConfiguracionFacturaConVentaRepository;
+import com.franco.dev.service.CrudService;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@AllArgsConstructor
+public class ConfiguracionFacturaConVentaService extends CrudService<ConfiguracionFacturaConVenta, ConfiguracionFacturaConVentaRepository, Long> {
+
+    private final ConfiguracionFacturaConVentaRepository repository;
+
+    @Override
+    public ConfiguracionFacturaConVentaRepository getRepository() {
+        return repository;
+    }
+
+    /**
+     * Devuelve el registro único de configuración. Si no existe, lo crea con valores por defecto.
+     */
+    public ConfiguracionFacturaConVenta findOrCreate() {
+        List<ConfiguracionFacturaConVenta> list = repository.findAllByOrderByIdAsc();
+        if (!list.isEmpty()) {
+            return list.get(0);
+        }
+        ConfiguracionFacturaConVenta config = new ConfiguracionFacturaConVenta();
+        config.setHabilitado(false);
+        config.setCreadoEn(LocalDateTime.now());
+        config.setModificadoEn(LocalDateTime.now());
+        return repository.save(config);
+    }
+}

--- a/src/main/resources/db/migration/V147.1__add_configuracion_factura_venta_table.sql
+++ b/src/main/resources/db/migration/V147.1__add_configuracion_factura_venta_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS financiero.configuracion_factura_venta (
+    id BIGSERIAL PRIMARY KEY,
+    habilitado BOOLEAN NOT NULL DEFAULT FALSE,
+    usuario_id BIGINT,
+    creado_en TIMESTAMP DEFAULT NOW(),
+    modificado_en TIMESTAMP DEFAULT NOW(),
+    CONSTRAINT fk_configuracion_factura_venta_usuario FOREIGN KEY (usuario_id) REFERENCES personas.usuario(id)
+);
+
+INSERT INTO financiero.configuracion_factura_venta (habilitado, creado_en, modificado_en)
+SELECT FALSE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM financiero.configuracion_factura_venta);

--- a/src/main/resources/graphql/financiero/configuracion-factura-con-venta.graphqls
+++ b/src/main/resources/graphql/financiero/configuracion-factura-con-venta.graphqls
@@ -1,0 +1,21 @@
+type ConfiguracionFacturaConVenta {
+    id: ID!
+    habilitado: Boolean!
+    usuario: Usuario
+    creadoEn: Date
+    modificadoEn: Date
+}
+
+input ConfiguracionFacturaConVentaInput {
+    id: ID
+    habilitado: Boolean
+    usuarioId: ID
+}
+
+extend type Query {
+    configuracionFacturaConVenta: ConfiguracionFacturaConVenta!
+}
+
+extend type Mutation {
+    saveConfiguracionFacturaConVenta(input: ConfiguracionFacturaConVentaInput!): ConfiguracionFacturaConVenta!
+}


### PR DESCRIPTION
## Summary
- Entidad singleton `ConfiguracionFacturaConVenta` (habilitado/usuario/timestamps), siguiendo el mismo patrón que `ConfiguracionVentaTarjeta`.
- Query `configuracionFacturaConVenta` y mutation `saveConfiguracionFacturaConVenta`, con `findOrCreate()` en el service (crea el registro default si no existe).
- Migración `V147.1` crea `financiero.configuracion_factura_venta`.

Soporta el toggle "Finalizar con Factura" del POS desktop (ver PR relacionado en `frc-sistemas-integrados-angular`).

## Impacto en DB
Nueva tabla `financiero.configuracion_factura_venta`, migración aditiva únicamente (`CREATE TABLE IF NOT EXISTS` + insert de fila default). Sin impacto en tablas existentes.

## Test plan
- [ ] La app levanta y corre la migración `V147.1` sin errores
- [ ] Query `configuracionFacturaConVenta` devuelve el registro default (`habilitado: false`)
- [ ] Mutation `saveConfiguracionFacturaConVenta` persiste el toggle correctamente

## Riesgo
Bajo — entidad y endpoints nuevos, no modifica comportamiento existente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)