### PR TITLE
fix(productos): normalizar token antes del wildcard en busqueda Lucene

### DIFF
--- a/src/main/java/com/franco/dev/service/productos/search/ProductoSearchService.java
+++ b/src/main/java/com/franco/dev/service/productos/search/ProductoSearchService.java
@@ -80,9 +80,12 @@ public class ProductoSearchService {
 
     private PredicateFinalStep crearPredicadoToken(SearchPredicateFactory f, String token) {
         return f.bool(tokenBool -> {
+            // wildcard() no pasa el patron por el analyzer del campo (a diferencia de match()),
+            // por lo que hay que normalizarlo a mano para que coincida con el indice (lowercase + sin tildes).
+            String tokenWildcard = ProductoTextoRelevanceScorer.normalizar(token);
             tokenBool.should(f.wildcard()
                     .fields("descripcion", "descripcionFactura")
-                    .matching(token + "*")
+                    .matching(tokenWildcard + "*")
                     .boost(BOOST_PREFIJO));
 
             int fuzzyDistance = ProductoTextoRelevanceScorer.distanciaFuzzyMaxima(token.length());


### PR DESCRIPTION
## Que resuelve

El buscador de productos por texto (usado en los dialogos de Transferencia y Compras, via `productoService.onSearch` -> resolver GraphQL `productoSearch` -> `ProductoSearchService`) no devolvia resultados al filtrar por **descripcion**, mientras que la busqueda por **codigo** si funcionaba (porque no pasa por Lucene, usa consulta JPA directa).

Causa raiz: en `crearPredicadoToken` (`ProductoSearchService.java`), el predicado `f.wildcard()` de Hibernate Search **no pasa el patron de busqueda por el analyzer del campo** (a diferencia de `f.match()`), por lo que se comparaba el texto ingresado tal cual contra el indice Lucene. El indice esta normalizado a minusculas y sin tildes (`ProductoAnalysisConfigurer`), pero las descripciones se guardan en MAYUSCULAS en la BD, asi que el wildcard nunca matcheaba.

Fix: se normaliza el token (lowercase + sin tildes) con `ProductoTextoRelevanceScorer.normalizar()` antes de armar el patron `wildcard()`, igual que ya se hacia implicitamente para el `match()` fuzzy.

## Como probarlo

1. Levantar backend + frontend.
2. Abrir el dialogo de busqueda de productos en **Transferencia** o **Compras**.
3. Buscar por una palabra de la descripcion de un producto existente (ej: "aceite", "ACEITE", "aceite girasol"), con distintas combinaciones de mayusculas/minusculas y con/sin tildes.
4. Verificar que el producto aparece en los resultados (antes del fix, no aparecia nada).
5. Verificar que la busqueda por codigo sigue funcionando igual que antes (no se toco ese camino).

Verificado localmente: reproducido el bug, aplicado el fix, y confirmado que la busqueda por descripcion ahora devuelve resultados correctamente en ambos modulos.

## Impacto en DB

Ninguno. No hay migraciones ni cambios de esquema.

## Impacto en rollback

Ninguno. Cambio acotado a la construccion del predicado de busqueda en memoria, no persiste estado ni requiere reindexacion. Revertir el commit es seguro en cualquier momento.

## Riesgo

**Bajo.** Cambio de una linea logica (normalizacion de un string antes de un predicado de busqueda), sin tocar el schema del indice, la API GraphQL ni el comportamiento de la busqueda por codigo.