### PR TITLE
feat(venta): reporte detallado de ventas (items, movimientos, observaciones)

### DIFF
--- a/src/main/java/com/franco/dev/domain/operaciones/dto/MovimientoReporteDetalladoDto.java
+++ b/src/main/java/com/franco/dev/domain/operaciones/dto/MovimientoReporteDetalladoDto.java
@@ -1,0 +1,19 @@
+package com.franco.dev.domain.operaciones.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO para cada fila de movimiento de cobro del reporte detallado de ventas (subreport de movimientos).
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class MovimientoReporteDetalladoDto {
+    private String operacion;
+    private String formaPago;
+    private String moneda;
+    private Double valorEnMoneda;
+    private Double valorEnGs;
+}

--- a/src/main/java/com/franco/dev/domain/operaciones/dto/ReporteVentaDetalladoDto.java
+++ b/src/main/java/com/franco/dev/domain/operaciones/dto/ReporteVentaDetalladoDto.java
@@ -1,0 +1,37 @@
+package com.franco.dev.domain.operaciones.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import net.sf.jasperreports.engine.JRDataSource;
+
+/**
+ * DTO para cada venta del reporte detallado de ventas (JasperReports datasource principal).
+ * Encabezado de la venta + 3 sub-datasources (items, movimientos, observaciones) consumidos
+ * por componentes jr:list del jrxml, uno por venta.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReporteVentaDetalladoDto {
+    private Long ventaId;
+    private String sucursal;
+    private String cliente;
+    private String fecha;
+    private String formaPago;
+    private String moneda;
+    private String estado;
+    private String responsable;
+    private Double totalGs;
+    private Double totalRecibidoGs;
+    private Double totalRecibidoRs;
+    private Double totalRecibidoDs;
+    private Double totalRecibido;
+    private Double totalDescuento;
+    private Double totalAumento;
+    private Double totalFinal;
+    private Double costoTotalVenta;
+    private JRDataSource itemsDataSource;
+    private JRDataSource movimientosDataSource;
+    private JRDataSource observacionesDataSource;
+}

--- a/src/main/java/com/franco/dev/domain/operaciones/dto/VentaItemReporteDetalladoDto.java
+++ b/src/main/java/com/franco/dev/domain/operaciones/dto/VentaItemReporteDetalladoDto.java
@@ -1,0 +1,21 @@
+package com.franco.dev.domain.operaciones.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO para cada fila de producto del reporte detallado de ventas (subreport de items).
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class VentaItemReporteDetalladoDto {
+    private String producto;
+    private String presentacion;
+    private Double cantidad;
+    private Double precio;
+    private Double precioCosto;
+    private Double costoTotal;
+    private Double total;
+}

--- a/src/main/java/com/franco/dev/domain/operaciones/dto/VentaObservacionReporteDetalladoDto.java
+++ b/src/main/java/com/franco/dev/domain/operaciones/dto/VentaObservacionReporteDetalladoDto.java
@@ -1,0 +1,17 @@
+package com.franco.dev.domain.operaciones.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO para cada fila de observación del reporte detallado de ventas (subreport de observaciones).
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class VentaObservacionReporteDetalladoDto {
+    private String fecha;
+    private String descripcion;
+    private String motivo;
+}

--- a/src/main/java/com/franco/dev/graphql/operaciones/VentaGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/VentaGraphQL.java
@@ -14,6 +14,10 @@ import com.franco.dev.domain.operaciones.VentaItem;
 import com.franco.dev.domain.operaciones.VentaPorFuncionario;
 import com.franco.dev.domain.operaciones.VentaPorSucursal;
 import com.franco.dev.domain.operaciones.dto.LucroPorFuncionarioDto;
+import com.franco.dev.domain.operaciones.dto.MovimientoReporteDetalladoDto;
+import com.franco.dev.domain.operaciones.dto.ReporteVentaDetalladoDto;
+import com.franco.dev.domain.operaciones.dto.VentaItemReporteDetalladoDto;
+import com.franco.dev.domain.operaciones.dto.VentaObservacionReporteDetalladoDto;
 import com.franco.dev.domain.operaciones.dto.VentaPorPeriodoV1Dto;
 import com.franco.dev.domain.operaciones.enums.VentaEstado;
 import com.franco.dev.domain.personas.Cliente;
@@ -59,6 +63,7 @@ import com.franco.dev.utilitarios.print.escpos.image.*;
 import com.franco.dev.utilitarios.print.output.PrinterOutputStream;
 import graphql.kickstart.tools.GraphQLMutationResolver;
 import graphql.kickstart.tools.GraphQLQueryResolver;
+import net.sf.jasperreports.engine.data.JRBeanCollectionDataSource;
 import org.modelmapper.ModelMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -131,6 +136,9 @@ public class VentaGraphQL implements GraphQLQueryResolver, GraphQLMutationResolv
 
     @Autowired
     private CobroDetalleService cobroDetalleService;
+
+    @Autowired
+    private VentaObservacionService ventaObservacionService;
 
     @Autowired
     private MonedaService monedaService;
@@ -624,6 +632,268 @@ public class VentaGraphQL implements GraphQLQueryResolver, GraphQLMutationResolv
         String filtroIdVentaStr  = idVenta        != null ? idVenta.toString() : "Todos";
 
         return impresionService.imprimirReporteGenericVentas(
+                itemList,
+                filtroIdVentaStr,
+                fechaInicio != null ? fechaInicio : "-",
+                fechaFin    != null ? fechaFin    : "-",
+                filtroSucursalStr, filtroFpStr, filtroMonedaStr,
+                filtroEstadoStr, filtroClienteStr,
+                filtroModoStr, filtroConObsStr, filtroConDescStr, filtroConAumStr,
+                totalGeneral, totalEfectivo, totalTarjeta,
+                totalConvenio, totalTransferencia, totalOtros,
+                usuario);
+    }
+
+    public String reporteGenericVentasDetallado(
+            Long idVenta,
+            Long idCaja,
+            Long sucId,
+            Long formaPago,
+            VentaEstado estado,
+            Boolean isDelivery,
+            Long monedaId,
+            Boolean conDescuento,
+            Boolean conAumento,
+            Boolean conObservacion,
+            Long clienteId,
+            String fechaInicio,
+            String fechaFin,
+            Long usuarioId) {
+
+        // Cargar todas las ventas sin límite de paginación
+        Pageable allPages = PageRequest.of(0, Integer.MAX_VALUE);
+        Page<Venta> ventaPage = service.onGenericSearch(
+                idVenta, idCaja, allPages, false,
+                sucId, formaPago, estado, isDelivery, monedaId,
+                conDescuento, conAumento, conObservacion, clienteId,
+                fechaInicio, fechaFin);
+
+        List<Venta> ventas = ventaPage.getContent();
+
+        // Acumuladores de totales por forma de pago (en Gs.)
+        double totalGeneral       = 0.0;
+        double totalEfectivo      = 0.0;
+        double totalTarjeta       = 0.0;
+        double totalConvenio      = 0.0;
+        double totalTransferencia = 0.0;
+        double totalOtros         = 0.0;
+
+        List<ReporteVentaDetalladoDto> itemList = new ArrayList<>();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
+
+        for (Venta v : ventas) {
+            double ventaTotalGs = v.getTotalGs() != null ? v.getTotalGs() : 0.0;
+            totalGeneral += ventaTotalGs;
+
+            // Resolver forma de pago y moneda usando la lógica del VentaResolver:
+            // si la venta no tiene formaPago directo, buscar en el cobro
+            FormaPago fp = v.getFormaPago();
+            Moneda moneda = null;
+            List<CobroDetalle> cobroDetalleList = new ArrayList<>();
+            if (v.getCobro() != null) {
+                cobroDetalleList = cobroDetalleService.findByCobroId(
+                        v.getCobro().getId(), v.getSucursalId());
+                if (cobroDetalleList != null && !cobroDetalleList.isEmpty()) {
+                    CobroDetalle primerDetalle = cobroDetalleList.get(0);
+                    if (fp == null) {
+                        fp = primerDetalle.getFormaPago();
+                    }
+                    moneda = primerDetalle.getMoneda();
+                }
+            }
+
+            String fpDesc = fp != null && fp.getDescripcion() != null
+                    ? fp.getDescripcion().toUpperCase() : "";
+
+            if (fpDesc.contains("EFECTIVO")) {
+                totalEfectivo += ventaTotalGs;
+            } else if (fpDesc.contains("TARJETA")) {
+                totalTarjeta += ventaTotalGs;
+            } else if (fpDesc.contains("CONVENIO")) {
+                totalConvenio += ventaTotalGs;
+            } else if (fpDesc.contains("TRANSFERENCIA")) {
+                totalTransferencia += ventaTotalGs;
+            } else {
+                totalOtros += ventaTotalGs;
+            }
+
+            // Items de la venta (producto, presentación, cantidad, precio, costo unitario/total)
+            List<VentaItem> ventaItemList = ventaItemService.findByVentaId(v.getId(), v.getSucursalId());
+            List<VentaItemReporteDetalladoDto> itemsDto = new ArrayList<>();
+            double costoTotalVenta = 0.0;
+            for (VentaItem vi : ventaItemList) {
+                double cantidad = vi.getCantidad() != null ? vi.getCantidad() : 0.0;
+                double precioCosto = vi.getPrecioCosto() != null ? vi.getPrecioCosto() : 0.0;
+                double precio = vi.getPrecio() != null ? vi.getPrecio() : 0.0;
+                double costoTotalItem = precioCosto * cantidad;
+                costoTotalVenta += costoTotalItem;
+                itemsDto.add(new VentaItemReporteDetalladoDto(
+                        vi.getProducto() != null ? vi.getProducto().getDescripcion() : "",
+                        vi.getPresentacion() != null ? vi.getPresentacion().getDescripcion() : "",
+                        cantidad,
+                        precio,
+                        precioCosto,
+                        costoTotalItem,
+                        vi.getPrecio() != null && vi.getCantidad() != null ? precio * cantidad : 0.0));
+            }
+
+            // Movimientos de cobro (operación, forma de pago, moneda, valor en moneda/Gs) y totales
+            List<MovimientoReporteDetalladoDto> movimientosDto = new ArrayList<>();
+            double totalRecibidoGs = 0.0;
+            double totalRecibidoRs = 0.0;
+            double totalRecibidoDs = 0.0;
+            double totalRecibido = 0.0;
+            double totalDescuento = 0.0;
+            double totalAumento = 0.0;
+            double totalFinal = 0.0;
+            for (CobroDetalle cd : cobroDetalleList) {
+                String operacion = cd.getPago() != null && cd.getPago() ? "PAGO"
+                        : cd.getDescuento() != null && cd.getDescuento() ? "DESCUENTO"
+                        : cd.getAumento() != null && cd.getAumento() ? "AUMENTO"
+                        : cd.getVuelto() != null && cd.getVuelto() ? "VUELTO"
+                        : "PROBLEMA";
+                double valor = cd.getValor() != null ? cd.getValor() : 0.0;
+                double cambio = cd.getCambio() != null ? cd.getCambio() : 1.0;
+                String denominacion = cd.getMoneda() != null && cd.getMoneda().getDenominacion() != null
+                        ? cd.getMoneda().getDenominacion() : "";
+
+                movimientosDto.add(new MovimientoReporteDetalladoDto(
+                        operacion,
+                        cd.getFormaPago() != null ? cd.getFormaPago().getDescripcion() : "",
+                        denominacion,
+                        valor,
+                        valor * cambio));
+
+                boolean recibido = (cd.getPago() != null && cd.getPago()) || (cd.getVuelto() != null && cd.getVuelto());
+                boolean aumento = cd.getAumento() != null && cd.getAumento();
+                boolean descuento = cd.getDescuento() != null && cd.getDescuento();
+                if ("GUARANI".equals(denominacion)) {
+                    if (recibido) {
+                        totalRecibidoGs += valor;
+                        totalRecibido += valor;
+                        totalFinal += valor;
+                    } else if (aumento) {
+                        totalAumento += valor;
+                        totalFinal += valor;
+                    } else if (descuento) {
+                        totalDescuento += valor;
+                    }
+                } else if ("REAL".equals(denominacion)) {
+                    if (recibido) {
+                        totalRecibidoRs += valor;
+                        totalRecibido += valor * cambio;
+                        totalFinal += valor * cambio;
+                    } else if (aumento) {
+                        totalAumento += valor * cambio;
+                        totalFinal += valor * cambio;
+                    } else if (descuento) {
+                        totalDescuento += valor * cambio;
+                    }
+                } else if ("DOLAR".equals(denominacion)) {
+                    if (recibido) {
+                        totalRecibidoDs += valor;
+                        totalRecibido += valor * cambio;
+                        totalFinal += valor * cambio;
+                    } else if (aumento) {
+                        totalAumento += valor * cambio;
+                        totalFinal += valor * cambio;
+                    } else if (descuento) {
+                        totalDescuento += valor * cambio;
+                    }
+                }
+            }
+
+            // Observaciones de la venta (descripción + motivo)
+            List<VentaObservacion> ventaObservacionList = ventaObservacionService
+                    .findByVentaIdAndSucursalId(v.getId(), v.getSucursalId());
+            List<VentaObservacionReporteDetalladoDto> observacionesDto = new ArrayList<>();
+            for (VentaObservacion vo : ventaObservacionList) {
+                observacionesDto.add(new VentaObservacionReporteDetalladoDto(
+                        vo.getCreadoEn() != null ? vo.getCreadoEn().format(formatter) : "",
+                        vo.getDescripcion() != null ? vo.getDescripcion() : "",
+                        vo.getMotivoObservacion() != null && vo.getMotivoObservacion().getDescripcion() != null
+                                ? vo.getMotivoObservacion().getDescripcion() : ""));
+            }
+
+            ReporteVentaDetalladoDto dto = new ReporteVentaDetalladoDto();
+            dto.setVentaId(v.getId());
+            dto.setSucursal(v.getSucursal() != null ? v.getSucursal().getNombre() : "");
+            dto.setCliente(v.getCliente() != null && v.getCliente().getPersona() != null
+                    ? v.getCliente().getPersona().getNombre() : "");
+            dto.setFecha(v.getCreadoEn() != null ? v.getCreadoEn().format(formatter) : "");
+            dto.setFormaPago(fp != null && fp.getDescripcion() != null ? fp.getDescripcion() : "");
+            dto.setMoneda(moneda != null && moneda.getDenominacion() != null ? moneda.getDenominacion() : "");
+            dto.setEstado(v.getEstado() != null ? v.getEstado().toString() : "");
+            dto.setResponsable(v.getUsuario() != null && v.getUsuario().getNickname() != null
+                    ? v.getUsuario().getNickname() : "");
+            dto.setTotalGs(ventaTotalGs);
+            dto.setTotalRecibidoGs(totalRecibidoGs);
+            dto.setTotalRecibidoRs(totalRecibidoRs);
+            dto.setTotalRecibidoDs(totalRecibidoDs);
+            dto.setTotalRecibido(totalRecibido);
+            dto.setTotalDescuento(totalDescuento);
+            dto.setTotalAumento(totalAumento);
+            dto.setTotalFinal(totalFinal);
+            dto.setCostoTotalVenta(costoTotalVenta);
+            dto.setItemsDataSource(new JRBeanCollectionDataSource(itemsDto));
+            dto.setMovimientosDataSource(new JRBeanCollectionDataSource(movimientosDto));
+            dto.setObservacionesDataSource(new JRBeanCollectionDataSource(observacionesDto));
+            itemList.add(dto);
+        }
+
+        // Resolver nombres reales de los filtros (idéntico a reporteGenericVentas)
+        Usuario usuario = usuarioId != null
+                ? usuarioService.findById(usuarioId).orElse(null) : null;
+
+        String filtroSucursalStr;
+        if (sucId != null) {
+            Sucursal suc = sucursalService.findById(sucId).orElse(null);
+            filtroSucursalStr = suc != null ? suc.getNombre() : "Sucursal " + sucId;
+        } else {
+            filtroSucursalStr = "Todas";
+        }
+
+        String filtroFpStr;
+        if (formaPago != null) {
+            FormaPago fp = formaPagoService.findById(formaPago).orElse(null);
+            filtroFpStr = fp != null ? fp.getDescripcion() : "FormaPago " + formaPago;
+        } else {
+            filtroFpStr = "Todas";
+        }
+
+        String filtroMonedaStr;
+        if (monedaId != null) {
+            Moneda m = monedaService.findById(monedaId).orElse(null);
+            filtroMonedaStr = m != null ? m.getDenominacion() : "Moneda " + monedaId;
+        } else {
+            filtroMonedaStr = "Todas";
+        }
+
+        String filtroEstadoStr  = estado    != null ? estado.toString() : "Todos";
+        String filtroClienteStr;
+        if (clienteId != null) {
+            Cliente c = clienteService.findById(clienteId).orElse(null);
+            filtroClienteStr = (c != null && c.getPersona() != null) ? c.getPersona().getNombre() : "ID: " + clienteId;
+        } else {
+            filtroClienteStr = "Todos";
+        }
+
+        String filtroModoStr;
+        if (isDelivery == null) {
+            filtroModoStr = "Todos";
+        } else if (isDelivery) {
+            filtroModoStr = "Delivery";
+        } else {
+            filtroModoStr = "Local";
+        }
+
+        String filtroConObsStr   = conObservacion != null && conObservacion ? "Sí" : "Todos";
+        String filtroConDescStr  = conDescuento   != null && conDescuento   ? "Sí" : "Todos";
+        String filtroConAumStr   = conAumento     != null && conAumento     ? "Sí" : "Todos";
+
+        String filtroIdVentaStr  = idVenta        != null ? idVenta.toString() : "Todos";
+
+        return impresionService.imprimirReporteGenericVentasDetallado(
                 itemList,
                 filtroIdVentaStr,
                 fechaInicio != null ? fechaInicio : "-",

--- a/src/main/java/com/franco/dev/graphql/operaciones/VentaGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/VentaGraphQL.java
@@ -814,6 +814,9 @@ public class VentaGraphQL implements GraphQLQueryResolver, GraphQLMutationResolv
                         vo.getMotivoObservacion() != null && vo.getMotivoObservacion().getDescripcion() != null
                                 ? vo.getMotivoObservacion().getDescripcion() : ""));
             }
+            if (observacionesDto.isEmpty()) {
+                observacionesDto.add(new VentaObservacionReporteDetalladoDto("", "Sin observaciones", "Sin motivos"));
+            }
 
             ReporteVentaDetalladoDto dto = new ReporteVentaDetalladoDto();
             dto.setVentaId(v.getId());

--- a/src/main/java/com/franco/dev/service/impresion/ImpresionService.java
+++ b/src/main/java/com/franco/dev/service/impresion/ImpresionService.java
@@ -15,6 +15,7 @@ import com.franco.dev.domain.operaciones.SolicitudPago;
 import com.franco.dev.domain.operaciones.dto.LucroPorFuncionarioDto;
 import com.franco.dev.domain.operaciones.dto.LucroPorProductosDto;
 import com.franco.dev.domain.operaciones.dto.ReporteVentaItemDto;
+import com.franco.dev.domain.operaciones.dto.ReporteVentaDetalladoDto;
 import com.franco.dev.domain.personas.Cliente;
 import com.franco.dev.domain.personas.Usuario;
 import com.franco.dev.domain.productos.Codigo;
@@ -1626,6 +1627,63 @@ public class ImpresionService {
             e.printStackTrace();
             return null;
         } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    public String imprimirReporteGenericVentasDetallado(
+            List<ReporteVentaDetalladoDto> itemList,
+            String filtroIdVenta,
+            String filtroFechaInicio,
+            String filtroFechaFin,
+            String filtroSucursal,
+            String filtroFormaPago,
+            String filtroMoneda,
+            String filtroEstado,
+            String filtroCliente,
+            String filtroModo,
+            String filtroConObservacion,
+            String filtroConDescuento,
+            String filtroConAumento,
+            Double totalGeneral,
+            Double totalEfectivo,
+            Double totalTarjeta,
+            Double totalConvenio,
+            Double totalTransferencia,
+            Double totalOtros,
+            Usuario usuario) {
+        try {
+            JasperReport jasperReport = compileReportFromClasspath("reports/reporte-ventas-detallado.jrxml");
+            JRBeanCollectionDataSource dataSource = new JRBeanCollectionDataSource(
+                    itemList != null ? itemList : new ArrayList<>());
+            Map<String, Object> parameters = new HashMap<>();
+            parameters.put("fechaReporte", DateUtils.toString(LocalDateTime.now()));
+            parameters.put("usuario", usuario != null ? usuario.getNickname() : "");
+            parameters.put("logo", imageService.getImagePath() + File.separator + "logo.png");
+            parameters.put("filtroIdVenta", filtroIdVenta != null ? filtroIdVenta : "");
+            parameters.put("filtroFechaInicio", filtroFechaInicio != null ? filtroFechaInicio : "");
+            parameters.put("filtroFechaFin", filtroFechaFin != null ? filtroFechaFin : "");
+            parameters.put("filtroSucursal", filtroSucursal != null ? filtroSucursal : "");
+            parameters.put("filtroFormaPago", filtroFormaPago != null ? filtroFormaPago : "");
+            parameters.put("filtroMoneda", filtroMoneda != null ? filtroMoneda : "");
+            parameters.put("filtroEstado", filtroEstado != null ? filtroEstado : "");
+            parameters.put("filtroCliente", filtroCliente != null ? filtroCliente : "");
+            parameters.put("filtroModo", filtroModo != null ? filtroModo : "");
+            parameters.put("filtroConObservacion", filtroConObservacion != null ? filtroConObservacion : "");
+            parameters.put("filtroConDescuento", filtroConDescuento != null ? filtroConDescuento : "");
+            parameters.put("filtroConAumento", filtroConAumento != null ? filtroConAumento : "");
+            parameters.put("totalGeneral", totalGeneral != null ? totalGeneral : 0.0);
+            parameters.put("totalEfectivo", totalEfectivo != null ? totalEfectivo : 0.0);
+            parameters.put("totalTarjeta", totalTarjeta != null ? totalTarjeta : 0.0);
+            parameters.put("totalConvenio", totalConvenio != null ? totalConvenio : 0.0);
+            parameters.put("totalTransferencia", totalTransferencia != null ? totalTransferencia : 0.0);
+            parameters.put("totalOtros", totalOtros != null ? totalOtros : 0.0);
+            parameters.put("cantidadVentas", itemList != null ? (long) itemList.size() : 0L);
+            JasperPrint jasperPrint = JasperFillManager.fillReport(jasperReport, parameters, dataSource);
+            byte[] pdfBytes = JasperExportManager.exportReportToPdf(jasperPrint);
+            return Base64.getEncoder().encodeToString(pdfBytes);
+        } catch (JRException e) {
             e.printStackTrace();
             return null;
         }

--- a/src/main/resources/graphql/operaciones/venta.graphqls
+++ b/src/main/resources/graphql/operaciones/venta.graphqls
@@ -118,6 +118,22 @@ extend type Query {
         fechaFin: String
         usuarioId: ID
     ): String
+    reporteGenericVentasDetallado(
+        idVenta: ID
+        idCaja: ID
+        sucId: ID
+        formaPago: ID
+        estado: VentaEstado
+        isDelivery: Boolean
+        monedaId: Int
+        conDescuento: Boolean
+        conAumento: Boolean
+        conObservacion: Boolean
+        clienteId: ID
+        fechaInicio: String
+        fechaFin: String
+        usuarioId: ID
+    ): String
 #    ventaPorPeriodo(inicio:String, fin:String, sucId: ID): [VentaPorPeriodo]
 #    ventaPorSucursal(inicio:String, fin:String): [VentaPorSucursal]
 }

--- a/src/main/resources/reports/reporte-ventas-detallado.jrxml
+++ b/src/main/resources/reports/reporte-ventas-detallado.jrxml
@@ -1,0 +1,837 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="reporte-ventas-detallado" pageWidth="842" pageHeight="595" orientation="Landscape" whenNoDataType="AllSectionsNoDetail" columnWidth="802" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isFloatColumnFooter="true" uuid="b2c3d4e5-f6a7-8901-bcde-f12345678901">
+	<subDataset name="ItemsDataset" uuid="c1a2b3c4-d5e6-4f7a-8b9c-0d1e2f3a4b01">
+		<field name="producto" class="java.lang.String"/>
+		<field name="presentacion" class="java.lang.String"/>
+		<field name="cantidad" class="java.lang.Double"/>
+		<field name="precio" class="java.lang.Double"/>
+		<field name="precioCosto" class="java.lang.Double"/>
+		<field name="costoTotal" class="java.lang.Double"/>
+		<field name="total" class="java.lang.Double"/>
+	</subDataset>
+	<subDataset name="MovimientosDataset" uuid="c1a2b3c4-d5e6-4f7a-8b9c-0d1e2f3a4b02">
+		<field name="operacion" class="java.lang.String"/>
+		<field name="formaPago" class="java.lang.String"/>
+		<field name="moneda" class="java.lang.String"/>
+		<field name="valorEnMoneda" class="java.lang.Double"/>
+		<field name="valorEnGs" class="java.lang.Double"/>
+	</subDataset>
+	<subDataset name="ObservacionesDataset" uuid="c1a2b3c4-d5e6-4f7a-8b9c-0d1e2f3a4b03">
+		<field name="fecha" class="java.lang.String"/>
+		<field name="descripcion" class="java.lang.String"/>
+		<field name="motivo" class="java.lang.String"/>
+	</subDataset>
+	<parameter name="fechaReporte" class="java.lang.String"/>
+	<parameter name="usuario" class="java.lang.String"/>
+	<parameter name="logo" class="java.lang.String"/>
+	<parameter name="filtroFechaInicio" class="java.lang.String"/>
+	<parameter name="filtroFechaFin" class="java.lang.String"/>
+	<parameter name="filtroSucursal" class="java.lang.String"/>
+	<parameter name="filtroFormaPago" class="java.lang.String"/>
+	<parameter name="filtroMoneda" class="java.lang.String"/>
+	<parameter name="filtroEstado" class="java.lang.String"/>
+	<parameter name="filtroCliente" class="java.lang.String"/>
+	<parameter name="filtroModo" class="java.lang.String"/>
+	<parameter name="filtroConObservacion" class="java.lang.String"/>
+	<parameter name="filtroConDescuento" class="java.lang.String"/>
+	<parameter name="filtroConAumento" class="java.lang.String"/>
+	<parameter name="totalGeneral" class="java.lang.Double"/>
+	<parameter name="totalEfectivo" class="java.lang.Double"/>
+	<parameter name="totalTarjeta" class="java.lang.Double"/>
+	<parameter name="totalConvenio" class="java.lang.Double"/>
+	<parameter name="totalTransferencia" class="java.lang.Double"/>
+	<parameter name="totalOtros" class="java.lang.Double"/>
+	<parameter name="cantidadVentas" class="java.lang.Long"/>
+	<parameter name="filtroIdVenta" class="java.lang.String"/>
+	<queryString>
+		<![CDATA[]]>
+	</queryString>
+	<field name="ventaId" class="java.lang.Long"/>
+	<field name="sucursal" class="java.lang.String"/>
+	<field name="cliente" class="java.lang.String"/>
+	<field name="fecha" class="java.lang.String"/>
+	<field name="formaPago" class="java.lang.String"/>
+	<field name="moneda" class="java.lang.String"/>
+	<field name="estado" class="java.lang.String"/>
+	<field name="responsable" class="java.lang.String"/>
+	<field name="totalGs" class="java.lang.Double"/>
+	<field name="totalRecibidoGs" class="java.lang.Double"/>
+	<field name="totalRecibidoRs" class="java.lang.Double"/>
+	<field name="totalRecibidoDs" class="java.lang.Double"/>
+	<field name="totalRecibido" class="java.lang.Double"/>
+	<field name="totalDescuento" class="java.lang.Double"/>
+	<field name="totalAumento" class="java.lang.Double"/>
+	<field name="totalFinal" class="java.lang.Double"/>
+	<field name="costoTotalVenta" class="java.lang.Double"/>
+	<field name="itemsDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
+	<field name="movimientosDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
+	<field name="observacionesDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
+	<title>
+		<band height="148" splitType="Stretch">
+			<image hAlign="Center">
+				<reportElement x="10" y="51" width="100" height="76" uuid="11111111-1111-1111-1111-111111111101"/>
+				<imageExpression><![CDATA[$P{logo}]]></imageExpression>
+			</image>
+			<staticText>
+				<reportElement x="0" y="0" width="802" height="20" uuid="11111111-1111-1111-1111-111111111102"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="14" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Reporte Detallado de Ventas]]></text>
+			</staticText>
+			<rectangle>
+				<reportElement x="120" y="32" width="449" height="100" uuid="11111111-1111-1111-1111-111111111107"/>
+				<graphicElement>
+					<pen lineColor="#808080"/>
+				</graphicElement>
+			</rectangle>
+			<staticText>
+				<reportElement x="130" y="41" width="48" height="12" uuid="d2efc4a7-d380-4522-bb04-242ad853d7e3"/>
+				<textElement>
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[ID:]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="188" y="41" width="120" height="12" uuid="11111111-1111-1111-1111-111111111145"/>
+				<textElement>
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroIdVenta}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="130" y="53" width="58" height="12" uuid="11111111-1111-1111-1111-111111111109"/>
+				<textElement>
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Fecha inicio:]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="188" y="53" width="120" height="12" uuid="11111111-1111-1111-1111-111111111110"/>
+				<textElement>
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroFechaInicio}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="130" y="65" width="48" height="12" uuid="11111111-1111-1111-1111-111111111111"/>
+				<textElement>
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Fecha fin:]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="188" y="65" width="120" height="12" uuid="11111111-1111-1111-1111-111111111112"/>
+				<textElement>
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroFechaFin}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="130" y="77" width="48" height="12" uuid="11111111-1111-1111-1111-111111111113"/>
+				<textElement>
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Sucursal:]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="188" y="77" width="202" height="12" uuid="11111111-1111-1111-1111-111111111114"/>
+				<textElement>
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroSucursal}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="390" y="41" width="75" height="12" uuid="11111111-1111-1111-1111-111111111115"/>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Forma de pago:]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="475" y="41" width="84" height="12" uuid="11111111-1111-1111-1111-111111111116"/>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroFormaPago}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="426" y="53" width="39" height="12" uuid="11111111-1111-1111-1111-111111111133"/>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Moneda:]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="475" y="53" width="84" height="12" uuid="11111111-1111-1111-1111-111111111134"/>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroMoneda}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="426" y="65" width="39" height="12" uuid="11111111-1111-1111-1111-111111111117"/>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Estado:]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="475" y="65" width="84" height="12" uuid="11111111-1111-1111-1111-111111111118"/>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroEstado}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="130" y="89" width="48" height="12" uuid="11111111-1111-1111-1111-111111111119"/>
+				<textElement>
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Cliente:]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="188" y="89" width="212" height="12" uuid="11111111-1111-1111-1111-111111111120"/>
+				<textElement>
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroCliente}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="130" y="101" width="48" height="12" uuid="11111111-1111-1111-1111-111111111135"/>
+				<textElement textAlignment="Left">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Modo:]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="188" y="101" width="38" height="12" uuid="11111111-1111-1111-1111-111111111136"/>
+				<textElement>
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroModo}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="380" y="101" width="85" height="12" uuid="11111111-1111-1111-1111-111111111137"/>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Con observación:]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="475" y="101" width="84" height="12" uuid="11111111-1111-1111-1111-111111111138"/>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroConObservacion}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="391" y="77" width="74" height="12" uuid="11111111-1111-1111-1111-111111111139"/>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Con descuento:]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="475" y="77" width="84" height="12" uuid="11111111-1111-1111-1111-111111111140"/>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroConDescuento}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="400" y="89" width="65" height="12" uuid="11111111-1111-1111-1111-111111111141"/>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Con aumento:]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="475" y="89" width="84" height="12" uuid="11111111-1111-1111-1111-111111111142"/>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtroConAumento}]]></textFieldExpression>
+			</textField>
+			<rectangle>
+				<reportElement x="580" y="32" width="222" height="100" uuid="11111111-1111-1111-1111-111111111121"/>
+				<graphicElement>
+					<pen lineColor="#808080"/>
+				</graphicElement>
+			</rectangle>
+			<staticText>
+				<reportElement mode="Opaque" x="640" y="25" width="100" height="13" uuid="11111111-1111-1111-1111-111111111122">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Resumen General]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="590" y="41" width="110" height="12" uuid="11111111-1111-1111-1111-111111111123"/>
+				<textElement>
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Cant. ventas:]]></text>
+			</staticText>
+			<textField pattern="#,##0">
+				<reportElement x="704" y="41" width="86" height="12" uuid="11111111-1111-1111-1111-111111111124"/>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{cantidadVentas}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="590" y="53" width="110" height="12" uuid="11111111-1111-1111-1111-111111111125"/>
+				<textElement>
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Efectivo (Gs.):]]></text>
+			</staticText>
+			<textField pattern="#,###">
+				<reportElement x="704" y="53" width="86" height="12" uuid="11111111-1111-1111-1111-111111111126"/>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{totalEfectivo}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="590" y="65" width="110" height="12" uuid="11111111-1111-1111-1111-111111111127"/>
+				<textElement>
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Tarjeta (Gs.):]]></text>
+			</staticText>
+			<textField pattern="#,###">
+				<reportElement x="704" y="65" width="86" height="12" uuid="11111111-1111-1111-1111-111111111128"/>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{totalTarjeta}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="590" y="77" width="110" height="12" uuid="11111111-1111-1111-1111-111111111129"/>
+				<textElement>
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Convenio (Gs.):]]></text>
+			</staticText>
+			<textField pattern="#,###">
+				<reportElement x="704" y="77" width="86" height="12" uuid="11111111-1111-1111-1111-111111111130"/>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{totalConvenio}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="590" y="89" width="110" height="12" uuid="11111111-1111-1111-1111-111111111131"/>
+				<textElement>
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Transferencia (Gs.):]]></text>
+			</staticText>
+			<textField pattern="#,###">
+				<reportElement x="704" y="89" width="86" height="12" uuid="11111111-1111-1111-1111-111111111132"/>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{totalTransferencia}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="590" y="113" width="110" height="12" uuid="11111111-1111-1111-1111-111111111143"/>
+				<textElement>
+					<font fontName="Verdana" size="9" isBold="true"/>
+				</textElement>
+				<text><![CDATA[TOTAL (Gs.):]]></text>
+			</staticText>
+			<textField pattern="#,###">
+				<reportElement x="704" y="113" width="86" height="12" uuid="11111111-1111-1111-1111-111111111144"/>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{totalGeneral}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="130" y="113" width="58" height="12" uuid="11111111-1111-1111-1111-111111111103"/>
+				<textElement textAlignment="Left" verticalAlignment="Top">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Creado en:]]></text>
+			</staticText>
+			<textField>
+				<reportElement x="188" y="113" width="77" height="12" uuid="11111111-1111-1111-1111-111111111104"/>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{fechaReporte}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="265" y="113" width="27" height="12" uuid="11111111-1111-1111-1111-111111111105"/>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[por:]]></text>
+			</staticText>
+			<textField>
+				<reportElement x="292" y="113" width="146" height="12" uuid="11111111-1111-1111-1111-111111111106"/>
+				<textElement verticalAlignment="Middle">
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{usuario}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement mode="Opaque" x="291" y="25" width="100" height="13" backcolor="#FFFFFF" uuid="11111111-1111-1111-1111-111111111108"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="10" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Filtros aplicados]]></text>
+			</staticText>
+		</band>
+	</title>
+	<detail>
+		<band height="210" splitType="Stretch">
+			<rectangle>
+				<reportElement x="0" y="0" width="802" height="14" backcolor="#EDEDED" mode="Opaque" uuid="33333333-1111-1111-1111-333333333301"/>
+				<graphicElement>
+					<pen lineColor="#A3A3A3"/>
+				</graphicElement>
+			</rectangle>
+			<textField>
+				<reportElement x="0" y="0" width="45" height="14" uuid="33333333-1111-1111-1111-333333333302"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA["Venta #" + $F{ventaId}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="115" y="0" width="150" height="14" uuid="33333333-1111-1111-1111-333333333303"/>
+				<textElement textAlignment="Left" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{sucursal}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="265" y="0" width="150" height="14" uuid="33333333-1111-1111-1111-333333333304"/>
+				<textElement textAlignment="Left" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{cliente}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="415" y="0" width="85" height="14" uuid="33333333-1111-1111-1111-333333333305"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{fecha}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="500" y="0" width="65" height="14" uuid="33333333-1111-1111-1111-333333333306"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{estado}]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement x="565" y="0" width="130" height="14" uuid="33333333-1111-1111-1111-333333333307"/>
+				<textElement textAlignment="Left" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA["Resp.: " + ($F{responsable} != null ? $F{responsable} : "")]]></textFieldExpression>
+			</textField>
+			<textField pattern="#,###" isBlankWhenNull="true">
+				<reportElement x="695" y="0" width="107" height="14" uuid="33333333-1111-1111-1111-333333333308"/>
+				<textElement textAlignment="Right" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{totalGs}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement positionType="Float" x="0" y="16" width="150" height="10" uuid="33333333-2222-1111-1111-333333333309"/>
+				<textElement>
+					<font fontName="Verdana" size="8" isBold="true" isUnderline="true"/>
+				</textElement>
+				<text><![CDATA[Productos]]></text>
+			</staticText>
+			<staticText>
+				<reportElement positionType="Float" x="0" y="27" width="220" height="10" uuid="33333333-2222-1111-1111-333333333310"/>
+				<textElement>
+					<font fontName="Verdana" size="7" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Producto]]></text>
+			</staticText>
+			<staticText>
+				<reportElement positionType="Float" x="220" y="27" width="120" height="10" uuid="33333333-2222-1111-1111-333333333311"/>
+				<textElement>
+					<font fontName="Verdana" size="7" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Presentación]]></text>
+			</staticText>
+			<staticText>
+				<reportElement positionType="Float" x="340" y="27" width="70" height="10" uuid="33333333-2222-1111-1111-333333333312"/>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="7" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Cantidad]]></text>
+			</staticText>
+			<staticText>
+				<reportElement positionType="Float" x="410" y="27" width="90" height="10" uuid="33333333-2222-1111-1111-333333333313"/>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="7" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Precio]]></text>
+			</staticText>
+			<staticText>
+				<reportElement positionType="Float" x="500" y="27" width="90" height="10" uuid="33333333-2222-1111-1111-333333333314"/>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="7" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Costo Unit.]]></text>
+			</staticText>
+			<staticText>
+				<reportElement positionType="Float" x="590" y="27" width="100" height="10" uuid="33333333-2222-1111-1111-333333333315"/>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="7" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Costo Total]]></text>
+			</staticText>
+			<staticText>
+				<reportElement positionType="Float" x="690" y="27" width="112" height="10" uuid="33333333-2222-1111-1111-333333333316"/>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="7" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Total]]></text>
+			</staticText>
+			<componentElement>
+				<reportElement positionType="Float" x="0" y="38" width="802" height="12" uuid="33333333-3333-1111-1111-333333333317"/>
+				<jr:list xmlns:jr="http://jasperreports.sourceforge.net/jasperreports/components" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports/components http://jasperreports.sourceforge.net/xsd/components.xsd" printOrder="Vertical">
+					<datasetRun subDataset="ItemsDataset" uuid="c2a2b3c4-d5e6-4f7a-8b9c-0d1e2f3a4b21">
+						<dataSourceExpression><![CDATA[$F{itemsDataSource}]]></dataSourceExpression>
+					</datasetRun>
+					<jr:listContents height="12" width="802">
+						<textField isBlankWhenNull="true">
+							<reportElement x="0" y="0" width="220" height="12" uuid="33333333-4444-1111-1111-333333333318"/>
+							<textElement verticalAlignment="Middle">
+								<font fontName="Verdana" size="7"/>
+							</textElement>
+							<textFieldExpression><![CDATA[$F{producto}]]></textFieldExpression>
+						</textField>
+						<textField isBlankWhenNull="true">
+							<reportElement x="220" y="0" width="120" height="12" uuid="33333333-4444-1111-1111-333333333319"/>
+							<textElement verticalAlignment="Middle">
+								<font fontName="Verdana" size="7"/>
+							</textElement>
+							<textFieldExpression><![CDATA[$F{presentacion}]]></textFieldExpression>
+						</textField>
+						<textField pattern="#,##0.##" isBlankWhenNull="true">
+							<reportElement x="340" y="0" width="70" height="12" uuid="33333333-4444-1111-1111-333333333320"/>
+							<textElement textAlignment="Right" verticalAlignment="Middle">
+								<font fontName="Verdana" size="7"/>
+							</textElement>
+							<textFieldExpression><![CDATA[$F{cantidad}]]></textFieldExpression>
+						</textField>
+						<textField pattern="#,##0" isBlankWhenNull="true">
+							<reportElement x="410" y="0" width="90" height="12" uuid="33333333-4444-1111-1111-333333333321"/>
+							<textElement textAlignment="Right" verticalAlignment="Middle">
+								<font fontName="Verdana" size="7"/>
+							</textElement>
+							<textFieldExpression><![CDATA[$F{precio}]]></textFieldExpression>
+						</textField>
+						<textField pattern="#,##0" isBlankWhenNull="true">
+							<reportElement x="500" y="0" width="90" height="12" uuid="33333333-4444-1111-1111-333333333322"/>
+							<textElement textAlignment="Right" verticalAlignment="Middle">
+								<font fontName="Verdana" size="7"/>
+							</textElement>
+							<textFieldExpression><![CDATA[$F{precioCosto}]]></textFieldExpression>
+						</textField>
+						<textField pattern="#,##0" isBlankWhenNull="true">
+							<reportElement x="590" y="0" width="100" height="12" uuid="33333333-4444-1111-1111-333333333323"/>
+							<textElement textAlignment="Right" verticalAlignment="Middle">
+								<font fontName="Verdana" size="7"/>
+							</textElement>
+							<textFieldExpression><![CDATA[$F{costoTotal}]]></textFieldExpression>
+						</textField>
+						<textField pattern="#,##0" isBlankWhenNull="true">
+							<reportElement x="690" y="0" width="112" height="12" uuid="33333333-4444-1111-1111-333333333324"/>
+							<textElement textAlignment="Right" verticalAlignment="Middle">
+								<font fontName="Verdana" size="7"/>
+							</textElement>
+							<textFieldExpression><![CDATA[$F{total}]]></textFieldExpression>
+						</textField>
+					</jr:listContents>
+				</jr:list>
+			</componentElement>
+			<staticText>
+				<reportElement positionType="Float" x="0" y="51" width="150" height="10" uuid="33333333-2222-1111-1111-333333333330"/>
+				<textElement>
+					<font fontName="Verdana" size="8" isBold="true" isUnderline="true"/>
+				</textElement>
+				<text><![CDATA[Movimientos]]></text>
+			</staticText>
+			<staticText>
+				<reportElement positionType="Float" x="0" y="62" width="180" height="10" uuid="33333333-2222-1111-1111-333333333331"/>
+				<textElement>
+					<font fontName="Verdana" size="7" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Operación]]></text>
+			</staticText>
+			<staticText>
+				<reportElement positionType="Float" x="180" y="62" width="150" height="10" uuid="33333333-2222-1111-1111-333333333332"/>
+				<textElement>
+					<font fontName="Verdana" size="7" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Forma de Pago]]></text>
+			</staticText>
+			<staticText>
+				<reportElement positionType="Float" x="330" y="62" width="90" height="10" uuid="33333333-2222-1111-1111-333333333333"/>
+				<textElement>
+					<font fontName="Verdana" size="7" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Moneda]]></text>
+			</staticText>
+			<staticText>
+				<reportElement positionType="Float" x="420" y="62" width="130" height="10" uuid="33333333-2222-1111-1111-333333333334"/>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="7" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Valor en Moneda]]></text>
+			</staticText>
+			<staticText>
+				<reportElement positionType="Float" x="550" y="62" width="130" height="10" uuid="33333333-2222-1111-1111-333333333335"/>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="7" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Valor en Gs]]></text>
+			</staticText>
+			<componentElement>
+				<reportElement positionType="Float" x="0" y="73" width="802" height="12" uuid="33333333-3333-1111-1111-333333333336"/>
+				<jr:list xmlns:jr="http://jasperreports.sourceforge.net/jasperreports/components" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports/components http://jasperreports.sourceforge.net/xsd/components.xsd" printOrder="Vertical">
+					<datasetRun subDataset="MovimientosDataset" uuid="c2a2b3c4-d5e6-4f7a-8b9c-0d1e2f3a4b22">
+						<dataSourceExpression><![CDATA[$F{movimientosDataSource}]]></dataSourceExpression>
+					</datasetRun>
+					<jr:listContents height="12" width="802">
+						<textField isBlankWhenNull="true">
+							<reportElement x="0" y="0" width="180" height="12" uuid="33333333-4444-1111-1111-333333333337"/>
+							<textElement verticalAlignment="Middle">
+								<font fontName="Verdana" size="7"/>
+							</textElement>
+							<textFieldExpression><![CDATA[$F{operacion}]]></textFieldExpression>
+						</textField>
+						<textField isBlankWhenNull="true">
+							<reportElement x="180" y="0" width="150" height="12" uuid="33333333-4444-1111-1111-333333333338"/>
+							<textElement verticalAlignment="Middle">
+								<font fontName="Verdana" size="7"/>
+							</textElement>
+							<textFieldExpression><![CDATA[$F{formaPago}]]></textFieldExpression>
+						</textField>
+						<textField isBlankWhenNull="true">
+							<reportElement x="330" y="0" width="90" height="12" uuid="33333333-4444-1111-1111-333333333339"/>
+							<textElement verticalAlignment="Middle">
+								<font fontName="Verdana" size="7"/>
+							</textElement>
+							<textFieldExpression><![CDATA[$F{moneda}]]></textFieldExpression>
+						</textField>
+						<textField pattern="#,##0.##" isBlankWhenNull="true">
+							<reportElement x="420" y="0" width="130" height="12" uuid="33333333-4444-1111-1111-333333333340"/>
+							<textElement textAlignment="Right" verticalAlignment="Middle">
+								<font fontName="Verdana" size="7"/>
+							</textElement>
+							<textFieldExpression><![CDATA[$F{valorEnMoneda}]]></textFieldExpression>
+						</textField>
+						<textField pattern="#,##0" isBlankWhenNull="true">
+							<reportElement x="550" y="0" width="130" height="12" uuid="33333333-4444-1111-1111-333333333341"/>
+							<textElement textAlignment="Right" verticalAlignment="Middle">
+								<font fontName="Verdana" size="7"/>
+							</textElement>
+							<textFieldExpression><![CDATA[$F{valorEnGs}]]></textFieldExpression>
+						</textField>
+					</jr:listContents>
+				</jr:list>
+			</componentElement>
+			<staticText>
+				<reportElement positionType="Float" x="0" y="86" width="150" height="10" uuid="33333333-2222-1111-1111-333333333350"/>
+				<textElement>
+					<font fontName="Verdana" size="8" isBold="true" isUnderline="true"/>
+				</textElement>
+				<text><![CDATA[Observaciones]]></text>
+			</staticText>
+			<staticText>
+				<reportElement positionType="Float" x="0" y="97" width="120" height="10" uuid="33333333-2222-1111-1111-333333333351"/>
+				<textElement>
+					<font fontName="Verdana" size="7" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Fecha]]></text>
+			</staticText>
+			<staticText>
+				<reportElement positionType="Float" x="120" y="97" width="400" height="10" uuid="33333333-2222-1111-1111-333333333352"/>
+				<textElement>
+					<font fontName="Verdana" size="7" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Descripción]]></text>
+			</staticText>
+			<staticText>
+				<reportElement positionType="Float" x="520" y="97" width="200" height="10" uuid="33333333-2222-1111-1111-333333333353"/>
+				<textElement>
+					<font fontName="Verdana" size="7" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Motivo]]></text>
+			</staticText>
+			<componentElement>
+				<reportElement positionType="Float" x="0" y="108" width="802" height="12" uuid="33333333-3333-1111-1111-333333333354"/>
+				<jr:list xmlns:jr="http://jasperreports.sourceforge.net/jasperreports/components" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports/components http://jasperreports.sourceforge.net/xsd/components.xsd" printOrder="Vertical">
+					<datasetRun subDataset="ObservacionesDataset" uuid="c2a2b3c4-d5e6-4f7a-8b9c-0d1e2f3a4b23">
+						<dataSourceExpression><![CDATA[$F{observacionesDataSource}]]></dataSourceExpression>
+					</datasetRun>
+					<jr:listContents height="12" width="802">
+						<textField isBlankWhenNull="true">
+							<reportElement x="0" y="0" width="120" height="12" uuid="33333333-4444-1111-1111-333333333355"/>
+							<textElement verticalAlignment="Middle">
+								<font fontName="Verdana" size="7"/>
+							</textElement>
+							<textFieldExpression><![CDATA[$F{fecha}]]></textFieldExpression>
+						</textField>
+						<textField isBlankWhenNull="true">
+							<reportElement x="120" y="0" width="400" height="12" uuid="33333333-4444-1111-1111-333333333356"/>
+							<textElement verticalAlignment="Middle">
+								<font fontName="Verdana" size="7"/>
+							</textElement>
+							<textFieldExpression><![CDATA[$F{descripcion}]]></textFieldExpression>
+						</textField>
+						<textField isBlankWhenNull="true">
+							<reportElement x="520" y="0" width="200" height="12" uuid="33333333-4444-1111-1111-333333333357"/>
+							<textElement verticalAlignment="Middle">
+								<font fontName="Verdana" size="7"/>
+							</textElement>
+							<textFieldExpression><![CDATA[$F{motivo}]]></textFieldExpression>
+						</textField>
+					</jr:listContents>
+				</jr:list>
+			</componentElement>
+			<frame>
+				<reportElement positionType="Float" x="0" y="121" width="350" height="70" uuid="33333333-5555-1111-1111-333333333360"/>
+				<staticText>
+					<reportElement x="0" y="0" width="200" height="10" uuid="33333333-5555-1111-1111-333333333361"/>
+					<textElement>
+						<font fontName="Verdana" size="7"/>
+					</textElement>
+					<text><![CDATA[Costo total venta (Gs.):]]></text>
+				</staticText>
+				<textField pattern="#,##0" isBlankWhenNull="true">
+					<reportElement x="200" y="0" width="150" height="10" uuid="33333333-5555-1111-1111-333333333362"/>
+					<textElement textAlignment="Right">
+						<font fontName="Verdana" size="7"/>
+					</textElement>
+					<textFieldExpression><![CDATA[$F{costoTotalVenta}]]></textFieldExpression>
+				</textField>
+				<staticText>
+					<reportElement x="0" y="10" width="200" height="10" uuid="33333333-5555-1111-1111-333333333363"/>
+					<textElement>
+						<font fontName="Verdana" size="7"/>
+					</textElement>
+					<text><![CDATA[Total recibido Gs:]]></text>
+				</staticText>
+				<textField pattern="#,##0" isBlankWhenNull="true">
+					<reportElement x="200" y="10" width="150" height="10" uuid="33333333-5555-1111-1111-333333333364"/>
+					<textElement textAlignment="Right">
+						<font fontName="Verdana" size="7"/>
+					</textElement>
+					<textFieldExpression><![CDATA[$F{totalRecibidoGs}]]></textFieldExpression>
+				</textField>
+				<staticText>
+					<reportElement x="0" y="20" width="200" height="10" uuid="33333333-5555-1111-1111-333333333365"/>
+					<textElement>
+						<font fontName="Verdana" size="7"/>
+					</textElement>
+					<text><![CDATA[Total recibido Rs:]]></text>
+				</staticText>
+				<textField pattern="#,##0.##" isBlankWhenNull="true">
+					<reportElement x="200" y="20" width="150" height="10" uuid="33333333-5555-1111-1111-333333333366"/>
+					<textElement textAlignment="Right">
+						<font fontName="Verdana" size="7"/>
+					</textElement>
+					<textFieldExpression><![CDATA[$F{totalRecibidoRs}]]></textFieldExpression>
+				</textField>
+				<staticText>
+					<reportElement x="0" y="30" width="200" height="10" uuid="33333333-5555-1111-1111-333333333367"/>
+					<textElement>
+						<font fontName="Verdana" size="7"/>
+					</textElement>
+					<text><![CDATA[Total recibido Ds:]]></text>
+				</staticText>
+				<textField pattern="#,##0.##" isBlankWhenNull="true">
+					<reportElement x="200" y="30" width="150" height="10" uuid="33333333-5555-1111-1111-333333333368"/>
+					<textElement textAlignment="Right">
+						<font fontName="Verdana" size="7"/>
+					</textElement>
+					<textFieldExpression><![CDATA[$F{totalRecibidoDs}]]></textFieldExpression>
+				</textField>
+				<staticText>
+					<reportElement x="0" y="40" width="200" height="10" uuid="33333333-5555-1111-1111-333333333369"/>
+					<textElement>
+						<font fontName="Verdana" size="7"/>
+					</textElement>
+					<text><![CDATA[Total descuento (Gs.):]]></text>
+				</staticText>
+				<textField pattern="#,##0" isBlankWhenNull="true">
+					<reportElement x="200" y="40" width="150" height="10" uuid="33333333-5555-1111-1111-333333333370"/>
+					<textElement textAlignment="Right">
+						<font fontName="Verdana" size="7"/>
+					</textElement>
+					<textFieldExpression><![CDATA[$F{totalDescuento}]]></textFieldExpression>
+				</textField>
+				<staticText>
+					<reportElement x="0" y="50" width="200" height="10" uuid="33333333-5555-1111-1111-333333333371"/>
+					<textElement>
+						<font fontName="Verdana" size="7"/>
+					</textElement>
+					<text><![CDATA[Total aumento (Gs.):]]></text>
+				</staticText>
+				<textField pattern="#,##0" isBlankWhenNull="true">
+					<reportElement x="200" y="50" width="150" height="10" uuid="33333333-5555-1111-1111-333333333372"/>
+					<textElement textAlignment="Right">
+						<font fontName="Verdana" size="7"/>
+					</textElement>
+					<textFieldExpression><![CDATA[$F{totalAumento}]]></textFieldExpression>
+				</textField>
+				<staticText>
+					<reportElement x="0" y="60" width="200" height="10" uuid="33333333-5555-1111-1111-333333333373"/>
+					<textElement>
+						<font fontName="Verdana" size="7" isBold="true"/>
+					</textElement>
+					<text><![CDATA[Total final (Gs.):]]></text>
+				</staticText>
+				<textField pattern="#,##0" isBlankWhenNull="true">
+					<reportElement x="200" y="60" width="150" height="10" uuid="33333333-5555-1111-1111-333333333374"/>
+					<textElement textAlignment="Right">
+						<font fontName="Verdana" size="7" isBold="true"/>
+					</textElement>
+					<textFieldExpression><![CDATA[$F{totalFinal}]]></textFieldExpression>
+				</textField>
+			</frame>
+			<line>
+				<reportElement positionType="Float" x="0" y="192" width="802" height="1" uuid="33333333-6666-1111-1111-333333333380"/>
+				<graphicElement>
+					<pen lineWidth="1.0" lineColor="#000000"/>
+				</graphicElement>
+			</line>
+		</band>
+	</detail>
+	<columnFooter>
+		<band height="20">
+			<staticText>
+				<reportElement x="0" y="0" width="40" height="10" uuid="44444444-4444-4444-4444-444444444406"/>
+				<textElement>
+					<font fontName="Verdana" size="7"/>
+				</textElement>
+				<text><![CDATA[Página:]]></text>
+			</staticText>
+			<textField>
+				<reportElement x="42" y="0" width="30" height="10" uuid="44444444-4444-4444-4444-444444444407"/>
+				<textElement>
+					<font fontName="Verdana" size="7"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$V{PAGE_NUMBER}]]></textFieldExpression>
+			</textField>
+		</band>
+	</columnFooter>
+</jasperReport>

--- a/src/main/resources/reports/reporte-ventas-detallado.jrxml
+++ b/src/main/resources/reports/reporte-ventas-detallado.jrxml
@@ -390,7 +390,7 @@
 		</band>
 	</title>
 	<detail>
-		<band height="210" splitType="Stretch">
+		<band height="165" splitType="Stretch">
 			<rectangle>
 				<reportElement x="0" y="0" width="802" height="14" backcolor="#EDEDED" mode="Opaque" uuid="33333333-1111-1111-1111-333333333301"/>
 				<graphicElement>
@@ -432,13 +432,13 @@
 				</textElement>
 				<textFieldExpression><![CDATA[$F{estado}]]></textFieldExpression>
 			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement x="565" y="0" width="130" height="14" uuid="33333333-1111-1111-1111-333333333307"/>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Verdana" size="8"/>
+			<staticText>
+				<reportElement x="565" y="0" width="125" height="14" uuid="33333333-1111-1111-1111-333333333307"/>
+				<textElement textAlignment="Right" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8" isBold="true"/>
 				</textElement>
-				<textFieldExpression><![CDATA["Resp.: " + ($F{responsable} != null ? $F{responsable} : "")]]></textFieldExpression>
-			</textField>
+				<text><![CDATA[Total:]]></text>
+			</staticText>
 			<textField pattern="#,###" isBlankWhenNull="true">
 				<reportElement x="695" y="0" width="107" height="14" uuid="33333333-1111-1111-1111-333333333308"/>
 				<textElement textAlignment="Right" verticalAlignment="Middle">
@@ -446,113 +446,117 @@
 				</textElement>
 				<textFieldExpression><![CDATA[$F{totalGs}]]></textFieldExpression>
 			</textField>
+			<rectangle>
+				<reportElement positionType="Float" x="0" y="16" width="802" height="12" backcolor="#37474F" mode="Opaque" uuid="33333333-2222-1111-1111-300900000001"/>
+			</rectangle>
 			<staticText>
-				<reportElement positionType="Float" x="0" y="16" width="150" height="10" uuid="33333333-2222-1111-1111-333333333309"/>
-				<textElement>
-					<font fontName="Verdana" size="8" isBold="true" isUnderline="true"/>
+				<reportElement positionType="Float" mode="Transparent" x="0" y="16" width="802" height="12" forecolor="#FFFFFF" uuid="33333333-2222-1111-1111-333333333309"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8" isBold="true"/>
+					<paragraph lineSpacing="Single"/>
 				</textElement>
-				<text><![CDATA[Productos]]></text>
+				<text><![CDATA[PRODUCTOS]]></text>
 			</staticText>
 			<staticText>
-				<reportElement positionType="Float" x="0" y="27" width="220" height="10" uuid="33333333-2222-1111-1111-333333333310"/>
+				<reportElement positionType="Float" x="0" y="29" width="220" height="9" uuid="33333333-2222-1111-1111-333333333310"/>
 				<textElement>
 					<font fontName="Verdana" size="7" isBold="true"/>
 				</textElement>
 				<text><![CDATA[Producto]]></text>
 			</staticText>
 			<staticText>
-				<reportElement positionType="Float" x="220" y="27" width="120" height="10" uuid="33333333-2222-1111-1111-333333333311"/>
+				<reportElement positionType="Float" x="220" y="29" width="120" height="9" uuid="33333333-2222-1111-1111-333333333311"/>
 				<textElement>
 					<font fontName="Verdana" size="7" isBold="true"/>
 				</textElement>
 				<text><![CDATA[Presentación]]></text>
 			</staticText>
 			<staticText>
-				<reportElement positionType="Float" x="340" y="27" width="70" height="10" uuid="33333333-2222-1111-1111-333333333312"/>
+				<reportElement positionType="Float" x="340" y="29" width="70" height="9" uuid="33333333-2222-1111-1111-333333333312"/>
 				<textElement textAlignment="Right">
 					<font fontName="Verdana" size="7" isBold="true"/>
 				</textElement>
 				<text><![CDATA[Cantidad]]></text>
 			</staticText>
 			<staticText>
-				<reportElement positionType="Float" x="410" y="27" width="90" height="10" uuid="33333333-2222-1111-1111-333333333313"/>
+				<reportElement positionType="Float" x="410" y="29" width="90" height="9" uuid="33333333-2222-1111-1111-333333333313"/>
 				<textElement textAlignment="Right">
 					<font fontName="Verdana" size="7" isBold="true"/>
 				</textElement>
 				<text><![CDATA[Precio]]></text>
 			</staticText>
 			<staticText>
-				<reportElement positionType="Float" x="500" y="27" width="90" height="10" uuid="33333333-2222-1111-1111-333333333314"/>
+				<reportElement positionType="Float" x="500" y="29" width="90" height="9" uuid="33333333-2222-1111-1111-333333333314"/>
 				<textElement textAlignment="Right">
 					<font fontName="Verdana" size="7" isBold="true"/>
 				</textElement>
 				<text><![CDATA[Costo Unit.]]></text>
 			</staticText>
 			<staticText>
-				<reportElement positionType="Float" x="590" y="27" width="100" height="10" uuid="33333333-2222-1111-1111-333333333315"/>
+				<reportElement positionType="Float" x="590" y="29" width="100" height="9" uuid="33333333-2222-1111-1111-333333333315"/>
 				<textElement textAlignment="Right">
 					<font fontName="Verdana" size="7" isBold="true"/>
 				</textElement>
 				<text><![CDATA[Costo Total]]></text>
 			</staticText>
 			<staticText>
-				<reportElement positionType="Float" x="690" y="27" width="112" height="10" uuid="33333333-2222-1111-1111-333333333316"/>
+				<reportElement positionType="Float" x="690" y="29" width="112" height="9" uuid="33333333-2222-1111-1111-333333333316"/>
 				<textElement textAlignment="Right">
 					<font fontName="Verdana" size="7" isBold="true"/>
 				</textElement>
 				<text><![CDATA[Total]]></text>
 			</staticText>
 			<componentElement>
-				<reportElement positionType="Float" x="0" y="38" width="802" height="12" uuid="33333333-3333-1111-1111-333333333317"/>
+				<reportElement positionType="Float" x="0" y="38" width="802" height="11" uuid="33333333-3333-1111-1111-333333333317"/>
 				<jr:list xmlns:jr="http://jasperreports.sourceforge.net/jasperreports/components" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports/components http://jasperreports.sourceforge.net/xsd/components.xsd" printOrder="Vertical">
 					<datasetRun subDataset="ItemsDataset" uuid="c2a2b3c4-d5e6-4f7a-8b9c-0d1e2f3a4b21">
 						<dataSourceExpression><![CDATA[$F{itemsDataSource}]]></dataSourceExpression>
 					</datasetRun>
-					<jr:listContents height="12" width="802">
+					<jr:listContents height="11" width="802">
 						<textField isBlankWhenNull="true">
-							<reportElement x="0" y="0" width="220" height="12" uuid="33333333-4444-1111-1111-333333333318"/>
+							<reportElement x="0" y="0" width="220" height="11" uuid="33333333-4444-1111-1111-333333333318"/>
 							<textElement verticalAlignment="Middle">
 								<font fontName="Verdana" size="7"/>
 							</textElement>
 							<textFieldExpression><![CDATA[$F{producto}]]></textFieldExpression>
 						</textField>
 						<textField isBlankWhenNull="true">
-							<reportElement x="220" y="0" width="120" height="12" uuid="33333333-4444-1111-1111-333333333319"/>
+							<reportElement x="220" y="0" width="120" height="11" uuid="33333333-4444-1111-1111-333333333319"/>
 							<textElement verticalAlignment="Middle">
 								<font fontName="Verdana" size="7"/>
 							</textElement>
 							<textFieldExpression><![CDATA[$F{presentacion}]]></textFieldExpression>
 						</textField>
 						<textField pattern="#,##0.##" isBlankWhenNull="true">
-							<reportElement x="340" y="0" width="70" height="12" uuid="33333333-4444-1111-1111-333333333320"/>
+							<reportElement x="340" y="0" width="70" height="11" uuid="33333333-4444-1111-1111-333333333320"/>
 							<textElement textAlignment="Right" verticalAlignment="Middle">
 								<font fontName="Verdana" size="7"/>
 							</textElement>
 							<textFieldExpression><![CDATA[$F{cantidad}]]></textFieldExpression>
 						</textField>
 						<textField pattern="#,##0" isBlankWhenNull="true">
-							<reportElement x="410" y="0" width="90" height="12" uuid="33333333-4444-1111-1111-333333333321"/>
+							<reportElement x="410" y="0" width="90" height="11" uuid="33333333-4444-1111-1111-333333333321"/>
 							<textElement textAlignment="Right" verticalAlignment="Middle">
 								<font fontName="Verdana" size="7"/>
 							</textElement>
 							<textFieldExpression><![CDATA[$F{precio}]]></textFieldExpression>
 						</textField>
 						<textField pattern="#,##0" isBlankWhenNull="true">
-							<reportElement x="500" y="0" width="90" height="12" uuid="33333333-4444-1111-1111-333333333322"/>
+							<reportElement x="500" y="0" width="90" height="11" uuid="33333333-4444-1111-1111-333333333322"/>
 							<textElement textAlignment="Right" verticalAlignment="Middle">
 								<font fontName="Verdana" size="7"/>
 							</textElement>
 							<textFieldExpression><![CDATA[$F{precioCosto}]]></textFieldExpression>
 						</textField>
 						<textField pattern="#,##0" isBlankWhenNull="true">
-							<reportElement x="590" y="0" width="100" height="12" uuid="33333333-4444-1111-1111-333333333323"/>
+							<reportElement x="590" y="0" width="100" height="11" uuid="33333333-4444-1111-1111-333333333323"/>
 							<textElement textAlignment="Right" verticalAlignment="Middle">
 								<font fontName="Verdana" size="7"/>
 							</textElement>
 							<textFieldExpression><![CDATA[$F{costoTotal}]]></textFieldExpression>
 						</textField>
 						<textField pattern="#,##0" isBlankWhenNull="true">
-							<reportElement x="690" y="0" width="112" height="12" uuid="33333333-4444-1111-1111-333333333324"/>
+							<reportElement x="690" y="0" width="112" height="11" uuid="33333333-4444-1111-1111-333333333324"/>
 							<textElement textAlignment="Right" verticalAlignment="Middle">
 								<font fontName="Verdana" size="7"/>
 							</textElement>
@@ -561,85 +565,88 @@
 					</jr:listContents>
 				</jr:list>
 			</componentElement>
+			<rectangle>
+				<reportElement positionType="Float" x="0" y="49" width="802" height="12" backcolor="#37474F" mode="Opaque" uuid="33333333-2222-1111-1111-300900000002"/>
+			</rectangle>
 			<staticText>
-				<reportElement positionType="Float" x="0" y="51" width="150" height="10" uuid="33333333-2222-1111-1111-333333333330"/>
-				<textElement>
-					<font fontName="Verdana" size="8" isBold="true" isUnderline="true"/>
+				<reportElement positionType="Float" mode="Transparent" x="0" y="49" width="802" height="12" forecolor="#FFFFFF" uuid="33333333-2222-1111-1111-333333333330"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8" isBold="true"/>
 				</textElement>
-				<text><![CDATA[Movimientos]]></text>
+				<text><![CDATA[MOVIMIENTOS]]></text>
 			</staticText>
 			<staticText>
-				<reportElement positionType="Float" x="0" y="62" width="180" height="10" uuid="33333333-2222-1111-1111-333333333331"/>
+				<reportElement positionType="Float" x="0" y="62" width="200" height="9" uuid="33333333-2222-1111-1111-333333333331"/>
 				<textElement>
 					<font fontName="Verdana" size="7" isBold="true"/>
 				</textElement>
 				<text><![CDATA[Operación]]></text>
 			</staticText>
 			<staticText>
-				<reportElement positionType="Float" x="180" y="62" width="150" height="10" uuid="33333333-2222-1111-1111-333333333332"/>
+				<reportElement positionType="Float" x="200" y="62" width="180" height="9" uuid="33333333-2222-1111-1111-333333333332"/>
 				<textElement>
 					<font fontName="Verdana" size="7" isBold="true"/>
 				</textElement>
 				<text><![CDATA[Forma de Pago]]></text>
 			</staticText>
 			<staticText>
-				<reportElement positionType="Float" x="330" y="62" width="90" height="10" uuid="33333333-2222-1111-1111-333333333333"/>
+				<reportElement positionType="Float" x="380" y="62" width="100" height="9" uuid="33333333-2222-1111-1111-333333333333"/>
 				<textElement>
 					<font fontName="Verdana" size="7" isBold="true"/>
 				</textElement>
 				<text><![CDATA[Moneda]]></text>
 			</staticText>
 			<staticText>
-				<reportElement positionType="Float" x="420" y="62" width="130" height="10" uuid="33333333-2222-1111-1111-333333333334"/>
+				<reportElement positionType="Float" x="480" y="62" width="150" height="9" uuid="33333333-2222-1111-1111-333333333334"/>
 				<textElement textAlignment="Right">
 					<font fontName="Verdana" size="7" isBold="true"/>
 				</textElement>
 				<text><![CDATA[Valor en Moneda]]></text>
 			</staticText>
 			<staticText>
-				<reportElement positionType="Float" x="550" y="62" width="130" height="10" uuid="33333333-2222-1111-1111-333333333335"/>
+				<reportElement positionType="Float" x="630" y="62" width="172" height="9" uuid="33333333-2222-1111-1111-333333333335"/>
 				<textElement textAlignment="Right">
 					<font fontName="Verdana" size="7" isBold="true"/>
 				</textElement>
 				<text><![CDATA[Valor en Gs]]></text>
 			</staticText>
 			<componentElement>
-				<reportElement positionType="Float" x="0" y="73" width="802" height="12" uuid="33333333-3333-1111-1111-333333333336"/>
+				<reportElement positionType="Float" x="0" y="71" width="802" height="11" uuid="33333333-3333-1111-1111-333333333336"/>
 				<jr:list xmlns:jr="http://jasperreports.sourceforge.net/jasperreports/components" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports/components http://jasperreports.sourceforge.net/xsd/components.xsd" printOrder="Vertical">
 					<datasetRun subDataset="MovimientosDataset" uuid="c2a2b3c4-d5e6-4f7a-8b9c-0d1e2f3a4b22">
 						<dataSourceExpression><![CDATA[$F{movimientosDataSource}]]></dataSourceExpression>
 					</datasetRun>
-					<jr:listContents height="12" width="802">
+					<jr:listContents height="11" width="802">
 						<textField isBlankWhenNull="true">
-							<reportElement x="0" y="0" width="180" height="12" uuid="33333333-4444-1111-1111-333333333337"/>
+							<reportElement x="0" y="0" width="200" height="11" uuid="33333333-4444-1111-1111-333333333337"/>
 							<textElement verticalAlignment="Middle">
 								<font fontName="Verdana" size="7"/>
 							</textElement>
 							<textFieldExpression><![CDATA[$F{operacion}]]></textFieldExpression>
 						</textField>
 						<textField isBlankWhenNull="true">
-							<reportElement x="180" y="0" width="150" height="12" uuid="33333333-4444-1111-1111-333333333338"/>
+							<reportElement x="200" y="0" width="180" height="11" uuid="33333333-4444-1111-1111-333333333338"/>
 							<textElement verticalAlignment="Middle">
 								<font fontName="Verdana" size="7"/>
 							</textElement>
 							<textFieldExpression><![CDATA[$F{formaPago}]]></textFieldExpression>
 						</textField>
 						<textField isBlankWhenNull="true">
-							<reportElement x="330" y="0" width="90" height="12" uuid="33333333-4444-1111-1111-333333333339"/>
+							<reportElement x="380" y="0" width="100" height="11" uuid="33333333-4444-1111-1111-333333333339"/>
 							<textElement verticalAlignment="Middle">
 								<font fontName="Verdana" size="7"/>
 							</textElement>
 							<textFieldExpression><![CDATA[$F{moneda}]]></textFieldExpression>
 						</textField>
 						<textField pattern="#,##0.##" isBlankWhenNull="true">
-							<reportElement x="420" y="0" width="130" height="12" uuid="33333333-4444-1111-1111-333333333340"/>
+							<reportElement x="480" y="0" width="150" height="11" uuid="33333333-4444-1111-1111-333333333340"/>
 							<textElement textAlignment="Right" verticalAlignment="Middle">
 								<font fontName="Verdana" size="7"/>
 							</textElement>
 							<textFieldExpression><![CDATA[$F{valorEnMoneda}]]></textFieldExpression>
 						</textField>
 						<textField pattern="#,##0" isBlankWhenNull="true">
-							<reportElement x="550" y="0" width="130" height="12" uuid="33333333-4444-1111-1111-333333333341"/>
+							<reportElement x="630" y="0" width="172" height="11" uuid="33333333-4444-1111-1111-333333333341"/>
 							<textElement textAlignment="Right" verticalAlignment="Middle">
 								<font fontName="Verdana" size="7"/>
 							</textElement>
@@ -648,57 +655,60 @@
 					</jr:listContents>
 				</jr:list>
 			</componentElement>
+			<rectangle>
+				<reportElement positionType="Float" x="0" y="82" width="802" height="12" backcolor="#37474F" mode="Opaque" uuid="33333333-2222-1111-1111-300900000003"/>
+			</rectangle>
 			<staticText>
-				<reportElement positionType="Float" x="0" y="86" width="150" height="10" uuid="33333333-2222-1111-1111-333333333350"/>
-				<textElement>
-					<font fontName="Verdana" size="8" isBold="true" isUnderline="true"/>
+				<reportElement positionType="Float" mode="Transparent" x="0" y="82" width="802" height="12" forecolor="#FFFFFF" uuid="33333333-2222-1111-1111-333333333350"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font fontName="Verdana" size="8" isBold="true"/>
 				</textElement>
-				<text><![CDATA[Observaciones]]></text>
+				<text><![CDATA[OBSERVACIONES]]></text>
 			</staticText>
 			<staticText>
-				<reportElement positionType="Float" x="0" y="97" width="120" height="10" uuid="33333333-2222-1111-1111-333333333351"/>
+				<reportElement positionType="Float" x="0" y="95" width="100" height="9" uuid="33333333-2222-1111-1111-333333333351"/>
 				<textElement>
 					<font fontName="Verdana" size="7" isBold="true"/>
 				</textElement>
 				<text><![CDATA[Fecha]]></text>
 			</staticText>
 			<staticText>
-				<reportElement positionType="Float" x="120" y="97" width="400" height="10" uuid="33333333-2222-1111-1111-333333333352"/>
+				<reportElement positionType="Float" x="100" y="95" width="500" height="9" uuid="33333333-2222-1111-1111-333333333352"/>
 				<textElement>
 					<font fontName="Verdana" size="7" isBold="true"/>
 				</textElement>
 				<text><![CDATA[Descripción]]></text>
 			</staticText>
 			<staticText>
-				<reportElement positionType="Float" x="520" y="97" width="200" height="10" uuid="33333333-2222-1111-1111-333333333353"/>
+				<reportElement positionType="Float" x="600" y="95" width="202" height="9" uuid="33333333-2222-1111-1111-333333333353"/>
 				<textElement>
 					<font fontName="Verdana" size="7" isBold="true"/>
 				</textElement>
 				<text><![CDATA[Motivo]]></text>
 			</staticText>
 			<componentElement>
-				<reportElement positionType="Float" x="0" y="108" width="802" height="12" uuid="33333333-3333-1111-1111-333333333354"/>
+				<reportElement positionType="Float" x="0" y="104" width="802" height="11" uuid="33333333-3333-1111-1111-333333333354"/>
 				<jr:list xmlns:jr="http://jasperreports.sourceforge.net/jasperreports/components" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports/components http://jasperreports.sourceforge.net/xsd/components.xsd" printOrder="Vertical">
 					<datasetRun subDataset="ObservacionesDataset" uuid="c2a2b3c4-d5e6-4f7a-8b9c-0d1e2f3a4b23">
 						<dataSourceExpression><![CDATA[$F{observacionesDataSource}]]></dataSourceExpression>
 					</datasetRun>
-					<jr:listContents height="12" width="802">
+					<jr:listContents height="11" width="802">
 						<textField isBlankWhenNull="true">
-							<reportElement x="0" y="0" width="120" height="12" uuid="33333333-4444-1111-1111-333333333355"/>
+							<reportElement x="0" y="0" width="100" height="11" uuid="33333333-4444-1111-1111-333333333355"/>
 							<textElement verticalAlignment="Middle">
 								<font fontName="Verdana" size="7"/>
 							</textElement>
 							<textFieldExpression><![CDATA[$F{fecha}]]></textFieldExpression>
 						</textField>
 						<textField isBlankWhenNull="true">
-							<reportElement x="120" y="0" width="400" height="12" uuid="33333333-4444-1111-1111-333333333356"/>
+							<reportElement x="100" y="0" width="500" height="11" uuid="33333333-4444-1111-1111-333333333356"/>
 							<textElement verticalAlignment="Middle">
 								<font fontName="Verdana" size="7"/>
 							</textElement>
 							<textFieldExpression><![CDATA[$F{descripcion}]]></textFieldExpression>
 						</textField>
 						<textField isBlankWhenNull="true">
-							<reportElement x="520" y="0" width="200" height="12" uuid="33333333-4444-1111-1111-333333333357"/>
+							<reportElement x="600" y="0" width="202" height="11" uuid="33333333-4444-1111-1111-333333333357"/>
 							<textElement verticalAlignment="Middle">
 								<font fontName="Verdana" size="7"/>
 							</textElement>
@@ -708,100 +718,114 @@
 				</jr:list>
 			</componentElement>
 			<frame>
-				<reportElement positionType="Float" x="0" y="121" width="350" height="70" uuid="33333333-5555-1111-1111-333333333360"/>
+				<reportElement positionType="Float" x="0" y="115" width="802" height="40" uuid="33333333-5555-1111-1111-333333333360"/>
 				<staticText>
-					<reportElement x="0" y="0" width="200" height="10" uuid="33333333-5555-1111-1111-333333333361"/>
+					<reportElement x="0" y="0" width="150" height="10" uuid="33333333-5555-1111-1111-333333333375"/>
+					<textElement>
+						<font fontName="Verdana" size="7"/>
+					</textElement>
+					<text><![CDATA[Responsable:]]></text>
+				</staticText>
+				<textField isBlankWhenNull="true">
+					<reportElement x="150" y="0" width="120" height="10" uuid="33333333-5555-1111-1111-333333333376"/>
+					<textElement>
+						<font fontName="Verdana" size="7"/>
+					</textElement>
+					<textFieldExpression><![CDATA[$F{responsable}]]></textFieldExpression>
+				</textField>
+				<staticText>
+					<reportElement x="0" y="10" width="150" height="10" uuid="33333333-5555-1111-1111-333333333361"/>
 					<textElement>
 						<font fontName="Verdana" size="7"/>
 					</textElement>
 					<text><![CDATA[Costo total venta (Gs.):]]></text>
 				</staticText>
 				<textField pattern="#,##0" isBlankWhenNull="true">
-					<reportElement x="200" y="0" width="150" height="10" uuid="33333333-5555-1111-1111-333333333362"/>
+					<reportElement x="150" y="10" width="120" height="10" uuid="33333333-5555-1111-1111-333333333362"/>
 					<textElement textAlignment="Right">
 						<font fontName="Verdana" size="7"/>
 					</textElement>
 					<textFieldExpression><![CDATA[$F{costoTotalVenta}]]></textFieldExpression>
 				</textField>
 				<staticText>
-					<reportElement x="0" y="10" width="200" height="10" uuid="33333333-5555-1111-1111-333333333363"/>
+					<reportElement x="0" y="20" width="150" height="10" uuid="33333333-5555-1111-1111-333333333363"/>
 					<textElement>
 						<font fontName="Verdana" size="7"/>
 					</textElement>
 					<text><![CDATA[Total recibido Gs:]]></text>
 				</staticText>
 				<textField pattern="#,##0" isBlankWhenNull="true">
-					<reportElement x="200" y="10" width="150" height="10" uuid="33333333-5555-1111-1111-333333333364"/>
+					<reportElement x="150" y="20" width="120" height="10" uuid="33333333-5555-1111-1111-333333333364"/>
 					<textElement textAlignment="Right">
 						<font fontName="Verdana" size="7"/>
 					</textElement>
 					<textFieldExpression><![CDATA[$F{totalRecibidoGs}]]></textFieldExpression>
 				</textField>
 				<staticText>
-					<reportElement x="0" y="20" width="200" height="10" uuid="33333333-5555-1111-1111-333333333365"/>
+					<reportElement x="0" y="30" width="150" height="10" uuid="33333333-5555-1111-1111-333333333365"/>
 					<textElement>
 						<font fontName="Verdana" size="7"/>
 					</textElement>
 					<text><![CDATA[Total recibido Rs:]]></text>
 				</staticText>
 				<textField pattern="#,##0.##" isBlankWhenNull="true">
-					<reportElement x="200" y="20" width="150" height="10" uuid="33333333-5555-1111-1111-333333333366"/>
+					<reportElement x="150" y="30" width="120" height="10" uuid="33333333-5555-1111-1111-333333333366"/>
 					<textElement textAlignment="Right">
 						<font fontName="Verdana" size="7"/>
 					</textElement>
 					<textFieldExpression><![CDATA[$F{totalRecibidoRs}]]></textFieldExpression>
 				</textField>
 				<staticText>
-					<reportElement x="0" y="30" width="200" height="10" uuid="33333333-5555-1111-1111-333333333367"/>
+					<reportElement x="420" y="0" width="150" height="10" uuid="33333333-5555-1111-1111-333333333367"/>
 					<textElement>
 						<font fontName="Verdana" size="7"/>
 					</textElement>
 					<text><![CDATA[Total recibido Ds:]]></text>
 				</staticText>
 				<textField pattern="#,##0.##" isBlankWhenNull="true">
-					<reportElement x="200" y="30" width="150" height="10" uuid="33333333-5555-1111-1111-333333333368"/>
+					<reportElement x="570" y="0" width="120" height="10" uuid="33333333-5555-1111-1111-333333333368"/>
 					<textElement textAlignment="Right">
 						<font fontName="Verdana" size="7"/>
 					</textElement>
 					<textFieldExpression><![CDATA[$F{totalRecibidoDs}]]></textFieldExpression>
 				</textField>
 				<staticText>
-					<reportElement x="0" y="40" width="200" height="10" uuid="33333333-5555-1111-1111-333333333369"/>
+					<reportElement x="420" y="10" width="150" height="10" uuid="33333333-5555-1111-1111-333333333369"/>
 					<textElement>
 						<font fontName="Verdana" size="7"/>
 					</textElement>
 					<text><![CDATA[Total descuento (Gs.):]]></text>
 				</staticText>
 				<textField pattern="#,##0" isBlankWhenNull="true">
-					<reportElement x="200" y="40" width="150" height="10" uuid="33333333-5555-1111-1111-333333333370"/>
+					<reportElement x="570" y="10" width="120" height="10" uuid="33333333-5555-1111-1111-333333333370"/>
 					<textElement textAlignment="Right">
 						<font fontName="Verdana" size="7"/>
 					</textElement>
 					<textFieldExpression><![CDATA[$F{totalDescuento}]]></textFieldExpression>
 				</textField>
 				<staticText>
-					<reportElement x="0" y="50" width="200" height="10" uuid="33333333-5555-1111-1111-333333333371"/>
+					<reportElement x="420" y="20" width="150" height="10" uuid="33333333-5555-1111-1111-333333333371"/>
 					<textElement>
 						<font fontName="Verdana" size="7"/>
 					</textElement>
 					<text><![CDATA[Total aumento (Gs.):]]></text>
 				</staticText>
 				<textField pattern="#,##0" isBlankWhenNull="true">
-					<reportElement x="200" y="50" width="150" height="10" uuid="33333333-5555-1111-1111-333333333372"/>
+					<reportElement x="570" y="20" width="120" height="10" uuid="33333333-5555-1111-1111-333333333372"/>
 					<textElement textAlignment="Right">
 						<font fontName="Verdana" size="7"/>
 					</textElement>
 					<textFieldExpression><![CDATA[$F{totalAumento}]]></textFieldExpression>
 				</textField>
 				<staticText>
-					<reportElement x="0" y="60" width="200" height="10" uuid="33333333-5555-1111-1111-333333333373"/>
+					<reportElement x="420" y="30" width="150" height="10" uuid="33333333-5555-1111-1111-333333333373"/>
 					<textElement>
 						<font fontName="Verdana" size="7" isBold="true"/>
 					</textElement>
 					<text><![CDATA[Total final (Gs.):]]></text>
 				</staticText>
 				<textField pattern="#,##0" isBlankWhenNull="true">
-					<reportElement x="200" y="60" width="150" height="10" uuid="33333333-5555-1111-1111-333333333374"/>
+					<reportElement x="570" y="30" width="120" height="10" uuid="33333333-5555-1111-1111-333333333374"/>
 					<textElement textAlignment="Right">
 						<font fontName="Verdana" size="7" isBold="true"/>
 					</textElement>
@@ -809,7 +833,7 @@
 				</textField>
 			</frame>
 			<line>
-				<reportElement positionType="Float" x="0" y="192" width="802" height="1" uuid="33333333-6666-1111-1111-333333333380"/>
+				<reportElement positionType="Float" x="0" y="155" width="802" height="1" uuid="33333333-6666-1111-1111-333333333380"/>
 				<graphicElement>
 					<pen lineWidth="1.0" lineColor="#000000"/>
 				</graphicElement>

--- a/src/main/resources/reports/reporte-ventas-detallado.jrxml
+++ b/src/main/resources/reports/reporte-ventas-detallado.jrxml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 6.21.5.final using JasperReports Library version 6.21.5-74d586df47b25dbd05bd0957999819196e59934a  -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="reporte-ventas-detallado" pageWidth="842" pageHeight="595" orientation="Landscape" whenNoDataType="AllSectionsNoDetail" columnWidth="802" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isFloatColumnFooter="true" uuid="b2c3d4e5-f6a7-8901-bcde-f12345678901">
 	<subDataset name="ItemsDataset" uuid="c1a2b3c4-d5e6-4f7a-8b9c-0d1e2f3a4b01">
 		<field name="producto" class="java.lang.String"/>
@@ -392,48 +393,51 @@
 	<detail>
 		<band height="165" splitType="Stretch">
 			<rectangle>
-				<reportElement x="0" y="0" width="802" height="14" backcolor="#EDEDED" mode="Opaque" uuid="33333333-1111-1111-1111-333333333301"/>
+				<reportElement mode="Opaque" x="0" y="0" width="802" height="14" backcolor="#EDEDED" uuid="33333333-1111-1111-1111-333333333301"/>
 				<graphicElement>
 					<pen lineColor="#A3A3A3"/>
 				</graphicElement>
 			</rectangle>
 			<textField>
-				<reportElement x="0" y="0" width="110" height="14" uuid="33333333-1111-1111-1111-333333333302"/>
+				<reportElement x="0" y="0" width="90" height="14" uuid="33333333-1111-1111-1111-333333333302"/>
+				<box leftPadding="5"/>
 				<textElement textAlignment="Left" verticalAlignment="Middle">
 					<font fontName="Verdana" size="8" isBold="true"/>
 				</textElement>
 				<textFieldExpression><![CDATA["Venta #" + $F{ventaId}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
-				<reportElement x="115" y="0" width="150" height="14" uuid="33333333-1111-1111-1111-333333333303"/>
+				<reportElement x="90" y="0" width="185" height="14" uuid="33333333-1111-1111-1111-333333333303"/>
 				<textElement textAlignment="Left" verticalAlignment="Middle">
 					<font fontName="Verdana" size="8"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{sucursal}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
-				<reportElement x="265" y="0" width="150" height="14" uuid="33333333-1111-1111-1111-333333333304"/>
+				<reportElement x="276" y="0" width="150" height="14" uuid="33333333-1111-1111-1111-333333333304"/>
 				<textElement textAlignment="Left" verticalAlignment="Middle">
 					<font fontName="Verdana" size="8"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{cliente}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
-				<reportElement x="415" y="0" width="85" height="14" uuid="33333333-1111-1111-1111-333333333305"/>
+				<reportElement x="426" y="0" width="85" height="14" uuid="33333333-1111-1111-1111-333333333305"/>
 				<textElement textAlignment="Center" verticalAlignment="Middle">
 					<font fontName="Verdana" size="8"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{fecha}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
-				<reportElement x="500" y="0" width="65" height="14" uuid="33333333-1111-1111-1111-333333333306"/>
+				<reportElement x="511" y="0" width="129" height="14" uuid="33333333-1111-1111-1111-333333333306">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
 				<textElement textAlignment="Center" verticalAlignment="Middle">
 					<font fontName="Verdana" size="8"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{estado}]]></textFieldExpression>
 			</textField>
 			<staticText>
-				<reportElement x="565" y="0" width="125" height="14" uuid="33333333-1111-1111-1111-333333333307"/>
+				<reportElement x="640" y="0" width="55" height="14" uuid="33333333-1111-1111-1111-333333333307"/>
 				<textElement textAlignment="Right" verticalAlignment="Middle">
 					<font fontName="Verdana" size="8" isBold="true"/>
 				</textElement>
@@ -441,13 +445,14 @@
 			</staticText>
 			<textField pattern="#,###" isBlankWhenNull="true">
 				<reportElement x="695" y="0" width="107" height="14" uuid="33333333-1111-1111-1111-333333333308"/>
+				<box rightPadding="5"/>
 				<textElement textAlignment="Right" verticalAlignment="Middle">
 					<font fontName="Verdana" size="8" isBold="true"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{totalGs}]]></textFieldExpression>
 			</textField>
 			<rectangle>
-				<reportElement positionType="Float" x="0" y="16" width="802" height="12" backcolor="#37474F" mode="Opaque" uuid="33333333-2222-1111-1111-300900000001"/>
+				<reportElement positionType="Float" mode="Opaque" x="0" y="16" width="802" height="12" backcolor="#37474F" uuid="33333333-2222-1111-1111-300900000001"/>
 			</rectangle>
 			<staticText>
 				<reportElement positionType="Float" mode="Transparent" x="0" y="16" width="802" height="12" forecolor="#FFFFFF" uuid="33333333-2222-1111-1111-333333333309"/>
@@ -566,7 +571,7 @@
 				</jr:list>
 			</componentElement>
 			<rectangle>
-				<reportElement positionType="Float" x="0" y="49" width="802" height="12" backcolor="#37474F" mode="Opaque" uuid="33333333-2222-1111-1111-300900000002"/>
+				<reportElement positionType="Float" mode="Opaque" x="0" y="49" width="802" height="12" backcolor="#37474F" uuid="33333333-2222-1111-1111-300900000002"/>
 			</rectangle>
 			<staticText>
 				<reportElement positionType="Float" mode="Transparent" x="0" y="49" width="802" height="12" forecolor="#FFFFFF" uuid="33333333-2222-1111-1111-333333333330"/>
@@ -656,7 +661,7 @@
 				</jr:list>
 			</componentElement>
 			<rectangle>
-				<reportElement positionType="Float" x="0" y="82" width="802" height="12" backcolor="#37474F" mode="Opaque" uuid="33333333-2222-1111-1111-300900000003"/>
+				<reportElement positionType="Float" mode="Opaque" x="0" y="82" width="802" height="12" backcolor="#37474F" uuid="33333333-2222-1111-1111-300900000003"/>
 			</rectangle>
 			<staticText>
 				<reportElement positionType="Float" mode="Transparent" x="0" y="82" width="802" height="12" forecolor="#FFFFFF" uuid="33333333-2222-1111-1111-333333333350"/>
@@ -705,14 +710,14 @@
 							<textElement verticalAlignment="Middle">
 								<font fontName="Verdana" size="7"/>
 							</textElement>
-							<textFieldExpression><![CDATA[$F{descripcion}]]></textFieldExpression>
+							<textFieldExpression><![CDATA[$F{descripcion} == null || $F{descripcion}.trim().isEmpty() ? "Sin observaciones" : $F{descripcion}]]></textFieldExpression>
 						</textField>
 						<textField isBlankWhenNull="true">
 							<reportElement x="600" y="0" width="202" height="11" uuid="33333333-4444-1111-1111-333333333357"/>
 							<textElement verticalAlignment="Middle">
 								<font fontName="Verdana" size="7"/>
 							</textElement>
-							<textFieldExpression><![CDATA[$F{motivo}]]></textFieldExpression>
+							<textFieldExpression><![CDATA[$F{motivo} == null || $F{motivo}.trim().isEmpty() ? "Sin motivos" : $F{motivo}]]></textFieldExpression>
 						</textField>
 					</jr:listContents>
 				</jr:list>
@@ -776,56 +781,56 @@
 					<textFieldExpression><![CDATA[$F{totalRecibidoRs}]]></textFieldExpression>
 				</textField>
 				<staticText>
-					<reportElement x="420" y="0" width="150" height="10" uuid="33333333-5555-1111-1111-333333333367"/>
+					<reportElement x="532" y="0" width="150" height="10" uuid="33333333-5555-1111-1111-333333333367"/>
 					<textElement>
 						<font fontName="Verdana" size="7"/>
 					</textElement>
 					<text><![CDATA[Total recibido Ds:]]></text>
 				</staticText>
 				<textField pattern="#,##0.##" isBlankWhenNull="true">
-					<reportElement x="570" y="0" width="120" height="10" uuid="33333333-5555-1111-1111-333333333368"/>
+					<reportElement x="682" y="0" width="120" height="10" uuid="33333333-5555-1111-1111-333333333368"/>
 					<textElement textAlignment="Right">
 						<font fontName="Verdana" size="7"/>
 					</textElement>
 					<textFieldExpression><![CDATA[$F{totalRecibidoDs}]]></textFieldExpression>
 				</textField>
 				<staticText>
-					<reportElement x="420" y="10" width="150" height="10" uuid="33333333-5555-1111-1111-333333333369"/>
+					<reportElement x="532" y="10" width="150" height="10" uuid="33333333-5555-1111-1111-333333333369"/>
 					<textElement>
 						<font fontName="Verdana" size="7"/>
 					</textElement>
 					<text><![CDATA[Total descuento (Gs.):]]></text>
 				</staticText>
 				<textField pattern="#,##0" isBlankWhenNull="true">
-					<reportElement x="570" y="10" width="120" height="10" uuid="33333333-5555-1111-1111-333333333370"/>
+					<reportElement x="682" y="10" width="120" height="10" uuid="33333333-5555-1111-1111-333333333370"/>
 					<textElement textAlignment="Right">
 						<font fontName="Verdana" size="7"/>
 					</textElement>
 					<textFieldExpression><![CDATA[$F{totalDescuento}]]></textFieldExpression>
 				</textField>
 				<staticText>
-					<reportElement x="420" y="20" width="150" height="10" uuid="33333333-5555-1111-1111-333333333371"/>
+					<reportElement x="532" y="20" width="150" height="10" uuid="33333333-5555-1111-1111-333333333371"/>
 					<textElement>
 						<font fontName="Verdana" size="7"/>
 					</textElement>
 					<text><![CDATA[Total aumento (Gs.):]]></text>
 				</staticText>
 				<textField pattern="#,##0" isBlankWhenNull="true">
-					<reportElement x="570" y="20" width="120" height="10" uuid="33333333-5555-1111-1111-333333333372"/>
+					<reportElement x="682" y="20" width="120" height="10" uuid="33333333-5555-1111-1111-333333333372"/>
 					<textElement textAlignment="Right">
 						<font fontName="Verdana" size="7"/>
 					</textElement>
 					<textFieldExpression><![CDATA[$F{totalAumento}]]></textFieldExpression>
 				</textField>
 				<staticText>
-					<reportElement x="420" y="30" width="150" height="10" uuid="33333333-5555-1111-1111-333333333373"/>
+					<reportElement x="532" y="30" width="150" height="10" uuid="33333333-5555-1111-1111-333333333373"/>
 					<textElement>
 						<font fontName="Verdana" size="7" isBold="true"/>
 					</textElement>
 					<text><![CDATA[Total final (Gs.):]]></text>
 				</staticText>
 				<textField pattern="#,##0" isBlankWhenNull="true">
-					<reportElement x="570" y="30" width="120" height="10" uuid="33333333-5555-1111-1111-333333333374"/>
+					<reportElement x="682" y="30" width="120" height="10" uuid="33333333-5555-1111-1111-333333333374"/>
 					<textElement textAlignment="Right">
 						<font fontName="Verdana" size="7" isBold="true"/>
 					</textElement>

--- a/src/main/resources/reports/reporte-ventas-detallado.jrxml
+++ b/src/main/resources/reports/reporte-ventas-detallado.jrxml
@@ -398,8 +398,8 @@
 				</graphicElement>
 			</rectangle>
 			<textField>
-				<reportElement x="0" y="0" width="45" height="14" uuid="33333333-1111-1111-1111-333333333302"/>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
+				<reportElement x="0" y="0" width="110" height="14" uuid="33333333-1111-1111-1111-333333333302"/>
+				<textElement textAlignment="Left" verticalAlignment="Middle">
 					<font fontName="Verdana" size="8" isBold="true"/>
 				</textElement>
 				<textFieldExpression><![CDATA["Venta #" + $F{ventaId}]]></textFieldExpression>


### PR DESCRIPTION
## Summary
- Nuevo query GraphQL `reporteGenericVentasDetallado` (mismos filtros que `reporteGenericVentas`) que genera un segundo PDF: encabezado de cada venta + detalle completo de productos (con costo unitario y costo total), movimientos de cobro (operación, forma de pago, moneda, valor en moneda/Gs) y observaciones (descripción + motivo).
- Los totales recibido Gs/Rs/Ds, descuento, aumento y final se calculan igual que hoy en `getTotales()` del desktop (`generic-list-venta.component.ts`), portados a Java.
- Nuevo jrxml `reporte-ventas-detallado.jrxml`: usa componentes `jr:list` (mismo patrón que `solicitud-pago.jrxml`) anidados por venta, cada uno alimentado por un campo `JRDataSource` propio del DTO de la venta (`itemsDataSource`, `movimientosDataSource`, `observacionesDataSource`).
- No modifica el reporte superficial existente (`reporteGenericVentas` / `reporte-ventas.jrxml`).

Complementa el PR del lado desktop (frc-sistemas-integrados-angular) que agrega el botón "Generar Reporte Detallado".

## Test plan
- [x] `mvn compile` (via `org.apache.maven.plugins:maven-compiler-plugin:compile`, sin BD) — compila sin errores.
- [x] Smoke test standalone con JasperReports (`JasperCompileManager.compileReport` + `JasperFillManager.fillReport` + export a PDF) usando datos simulados de 2 ventas con items, movimientos y observaciones (una con, una sin observaciones) — compila, llena y exporta correctamente (verificado con `pdftotext`).
- [ ] Probar end-to-end contra una base real desde el desktop una vez mergeado el PR complementario del frontend.

## Riesgo
Bajo: solo agrega un query/resolver/DTOs/jrxml nuevos; no toca el reporte ni el flujo existente. Impacto en desktop: ninguno hasta que se consuma el nuevo query.