### PR TITLE
fix(impresoras): no pisar sucursalId al compartir cola al central

### DIFF
--- a/src/main/java/com/franco/dev/domain/empresarial/Impresora.java
+++ b/src/main/java/com/franco/dev/domain/empresarial/Impresora.java
@@ -85,6 +85,13 @@ public class Impresora implements Identifiable<Long> {
     /** Code-page ESC/POS. */
     private String codepage;
 
+    /**
+     * true = ademas de vivir en {@link #sucursal}, tiene una cola CUPS proxy (IPP) instalada
+     * en el central via "compartir al central". Informativo: {@link #sucursal} sigue siendo el
+     * host real para el routing de {@code PrintRouterService}.
+     */
+    private Boolean compartidaEnCentral;
+
     @CreationTimestamp
     private LocalDateTime creadoEn;
 

--- a/src/main/java/com/franco/dev/graphql/empresarial/input/ImpresoraInput.java
+++ b/src/main/java/com/franco/dev/graphql/empresarial/input/ImpresoraInput.java
@@ -25,5 +25,6 @@ public class ImpresoraInput {
     private Integer altoMm;
     private String marca;
     private String codepage;
+    private Boolean compartidaEnCentral;
     private Long usuarioId;
 }

--- a/src/main/resources/db/migration/V148.3__add_compartida_en_central_impresora.sql
+++ b/src/main/resources/db/migration/V148.3__add_compartida_en_central_impresora.sql
@@ -1,0 +1,13 @@
+-- "Compartir al central" (ver CupsAdminService/agregar-desde-sucursal-dialog) instala en el
+-- central una cola CUPS proxy que reenvia por IPP a la sucursal dueña de la impresora. Antes,
+-- el unico modo de marcar esto era pisar impresora.sucursal_id con el id del central (0), lo que
+-- rompia PrintRouterService: el router cree que la impresora es local al central e imprime
+-- contra la cola IPP-proxy (fragil, sin el proxy GraphQL confiable) en vez de hacer el proxy
+-- GraphQL hacia la sucursal real.
+--
+-- compartida_en_central es un flag informativo, separado de sucursal_id: sucursal_id siempre
+-- refleja el host real donde esta conectada la impresora (routing correcto via
+-- PrintRouterService.proxyImprimir); este campo solo indica que ADEMAS existe una cola proxy
+-- IPP instalada en el central (para uso fuera de la app, ej. impresion directa del SO en esa PC).
+ALTER TABLE empresarial.impresora
+    ADD COLUMN IF NOT EXISTS compartida_en_central BOOLEAN DEFAULT FALSE;

--- a/src/main/resources/graphql/empresarial/impresora.graphqls
+++ b/src/main/resources/graphql/empresarial/impresora.graphqls
@@ -47,6 +47,7 @@ type Impresora {
     altoMm: Int
     marca: String
     codepage: String
+    compartidaEnCentral: Boolean
     creadoEn: Date
     usuario: Usuario
 }
@@ -77,6 +78,7 @@ input ImpresoraInput {
     altoMm: Int
     marca: String
     codepage: String
+    compartidaEnCentral: Boolean
     usuarioId: Int
 }
 


### PR DESCRIPTION
## Summary
- "Compartir al central" (Agregar desde sucursal) pisaba `Impresora.sucursalId = 0`, lo que rompía `PrintRouterService`: imprimía "local" contra la cola CUPS-proxy IPP (creada con `retry-current-job` en `CupsAdminService`) en vez de hacer proxy GraphQL a la sucursal dueña. Causaba jobs colgados ("Unable to add document to print job") al imprimir desde el central a una impresora compartida.
- `sucursalId` ahora siempre refleja el host real; se agrega `compartidaEnCentral` (Boolean informativo, sin efecto en routing) para no perder el dato de que además hay una cola proxy IPP en el central.

## PR hermano
`franco-system-backend-filial`: https://github.com/GabFrank/franco-system-backend-filial/pull/74 (mismo fix + columna espejo + fix de cache de `PrintService`) — coordinar merge.
`frc-sistemas-integrados-angular`: deja de pisar `sucursalId` al compartir, agrega el campo al modelo/queries y un badge visual.

## Impacto DB
Migración `V148.3`: `ALTER TABLE ADD COLUMN compartida_en_central BOOLEAN DEFAULT FALSE` (nullable con default, no rompe filas existentes, no requiere rollback especial).

## Test plan
- [ ] `./mvnw clean verify -B -DskipFlyway=true` en CI
- [ ] `saveImpresora` acepta y persiste `compartidaEnCentral`
- [ ] Compartir una impresora de una sucursal al central, imprimir una factura desde el central hacia esa impresora: debe llegar por proxy GraphQL (`PrintRouterService.proxyImprimir`, log `[PRINT] Reenviado y confirmado en ...`) en vez de quedar colgada en CUPS
- [ ] Impresoras no compartidas (sucursalId real, sin flag) siguen imprimiendo igual que antes

Riesgo: bajo.