### PR TITLE
fix(caja): imprimir cierre de caja con la impresora local del desktop

### DIFF
--- a/src/main/java/com/franco/dev/graphql/financiero/PdvCajaGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/PdvCajaGraphQL.java
@@ -200,7 +200,11 @@ public class PdvCajaGraphQL implements GraphQLQueryResolver, GraphQLMutationReso
     }
 
     public PdvCaja imprimirBalance(Long id, String printerName, String local, Long sucId) {
-        if (sucId != null) {
+        // Ruteo a la filial SOLO cuando el caller no especifica impresora (frc-mobile envia
+        // printerName=null y la filial resuelve su propia config). El desktop siempre envia
+        // su printerName local y debe imprimir con esa config, igual que reimprimirVenta.
+        boolean sinImpresora = printerName == null || printerName.isBlank();
+        if (sucId != null && sinImpresora) {
             Sucursal sucursal = sucursalService.findById(sucId).orElse(null);
             if (sucursal != null && sucursal.getIp() != null && !sucursal.getIp().isBlank()) {
                 return filialCajaProxyService.imprimirBalanceEnFilial(id, sucId, printerName, local);


### PR DESCRIPTION
## Qué resuelve

Al imprimir un cierre de caja desde el desktop (frc-sistemas-integrados), el ticket salía en la impresora de la **sucursal** en vez de la impresora configurada localmente en la app. El ruteo hacia la filial introducido en `6c210f12` (proxy de caja para mobile) se aplicaba a **todos** los callers de `imprimirBalance`, y el proxy además descartaba el `printerName`/`local` enviados por el desktop.

## Cambio

En `PdvCajaGraphQL.imprimirBalance` (central): el ruteo a la filial ahora solo ocurre cuando el caller **no especifica impresora** (`printerName` null/vacío):

- **frc-mobile** envía `printerName: null` → sigue ruteando a la filial, que resuelve su propia config (sin cambios).
- **desktop** siempre envía su `printerName` local → vuelve a imprimir directo en el central con esa config, igual que `reimprimirVenta` (comportamiento pre-`6c210f12`).

Sin cambios de schema GraphQL ni en clientes (desktop/mobile/filial).

## Cómo probarlo

1. Desde el desktop conectado al central, abrir Cajas → una caja de una sucursal con IP configurada → Imprimir Cierre → debe salir por la impresora ticket configurada en la app (no en la sucursal).
2. Desde frc-mobile, imprimir balance de cierre → debe seguir saliendo en la impresora de la sucursal.
3. Reimprimir factura desde la lista de facturas → sin cambios (no se tocó).

## Impacto en DB

Ninguno.

## Riesgo

Bajo — un solo método, restaura comportamiento anterior para desktop, mobile mantiene su flujo. Verificado con `./mvnw compile -DskipFlyway=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)