### PR TITLE
fix(personas): guardar estado activo del usuario en saveUsuario

### DIFF
--- a/src/main/java/com/franco/dev/graphql/personas/UsuarioGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/personas/UsuarioGraphQL.java
@@ -70,6 +70,12 @@ public class UsuarioGraphQL implements GraphQLQueryResolver, GraphQLMutationReso
             e.setUsuario(service.findById(input.getUsuarioId()).orElse(null));
         if (input.getPersonaId() != null)
             e.setPersona(personaService.findById(input.getPersonaId()).orElse(null));
+        if (input.getActivo() == null) {
+            // caller no envió 'activo': preservar el valor actual (o true si es nuevo)
+            e.setActivo(input.getId() != null
+                    ? service.findById(input.getId()).map(Usuario::getActivo).orElse(true)
+                    : true);
+        }
         e = service.save(e);
         return e;
     }

--- a/src/main/java/com/franco/dev/graphql/personas/input/UsuarioInput.java
+++ b/src/main/java/com/franco/dev/graphql/personas/input/UsuarioInput.java
@@ -12,4 +12,5 @@ public class UsuarioInput {
     private LocalDateTime creadoEn;
     private Long personaId;
     private Long usuarioId;
+    private Boolean activo;
 }


### PR DESCRIPTION
## Qué resuelve

Al editar un usuario desde el desktop y poner **Activo = No**, el cambio no se persistía: el usuario siempre quedaba activo.

**Causa raíz:** el schema GraphQL (`usuario.graphqls`) declara `activo: Boolean` en `UsuarioInput`, pero el DTO Java `UsuarioInput.java` no tenía el campo → el valor enviado por el cliente se descartaba silenciosamente al deserializar. Luego `ModelMapper` construye la entidad `Usuario`, cuyo field initializer es `activo = true`, por lo que **siempre se guardaba activo=true**.

## Cambios

- `UsuarioInput.java`: se agrega el campo `activo`.
- `UsuarioGraphQL.saveUsuario()`: si el caller **no** envía `activo` (ej. mobile, reset de contraseña), se preserva el valor actual del usuario en vez de pisarlo con `null`; `true` por defecto para usuarios nuevos.

## Cómo probarlo

1. Levantar el central con este build.
2. En el desktop: Usuarios → editar un usuario → toggle **Activo = No** → Guardar.
3. Verificar que la lista muestra "No" y que en DB `personas.usuario.activo = false`.
4. Regresión: resetear contraseña de un usuario inactivo → debe seguir inactivo. Crear usuario nuevo → debe quedar activo.

## Impacto

- **DB:** ninguno (sin migraciones).
- **Riesgo:** bajo — solo afecta la mutation `saveUsuario`; clientes que no envían `activo` conservan el comportamiento esperado.
- **Rollback:** revertir el commit, sin coordinación con clientes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)