### PR TITLE
ci(deploy): unir el runner a headscale para el deploy de alpha

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -147,6 +147,19 @@ jobs:
               | jq -r '.assets[] | select(.name == "frc-central-server.jar") | .url')"
           ls -lh frc-central-server.jar
 
+      # Alpha corre en una PC sin IP publica: el runner se une a la red
+      # headscale (VPN) para poder alcanzarla via su IP 100.64.x.x.
+      # Requiere el secret HEADSCALE_AUTHKEY (preauth key reusable+ephemeral)
+      # en el environment alpha. Beta/produccion siguen siendo alcanzables
+      # por IP publica y no pasan por este paso.
+      - name: Connect to headscale (alpha only)
+        if: inputs.instance == 'alpha'
+        uses: tailscale/github-action@v3
+        with:
+          authkey: ${{ secrets.HEADSCALE_AUTHKEY }}
+          hostname: gh-deploy-runner
+          args: --login-server=https://hs.farmaciafrancopy.com --accept-dns=false
+
       - name: Setup SSH
         run: |
           mkdir -p ~/.ssh


### PR DESCRIPTION
## Qué resuelve

La instancia **alpha** ya no corre en el servidor con IP pública (100.64.0.3 / 159.203.86.103) sino en una PC detrás de NAT (nodo headscale `100.64.0.2`). Los runners de GitHub no pueden alcanzarla por SSH, así que el deploy push a alpha fallaría.

Este PR agrega un paso condicional (`if: inputs.instance == 'alpha'`) que une el runner a la red headscale (`hs.farmaciafrancopy.com`) vía `tailscale/github-action@v3` antes del paso de SSH. Beta y producción no pasan por este paso — siguen igual.

## Cómo probarlo

1. Configurar en el environment **alpha**: `HEADSCALE_AUTHKEY` (preauth key reusable+ephemeral generada en el server headscale), `DEPLOY_HOST=100.64.0.2`, `DEPLOY_SSH_KEY` (clave dedicada nueva; la pública ya autorizada en la PC destino).
2. Correr el workflow **Deploy** manualmente (workflow_dispatch) eligiendo esta branch, instance `alpha`.
3. Verificar health check OK y `.current-version` actualizado en la PC.

## Impacto en DB
Ninguno.

## Impacto en rollback
Ninguno — la lógica de rollback de `deploy.sh` no cambia.

## Riesgo
Bajo. Solo afecta al canal alpha; commit `ci:` no genera release.

⚠️ Nota: `deploy-auto.yml` (trigger de release) usa los workflows de `master`, así que el deploy automático post-release a alpha recién usará esto cuando llegue a `master`. Mientras tanto, el deploy manual eligiendo la branch ya funciona.

🤖 Generated with [Claude Code](https://claude.com/claude-code)