### PR TITLE
feat(notificaciones): notificación push de diferencia en maletín

### DIFF
--- a/src/main/java/com/franco/dev/fmc/controller/PushNotificationController.java
+++ b/src/main/java/com/franco/dev/fmc/controller/PushNotificationController.java
@@ -236,6 +236,56 @@ public class PushNotificationController {
                 }
         }
 
+        @PostMapping("/notification/diferencia-maletin/{cajaId}/{sucursalId}/{diferenciaTotalGs}")
+        public ResponseEntity<PushNotificationResponse> sendDiferenciaMaletinNotification(
+                        @PathVariable Long cajaId,
+                        @PathVariable Long sucursalId,
+                        @PathVariable Double diferenciaTotalGs,
+                        @RequestParam(required = false) Double diferenciaGs,
+                        @RequestParam(required = false) Double diferenciaRs,
+                        @RequestParam(required = false) Double diferenciaDs,
+                        @RequestParam(required = false) String maletinDescripcion,
+                        @RequestParam(required = false) String sucursalNombre) {
+                try {
+                        if (diferenciaTotalGs == null || Math.abs(diferenciaTotalGs) <= 20000) {
+                                return new ResponseEntity<>(new PushNotificationResponse(HttpStatus.BAD_REQUEST.value(),
+                                                "La diferencia no supera el umbral de 20.000 Gs"), HttpStatus.BAD_REQUEST);
+                        }
+
+                        if (sucursalNombre == null || sucursalNombre.isEmpty()) {
+                                Sucursal sucursal = sucursalService.findById(sucursalId).orElse(null);
+                                sucursalNombre = sucursal != null ? sucursal.getNombre() : "";
+                        }
+
+                        List<Usuario> usuariosDestino = notificacionPreferenciaService
+                                        .obtenerUsuariosPorTipoNotificacion("DIFERENCIA_MALETIN");
+                        List<Long> usuariosRelevantes = usuariosDestino.stream()
+                                        .map(Usuario::getId)
+                                        .distinct()
+                                        .collect(Collectors.toList());
+
+                        if (!usuariosRelevantes.isEmpty()) {
+                                PushNotificationRequest request = notificationTemplateService.diferenciaMaletinDetectada(
+                                                cajaId, sucursalId, sucursalNombre, maletinDescripcion,
+                                                diferenciaGs, diferenciaRs, diferenciaDs, diferenciaTotalGs, df);
+                                request.setUsuarioIds(usuariosRelevantes);
+                                pushNotificationService.sendPushNotificationToToken(request);
+                                return new ResponseEntity<>(new PushNotificationResponse(HttpStatus.ACCEPTED.value(),
+                                                "Notificación enviada exitosamente"), HttpStatus.ACCEPTED);
+                        } else {
+                                return new ResponseEntity<>(new PushNotificationResponse(HttpStatus.NOT_FOUND.value(),
+                                                "No se encontraron usuarios con roles relevantes"),
+                                                HttpStatus.NOT_FOUND);
+                        }
+
+                } catch (Exception e) {
+                        return new ResponseEntity<>(
+                                        new PushNotificationResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                                                        "Error al enviar notificación: " + e.getMessage()),
+                                        HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+        }
+
         @PostMapping("/notification/venta-transferencia/{ventaId}/{sucursalId}/{valorTotal}")
         public ResponseEntity<PushNotificationResponse> sendVentaTransferenciaNotification(
                         @PathVariable Long ventaId,

--- a/src/main/java/com/franco/dev/fmc/service/NotificationDispatchService.java
+++ b/src/main/java/com/franco/dev/fmc/service/NotificationDispatchService.java
@@ -8,6 +8,7 @@ import com.franco.dev.domain.configuracion.enums.EstadoNotificacion;
 import com.franco.dev.fmc.model.DeliveryResult;
 import com.franco.dev.fmc.model.PushNotificationRequest;
 import com.franco.dev.repository.configuracion.NotificacionEnvioLogRepository;
+import com.franco.dev.repository.configuracion.NotificacionRepository;
 
 import com.franco.dev.service.configuracion.InicioSesionService;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -29,6 +30,7 @@ public class NotificationDispatchService {
     private static final Logger LOGGER = LoggerFactory.getLogger(NotificationDispatchService.class);
 
     private final NotificacionEnvioLogRepository notificacionEnvioLogRepository;
+    private final NotificacionRepository notificacionRepository;
 
     private final FCMService fcmService;
     private final InicioSesionService inicioSesionService;
@@ -44,11 +46,13 @@ public class NotificationDispatchService {
 
     public NotificationDispatchService(
             NotificacionEnvioLogRepository notificacionEnvioLogRepository,
+            NotificacionRepository notificacionRepository,
             FCMService fcmService,
             InicioSesionService inicioSesionService,
             Optional<MeterRegistry> meterRegistry,
             org.springframework.transaction.PlatformTransactionManager transactionManager) {
         this.notificacionEnvioLogRepository = notificacionEnvioLogRepository;
+        this.notificacionRepository = notificacionRepository;
         this.fcmService = fcmService;
         this.inicioSesionService = inicioSesionService;
         this.meterRegistry = meterRegistry;
@@ -82,6 +86,7 @@ public class NotificationDispatchService {
             DeliveryResult result = fcmService.sendToToken(target.getTokenFcm(), request);
             handleResult(target, notificacion, result);
             notificacionEnvioLogRepository.save(target);
+            notificacionRepository.save(notificacion);
         }
     }
 

--- a/src/main/java/com/franco/dev/fmc/service/NotificationRoleService.java
+++ b/src/main/java/com/franco/dev/fmc/service/NotificationRoleService.java
@@ -154,4 +154,5 @@ public class NotificationRoleService {
                 "ANALISIS DE CAJA",
                 "ANALISIS DE VENTA");
     }
+
 }

--- a/src/main/java/com/franco/dev/fmc/service/NotificationTemplateService.java
+++ b/src/main/java/com/franco/dev/fmc/service/NotificationTemplateService.java
@@ -392,6 +392,32 @@ public class NotificationTemplateService {
         return request;
     }
 
+    public PushNotificationRequest diferenciaMaletinDetectada(Long cajaId, Long sucursalId, String sucursalNombre,
+            String maletinDescripcion, Double diferenciaGs, Double diferenciaRs, Double diferenciaDs,
+            Double diferenciaTotalGs, DecimalFormat decimalFormat) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("SE HA DETECTADO UNA DIFERENCIA EN EL MALETÍN");
+        if (maletinDescripcion != null && !maletinDescripcion.isEmpty()) {
+            builder.append(" ").append(maletinDescripcion.toUpperCase());
+        }
+        builder.append(" EN LA SUCURSAL ").append(sucursalNombre != null ? sucursalNombre : "")
+                .append(" POR EL VALOR DE ");
+        if (diferenciaGs != null && diferenciaGs != 0) {
+            builder.append(decimalFormat.format(Math.abs(diferenciaGs))).append(" Gs. ");
+        }
+        if (diferenciaRs != null && diferenciaRs != 0) {
+            builder.append(decimalFormat.format(Math.abs(diferenciaRs))).append(" Rs. ");
+        }
+        if (diferenciaDs != null && diferenciaDs != 0) {
+            builder.append(decimalFormat.format(Math.abs(diferenciaDs))).append(" Ds. ");
+        }
+        PushNotificationRequest request = base("DIFERENCIA EN MALETÍN", builder.toString());
+        request.setType("DIFERENCIA_MALETIN");
+        request.setData("/financiero/analisis-diferencia/" + (cajaId != null ? cajaId : "") + "/"
+                + (sucursalId != null ? sucursalId : ""));
+        return request;
+    }
+
     public PushNotificationRequest ventaTransferenciaRealizada(Venta venta, Sucursal sucursal, Double valorTotal,
             DecimalFormat decimalFormat) {
         return ventaTransferenciaRealizada(

--- a/src/main/resources/db/migration/V149.3__add_notification_type_diferencia_maletin.sql
+++ b/src/main/resources/db/migration/V149.3__add_notification_type_diferencia_maletin.sql
@@ -1,0 +1,11 @@
+-- Habilita opt-out por usuario para la notificación DIFERENCIA_MALETIN,
+-- igual que VENTA_STOCK_CRITICO (ver V128.3 / V137.3).
+INSERT INTO configuraciones.notificacion_tipo_role (role_id, tipo_notificacion, descripcion, es_obligatorio, creado_en)
+SELECT r.id,
+       'DIFERENCIA_MALETIN',
+       'Alerta de diferencia detectada en maletín',
+       false,
+       NOW()
+FROM personas.role r
+WHERE r.nombre IN ('ANALISIS DE CAJA', 'ANALISIS CONTABLE', 'ANALISIS DE VENTA')
+ON CONFLICT (role_id, tipo_notificacion) DO NOTHING;


### PR DESCRIPTION
## Resumen
- Nueva notificación push `DIFERENCIA_MALETIN`, disparada por el frontend cuando la diferencia entre el cierre de la caja anterior y la apertura de la caja nueva que reutiliza el mismo maletín supera 20.000 Gs (mismo cálculo que la pantalla Análisis de Diferencias).
- Solo la reciben los roles `ANALISIS DE CAJA`, `ANALISIS CONTABLE` y `ANALISIS DE VENTA`; es desactivable por usuario (`notificacion_tipo_role` + `notificacion_preferencia_usuario`), igual que `VENTA_STOCK_CRITICO`.
- Fix adicional en `NotificationDispatchService`: la entidad `Notificacion` no se guardaba después de cada intento de envío (solo se guardaba el `NotificacionEnvioLog`), por lo que `intentosEnvio`, `ultimoError` y el pasaje a `FINALIZADA` nunca persistían en ningún tipo de notificación.

## Cómo probarlo
1. Cerrar una caja dejando una diferencia de conteo.
2. Abrir una caja nueva reutilizando el mismo maletín, con un conteo de apertura que no coincida con el cierre anterior por más de 20.000 Gs.
3. Verificar que llega la notificación push a un usuario con rol `ANALISIS DE CAJA`/`ANALISIS CONTABLE`/`ANALISIS DE VENTA`, y que el monto coincide con el que muestra Análisis de Diferencias.
4. Verificar que un usuario puede desactivarla desde Preferencias de notificaciones (mobile) y deja de recibirla.

## Impacto en DB
- Migración `V149.3` (aditiva, `INSERT ... ON CONFLICT DO NOTHING`): agrega filas en `configuraciones.notificacion_tipo_role` para `DIFERENCIA_MALETIN`. No modifica ni borra datos existentes. Probada manualmente contra bodega3 (dev).

## Riesgo
Bajo. Cambios aditivos; el fix de `NotificationDispatchService` es estrictamente correctivo (agrega un `save()` faltante) y no cambia el comportamiento de envío existente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)