### PR TITLE
feat: replicacion venta_tarjeta / configuracion_venta_tarjeta

### DIFF
--- a/src/main/resources/db/migration/V150.1__registrar_replicacion_venta_tarjeta.sql
+++ b/src/main/resources/db/migration/V150.1__registrar_replicacion_venta_tarjeta.sql
@@ -1,0 +1,11 @@
+-- Venta con tarjeta offline-first:
+-- - configuracion_venta_tarjeta: central -> todas las filiales (fuente de verdad: central).
+-- - venta_tarjeta: la filial crea (PENDIENTE) y sube al central; el estado que
+--   setea la app movil en el central (COMPLETADO) vuelve a la filial duena
+--   via central_filialX_pub con WHERE sucursal_id = X (mismo esquema que operaciones.venta).
+INSERT INTO configuraciones.replication_table
+    (table_name, direction, description, enabled, replicate_central_to_branch_with_filter, creado_en)
+VALUES
+    ('financiero.configuracion_venta_tarjeta', 'MAIN_TO_ALL', 'Configuracion Venta Tarjeta', true, false, NOW()),
+    ('financiero.venta_tarjeta', 'BRANCH_TO_MAIN', 'Venta Tarjeta', true, true, NOW())
+ON CONFLICT (table_name) DO NOTHING;


### PR DESCRIPTION
## Resumen
Registra en `configuraciones.replication_table`:
- `financiero.configuracion_venta_tarjeta` → **MAIN_TO_ALL** (config administrada en central, leída localmente en filiales)
- `financiero.venta_tarjeta` → **BRANCH_TO_MAIN** con `replicate_central_to_branch_with_filter=true` (la filial crea, el estado del móvil vuelve filtrado por sucursal — mismo esquema que `operaciones.venta`)

Parte de la feature **venta con tarjeta offline-first** (junto a los PRs de filial, desktop y frc-mobile).

## Despliegue
⚠️ Orden obligatorio: **primero** migrar filiales (V78.1), **después** este PR, después `setval` de secuencia por filial y `REFRESH PUBLICATION` (backflow con `copy_data=false`). Runbook completo en el workspace DEV-FRC (`docs/superpowers/specs/2026-07-22-venta-tarjeta-offline-runbook.md`). Despliegue escalonado: 5 filiales farmacia primero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)