### PR TITLE
fix(personas): persistir email en minúsculas

### DIFF
--- a/src/main/java/com/franco/dev/service/personas/PersonaService.java
+++ b/src/main/java/com/franco/dev/service/personas/PersonaService.java
@@ -55,7 +55,7 @@ public class PersonaService extends CrudService<Persona, PersonaRepository, Long
         if (entity.getDireccion() != null)
             entity.setDireccion(entity.getDireccion().toUpperCase());
         if (entity.getEmail() != null)
-            entity.setEmail(entity.getEmail().toUpperCase());
+            entity.setEmail(entity.getEmail().toLowerCase().trim());
         if (entity.getDocumento().contains("-")) {
             int index = entity.getDocumento().indexOf("-");
             entity.setDocumento(entity.getDocumento().substring(0, index));
@@ -86,7 +86,7 @@ public class PersonaService extends CrudService<Persona, PersonaRepository, Long
         if (entity.getDireccion() != null)
             entity.setDireccion(entity.getDireccion().toUpperCase());
         if (entity.getEmail() != null)
-            entity.setEmail(entity.getEmail().toUpperCase());
+            entity.setEmail(entity.getEmail().toLowerCase().trim());
 
         Persona p = super.save(entity);
         return p;


### PR DESCRIPTION
## Summary
- Persiste el email de persona en minúsculas (`toLowerCase().trim()`) en `save` y `saveLocal`.
- Nombre, apodo y dirección siguen normalizándose a mayúsculas.
- No incluye cambios de configuración local (`application.properties`).

## Test plan
- [ ] Guardar una persona con email en mayúsculas y verificar en DB que queda en minúsculas.
- [ ] Reabrir la persona y confirmar que el email se lee correctamente.

Made with [Cursor](https://cursor.com)