### PR TITLE
feat(financiero): filtro por numero de venta en facturaLegales

### DIFF
--- a/src/main/java/com/franco/dev/graphql/financiero/FacturaLegalGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/FacturaLegalGraphQL.java
@@ -242,9 +242,9 @@ public class FacturaLegalGraphQL implements GraphQLQueryResolver, GraphQLMutatio
 
     public Page<FacturaLegal> facturaLegales(Integer page, Integer size, String fechaInicio, String fechaFin,
             List<Long> sucId, String ruc, String nombre, Boolean iva5, Boolean iva10, Boolean isElectronico,
-            Boolean activo, Boolean sinNombre) {
+            Boolean activo, Boolean sinNombre, Long ventaId) {
         Page<FacturaLegal> response = service.findByAll(page, size, fechaInicio, fechaFin, sucId, ruc, nombre, iva5,
-                iva10, isElectronico, activo, sinNombre);
+                iva10, isElectronico, activo, sinNombre, ventaId);
         return response;
     }
 

--- a/src/main/java/com/franco/dev/repository/financiero/FacturaLegalSpecification.java
+++ b/src/main/java/com/franco/dev/repository/financiero/FacturaLegalSpecification.java
@@ -21,7 +21,8 @@ public final class FacturaLegalSpecification {
             String nombre,
             Boolean isElectronico,
             Boolean activo,
-            Boolean sinNombre) {
+            Boolean sinNombre,
+            Long ventaId) {
 
         return (root, query, criteriaBuilder) -> {
             List<Predicate> predicates = new ArrayList<>();
@@ -70,6 +71,10 @@ public final class FacturaLegalSpecification {
                 } else {
                     predicates.add(criteriaBuilder.notEqual(criteriaBuilder.upper(root.get("nombre")), "SIN NOMBRE"));
                 }
+            }
+
+            if (ventaId != null) {
+                predicates.add(criteriaBuilder.equal(root.join("venta", JoinType.INNER).get("id"), ventaId));
             }
 
             return criteriaBuilder.and(predicates.toArray(new Predicate[0]));

--- a/src/main/java/com/franco/dev/service/financiero/FacturaLegalService.java
+++ b/src/main/java/com/franco/dev/service/financiero/FacturaLegalService.java
@@ -83,10 +83,11 @@ public class FacturaLegalService extends CrudService<FacturaLegal, FacturaLegalR
 
     public Page<FacturaLegal> findByAll(Integer page, Integer size, String fechaInicio, String fechaFin,
             List<Long> sucId, String ruc, String nombre, Boolean iva5, Boolean iva10, Boolean isElectronico,
-            Boolean activo, Boolean sinNombre) {
+            Boolean activo, Boolean sinNombre, Long ventaId) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("id").ascending());
         Page<FacturaLegal> response = repository.findAll(
-                withFilters(fechaInicio, fechaFin, sucId, ruc, nombre, isElectronico, activo, sinNombre), pageable);
+                withFilters(fechaInicio, fechaFin, sucId, ruc, nombre, isElectronico, activo, sinNombre, ventaId),
+                pageable);
         return response;
     }
 

--- a/src/main/resources/graphql/financiero/factura-legal.graphqls
+++ b/src/main/resources/graphql/financiero/factura-legal.graphqls
@@ -96,7 +96,7 @@ type SaveFacturaLegalToFilialResponse {
 
 extend type Query {
     facturaLegal(id:ID!, sucId: ID):FacturaLegal
-    facturaLegales(page: Int, size: Int, fechaInicio: String, fechaFin: String, sucId: [ID], ruc: String, nombre: String, iva5: Boolean, iva10: Boolean, isElectronico: Boolean, activo: Boolean, sinNombre: Boolean):FacturaLegalPage!
+    facturaLegales(page: Int, size: Int, fechaInicio: String, fechaFin: String, sucId: [ID], ruc: String, nombre: String, iva5: Boolean, iva10: Boolean, isElectronico: Boolean, activo: Boolean, sinNombre: Boolean, ventaId: ID):FacturaLegalPage!
     countFacturaLegal: Int
     facturaLegalByCdc(cdc: String):FacturaLegal
     reimprimirFacturaLegal(id:ID!, sucId:ID!, printerName: String):Boolean


### PR DESCRIPTION
## Qué resuelve
Agrega el parámetro opcional `ventaId: ID` a la query `facturaLegales` para poder filtrar la lista de facturas por el id de la venta asociada (nuevo filtro "Número de venta" en el desktop).

- `FacturaLegalSpecification`: nuevo predicado `join("venta").id = ventaId` (el join compuesto incluye `sucursal_id`, respeta el multitenant).
- `FacturaLegalService.findByAll` y `FacturaLegalGraphQL.facturaLegales`: nuevo parámetro pasado en cadena.
- Schema `factura-legal.graphqls`: parámetro agregado al final, **aditivo y retrocompatible** (clientes viejos no lo envían y todo sigue igual).

PR par en el desktop: GabFrank/frc-sistemas-integrados-angular (feature/financiero-filtro-venta-facturas).

## Cómo probarlo
1. Levantar el server y abrir GraphiQL.
2. Ejecutar `facturaLegales(page: 0, size: 10, ventaId: 734498, ...)` → devuelve solo las facturas de esa venta.
3. Sin `ventaId` → comportamiento idéntico al actual.

## Impacto en DB
Ninguno — sin migraciones, solo lectura vía Specification.

## Riesgo
Bajo — cambio aditivo, un solo predicado nuevo condicionado a `ventaId != null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)