### PR TITLE
feat(productos): generar códigos EAN-13 internos (serie 2199)

### DIFF
--- a/src/main/java/com/franco/dev/graphql/productos/CodigoGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/productos/CodigoGraphQL.java
@@ -48,6 +48,10 @@ public class CodigoGraphQL implements GraphQLQueryResolver, GraphQLMutationResol
         return service.findByCodigo(texto);
     }
 
+    public String generarCodigoInterno() {
+        return service.generarCodigoInterno();
+    }
+
     public Boolean deleteCodigo(Long id) {
         Boolean ok = service.deleteById(id);
         return ok;

--- a/src/main/java/com/franco/dev/repository/productos/CodigoRepository.java
+++ b/src/main/java/com/franco/dev/repository/productos/CodigoRepository.java
@@ -33,4 +33,13 @@ public interface CodigoRepository extends HelperRepository<Codigo, Long> {
             "where c.principal = true and p.id = ?1 limit 1", nativeQuery = true)
     public Codigo findPrincipalByPresentacionId(Long id);
 
+    /**
+     * Máxima secuencia de 8 dígitos para códigos internos {@code 2199########X}.
+     */
+    @Query(value = "SELECT COALESCE(MAX(CAST(SUBSTRING(codigo FROM 5 FOR 8) AS BIGINT)), 0) " +
+            "FROM productos.codigo WHERE codigo ~ '^2199[0-9]{9}$'", nativeQuery = true)
+    Long findMaxInternalEan21Sequence();
+
+    boolean existsByCodigo(String codigo);
+
 }

--- a/src/main/java/com/franco/dev/service/productos/CodigoService.java
+++ b/src/main/java/com/franco/dev/service/productos/CodigoService.java
@@ -8,21 +8,26 @@ import com.franco.dev.repository.productos.CodigoRepository;
 import com.franco.dev.service.CrudService;
 import com.franco.dev.service.personas.UsuarioService;
 import com.franco.dev.service.productos.search.ProductoSearchIndexSyncService;
+import com.franco.dev.utilitarios.Ean13Utils;
 import graphql.GraphQLException;
-import lombok.AllArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.sql.PreparedStatement;
 import java.util.List;
 
+import org.hibernate.Session;
+
 @Service
-@AllArgsConstructor
 public class CodigoService extends CrudService<Codigo, CodigoRepository, Long> {
 
     @Autowired
-    private final CodigoRepository repository;
+    private CodigoRepository repository;
 
     @Autowired
     private UsuarioService usuarioService;
@@ -46,10 +51,43 @@ public class CodigoService extends CrudService<Codigo, CodigoRepository, Long> {
     @Autowired
     private Environment env;
 
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private static final int GENERAR_MAX_INTENTOS = 50;
+
     // funcion para buscar un Codigo por su codigo de barra
     public List<Codigo> findByCodigo(String texto) {
         texto = texto.replace(' ', '%');
         return repository.findByCodigo(texto.toUpperCase());
+    }
+
+    /**
+     * Próximo EAN-13 interno libre (prefijo {@link Ean13Utils#INTERNAL_PREFIX}).
+     * No persiste el registro; evita colisiones con UNIQUE(codigo).
+     */
+    @Transactional
+    public String generarCodigoInterno() {
+        // Lock de transacción via JDBC: pg_advisory_xact_lock retorna void (JDBC 1111)
+        // y Hibernate no puede mapearlo con createNativeQuery(...).getSingleResult().
+        entityManager.unwrap(Session.class).doWork(connection -> {
+            try (PreparedStatement ps = connection.prepareStatement(
+                    "SELECT pg_advisory_xact_lock(?)")) {
+                ps.setLong(1, 87219901L);
+                ps.execute();
+            }
+        });
+
+        Long maxSeq = repository.findMaxInternalEan21Sequence();
+        long next = (maxSeq == null ? 0L : maxSeq) + 1;
+
+        for (int i = 0; i < GENERAR_MAX_INTENTOS; i++) {
+            String candidato = Ean13Utils.fromInternalSequence(next + i);
+            if (!repository.existsByCodigo(candidato)) {
+                return candidato;
+            }
+        }
+        throw new GraphQLException("No se pudo generar un código interno único. Intente de nuevo.");
     }
 
     public Codigo save(CodigoInput input) throws GraphQLException {

--- a/src/main/java/com/franco/dev/utilitarios/Ean13Utils.java
+++ b/src/main/java/com/franco/dev/utilitarios/Ean13Utils.java
@@ -1,0 +1,57 @@
+package com.franco.dev.utilitarios;
+
+/**
+ * Generación / validación de EAN-13 para códigos internos in-house.
+ * Prefijo comercial interno Franco: {@value #INTERNAL_PREFIX} (subrango de 21…,
+ * evitando 20… reservado para productos de balanza).
+ */
+public final class Ean13Utils {
+
+    /** Prefijo de 4 dígitos + secuencia de 8 = 12 dígitos de datos. */
+    public static final String INTERNAL_PREFIX = "2199";
+
+    private static final int SEQ_DIGITS = 8;
+    private static final long MAX_SEQ = 99_999_999L;
+
+    private Ean13Utils() {
+    }
+
+    /**
+     * Construye un EAN-13: {@code prefix(4) + seq(8) + checkDigit}.
+     */
+    public static String fromInternalSequence(long sequence) {
+        if (sequence < 1 || sequence > MAX_SEQ) {
+            throw new IllegalArgumentException("Secuencia EAN interna fuera de rango: " + sequence);
+        }
+        String body12 = INTERNAL_PREFIX + String.format("%0" + SEQ_DIGITS + "d", sequence);
+        return body12 + checkDigit(body12);
+    }
+
+    /**
+     * Dígito de control EAN/UPC para exactamente 12 dígitos.
+     */
+    public static char checkDigit(String twelveDigits) {
+        if (twelveDigits == null || !twelveDigits.matches("\\d{12}")) {
+            throw new IllegalArgumentException("Se requieren 12 dígitos para checksum EAN-13");
+        }
+        int sum = 0;
+        for (int i = 0; i < 12; i++) {
+            int digit = twelveDigits.charAt(i) - '0';
+            // índices pares (desde 0) ×1, impares ×3
+            sum += (i % 2 == 0) ? digit : digit * 3;
+        }
+        int mod = sum % 10;
+        return (char) ('0' + ((mod == 0) ? 0 : (10 - mod)));
+    }
+
+    public static boolean isValidEan13(String code) {
+        if (code == null || !code.matches("\\d{13}")) {
+            return false;
+        }
+        return checkDigit(code.substring(0, 12)) == code.charAt(12);
+    }
+
+    public static boolean isInternalGenerated(String code) {
+        return code != null && code.matches("^" + INTERNAL_PREFIX + "\\d{9}$") && isValidEan13(code);
+    }
+}

--- a/src/main/resources/graphql/productos/producto/codigo.graphqls
+++ b/src/main/resources/graphql/productos/producto/codigo.graphqls
@@ -23,6 +23,11 @@ extend type Query {
     countCodigo: Int
     codigoPorCodigo(texto:String):[Codigo]
     codigosPorPresentacionId(id:Int):[Codigo]
+    """
+    Genera el próximo EAN-13 interno (prefijo 2199 + secuencia + check digit).
+    No lo persiste: el cliente lo guarda con saveCodigo. Se imprime como CODE128 en la app.
+    """
+    generarCodigoInterno: String!
 }
 
 extend type Mutation {


### PR DESCRIPTION
## Summary
- Agrega query GraphQL `generarCodigoInterno` con secuencia atómica y check digit EAN-13.
- Serie interna `2199…` (evita prefijo `20` de balanza).
- No persiste hasta `saveCodigo`; la unicidad queda respaldada por `UNIQUE(codigo)`.

## Test plan
- [ ] Llamar `generarCodigoInterno` y verificar formato `2199` + 8 dígitos + check
- [ ] Guardar el código generado y confirmar que no se puede duplicar
- [ ] Generar varios seguidos tras guardar y verificar secuencia creciente
- [ ] Confirmar que códigos de balanza / prefijo `20` no se ven afectados


Made with [Cursor](https://cursor.com)