### PR TITLE
feat(grafico): graficos de costos, inflacion y ventas con delivery

### DIFF
--- a/src/main/java/com/franco/dev/graphql/grafico/GraficoGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/grafico/GraficoGraphQL.java
@@ -50,6 +50,10 @@ public class GraficoGraphQL implements GraphQLQueryResolver {
         return graficoAggregationService.ventasPorSucursalMulti(periodos);
     }
 
+    public List<VentaPorSucursal> deliveryPorSucursalMulti(List<PeriodoGraficoInput> periodos) {
+        return graficoAggregationService.deliveryPorSucursalMulti(periodos);
+    }
+
     public List<VentaPorCiudad> ventasPorCiudadMulti(List<PeriodoGraficoInput> periodos) {
         return graficoAggregationService.ventasPorCiudadMulti(periodos);
     }

--- a/src/main/java/com/franco/dev/graphql/operaciones/VentaItemGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/VentaItemGraphQL.java
@@ -5,6 +5,8 @@ import com.franco.dev.domain.operaciones.Venta;
 import com.franco.dev.domain.operaciones.VentaItem;
 import com.franco.dev.graphql.operaciones.dto.ProductoVendidoEstadistica;
 import com.franco.dev.graphql.operaciones.dto.ProductoCompraPorPeriodo;
+import com.franco.dev.graphql.operaciones.dto.EvolucionCostoResponse;
+import com.franco.dev.graphql.operaciones.dto.RankingInflacionItem;
 import com.franco.dev.graphql.operaciones.dto.ProductoVentaPorPeriodo;
 import com.franco.dev.graphql.operaciones.input.VentaItemInput;
 import com.franco.dev.service.operaciones.VentaItemService;
@@ -189,5 +191,35 @@ public class VentaItemGraphQL implements GraphQLQueryResolver, GraphQLMutationRe
         }
 
         return service.obtenerComprasProductoPorMes(fechaInicio, fechaFin, productoId, sucursalId);
+    }
+
+    public EvolucionCostoResponse evolucionCostoProducto(String inicio, String fin, Long productoId,
+            Long sucursalId, String agrupacion) {
+        LocalDateTime fechaInicio = null;
+        LocalDateTime fechaFin = null;
+
+        if (inicio != null && !inicio.isEmpty()) {
+            fechaInicio = LocalDateTime.parse(inicio, DATE_FORMATTER);
+        }
+        if (fin != null && !fin.isEmpty()) {
+            fechaFin = LocalDateTime.parse(fin, DATE_FORMATTER);
+        }
+
+        return service.obtenerEvolucionCostoProducto(fechaInicio, fechaFin, productoId, sucursalId, agrupacion);
+    }
+
+    public List<RankingInflacionItem> rankingInflacionCosto(String inicio, String fin, Long sucursalId,
+            Long familiaId, Integer limit, String orden) {
+        LocalDateTime fechaInicio = null;
+        LocalDateTime fechaFin = null;
+
+        if (inicio != null && !inicio.isEmpty()) {
+            fechaInicio = LocalDateTime.parse(inicio, DATE_FORMATTER);
+        }
+        if (fin != null && !fin.isEmpty()) {
+            fechaFin = LocalDateTime.parse(fin, DATE_FORMATTER);
+        }
+
+        return service.obtenerRankingInflacionCosto(fechaInicio, fechaFin, sucursalId, familiaId, limit, orden);
     }
 }

--- a/src/main/java/com/franco/dev/graphql/operaciones/dto/EvolucionCostoResponse.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/dto/EvolucionCostoResponse.java
@@ -1,0 +1,15 @@
+package com.franco.dev.graphql.operaciones.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class EvolucionCostoResponse {
+    private List<ProductoCostoPorPeriodo> periodos;
+    private EvolucionCostoResumen resumen;
+}

--- a/src/main/java/com/franco/dev/graphql/operaciones/dto/EvolucionCostoResumen.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/dto/EvolucionCostoResumen.java
@@ -1,0 +1,18 @@
+package com.franco.dev.graphql.operaciones.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class EvolucionCostoResumen {
+    private Double costoInicial;
+    private Double costoFinal;
+    private Double variacionPorcentual;
+    private Double costoPromedioPonderado;
+    private String periodoConMayorCosto;
+    private Integer totalCompras;
+    private Boolean hayDatos;
+}

--- a/src/main/java/com/franco/dev/graphql/operaciones/dto/ProductoCostoPorPeriodo.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/dto/ProductoCostoPorPeriodo.java
@@ -1,0 +1,17 @@
+package com.franco.dev.graphql.operaciones.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductoCostoPorPeriodo {
+    private String periodo;
+    private Double costoPromedio;
+    private Double costoMinimo;
+    private Double costoMaximo;
+    private Double cantidad;
+    private Integer cantidadCompras;
+}

--- a/src/main/java/com/franco/dev/graphql/operaciones/dto/RankingInflacionItem.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/dto/RankingInflacionItem.java
@@ -1,0 +1,18 @@
+package com.franco.dev.graphql.operaciones.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RankingInflacionItem {
+    private Long productoId;
+    private String descripcion;
+    private Double costoInicial;
+    private Double costoFinal;
+    private Double variacionPorcentual;
+    private Integer periodos;
+    private Integer totalCompras;
+}

--- a/src/main/java/com/franco/dev/repository/operaciones/DeliveryRepository.java
+++ b/src/main/java/com/franco/dev/repository/operaciones/DeliveryRepository.java
@@ -26,6 +26,23 @@ public interface DeliveryRepository extends HelperRepository<Delivery, EmbebedPr
 
     Delivery findByIdAndSucursalId(Long id, Long sucId);
 
+    /**
+     * Total facturado en delivery por sucursal (gráfico "Ventas con Delivery").
+     * Suma el valor del precio de delivery de los deliveries CONCLUIDOS en el rango.
+     * Devuelve: [sucursalId, nombreSucursal, totalGs, cantidadDeliveries].
+     */
+    @Query(value = "SELECT d.sucursal_id, s.nombre, COALESCE(SUM(pd.valor), 0), COUNT(DISTINCT d.id) " +
+            "FROM operaciones.delivery d " +
+            "JOIN operaciones.precio_delivery pd ON d.precio_delivery_id = pd.id " +
+            "JOIN empresarial.sucursal s ON s.id = d.sucursal_id " +
+            "WHERE cast(d.estado as text) = 'CONCLUIDO' " +
+            "AND d.creado_en BETWEEN :startDate AND :endDate " +
+            "GROUP BY d.sucursal_id, s.nombre " +
+            "ORDER BY COALESCE(SUM(pd.valor), 0) DESC", nativeQuery = true)
+    List<Object[]> findTotalDeliveryPorSucursal(
+            @org.springframework.data.repository.query.Param("startDate") java.time.LocalDateTime startDate,
+            @org.springframework.data.repository.query.Param("endDate") java.time.LocalDateTime endDate);
+
 //    @Query("select p from Delivery p left outer join p.proveedor as pro left outer join pro.persona as per where LOWER(per.nombre) like %?1%")
 //    public List<Delivery> findByProveedor(String texto);
 

--- a/src/main/java/com/franco/dev/service/grafico/GraficoAggregationService.java
+++ b/src/main/java/com/franco/dev/service/grafico/GraficoAggregationService.java
@@ -14,6 +14,7 @@ import com.franco.dev.graphql.operaciones.dto.ProductoVendidoEstadistica;
 import com.franco.dev.service.empresarial.SucursalService;
 import com.franco.dev.service.financiero.GastoService;
 import com.franco.dev.service.operaciones.CobroDetalleService;
+import com.franco.dev.service.operaciones.DeliveryService;
 import com.franco.dev.service.operaciones.VentaItemService;
 import com.franco.dev.service.operaciones.VentaService;
 import lombok.RequiredArgsConstructor;
@@ -47,6 +48,7 @@ public class GraficoAggregationService {
     private final VentaItemService ventaItemService;
     private final GastoService gastoService;
     private final SucursalService sucursalService;
+    private final DeliveryService deliveryService;
 
     public List<VentaPorFuncionario> ventasPorFuncionarioMulti(
             List<PeriodoGraficoInput> periodos,
@@ -130,6 +132,23 @@ public class GraficoAggregationService {
         for (PeriodoGraficoInput periodo : periodos) {
             Integer anio = extraerAnho(periodo.getInicio());
             List<VentaPorSucursal> items = ventaService.ventaPorSucursal(
+                    periodo.getInicio(),
+                    periodo.getFin());
+            acumularVentasPorSucursal(mapa, items, periodo.getEtiqueta(), multiPeriodo, anio);
+        }
+
+        return ordenarVentasPorSucursalDesc(mapa.values());
+    }
+
+    public List<VentaPorSucursal> deliveryPorSucursalMulti(List<PeriodoGraficoInput> periodos) {
+        validarPeriodos(periodos);
+        boolean multiPeriodo = esMultiPeriodo(periodos);
+
+        Map<String, VentaPorSucursal> mapa = new LinkedHashMap<>();
+
+        for (PeriodoGraficoInput periodo : periodos) {
+            Integer anio = extraerAnho(periodo.getInicio());
+            List<VentaPorSucursal> items = deliveryService.deliveryPorSucursal(
                     periodo.getInicio(),
                     periodo.getFin());
             acumularVentasPorSucursal(mapa, items, periodo.getEtiqueta(), multiPeriodo, anio);

--- a/src/main/java/com/franco/dev/service/grafico/excel/GraficoExcelExportService.java
+++ b/src/main/java/com/franco/dev/service/grafico/excel/GraficoExcelExportService.java
@@ -38,6 +38,8 @@ public class GraficoExcelExportService {
                 return exportarCiudad(filtros, periodos);
             case VENTA_SUCURSAL:
                 return exportarSucursal(filtros, periodos);
+            case DELIVERY_SUCURSAL:
+                return exportarDeliverySucursal(filtros, periodos);
             case VENTA_FUNCIONARIO:
                 return exportarFuncionario(filtros, input, periodos);
             case FORMA_PAGO:
@@ -82,6 +84,22 @@ public class GraficoExcelExportService {
                 "Sucursal",
                 "Detalle por sucursal",
                 "Ventas por Sucursal",
+                filas,
+                GraficoExcelFormatoVisual.BARRAS_VERTICALES
+        );
+    }
+
+    private byte[] exportarDeliverySucursal(GraficoExcelFiltrosContext filtros, List<PeriodoGraficoInput> periodos)
+            throws IOException {
+        List<GraficoDesgloseFila> filas = graficoAggregationService.deliveryPorSucursalMulti(periodos).stream()
+                .map(GraficoDesgloseFila::desdeSucursal)
+                .collect(Collectors.toList());
+        return desgloseBarraExcelExporter.exportar(
+                filtros,
+                "Ventas con Delivery",
+                "Sucursal",
+                "Detalle por sucursal",
+                "Ventas con Delivery",
                 filas,
                 GraficoExcelFormatoVisual.BARRAS_VERTICALES
         );
@@ -233,6 +251,9 @@ public class GraficoExcelExportService {
                 break;
             case VENTA_SUCURSAL:
                 titulo = "Ventas por Sucursal";
+                break;
+            case DELIVERY_SUCURSAL:
+                titulo = "Ventas con Delivery";
                 break;
             case VENTA_FUNCIONARIO:
                 titulo = "Ventas por Funcionario";

--- a/src/main/java/com/franco/dev/service/grafico/excel/GraficoExcelTipo.java
+++ b/src/main/java/com/franco/dev/service/grafico/excel/GraficoExcelTipo.java
@@ -8,5 +8,6 @@ public enum GraficoExcelTipo {
     GASTO_CATEGORIA,
     PRODUCTOS_VENDIDOS,
     INGRESO_GASTO,
-    VENTAS_HORA
+    VENTAS_HORA,
+    DELIVERY_SUCURSAL
 }

--- a/src/main/java/com/franco/dev/service/operaciones/DeliveryService.java
+++ b/src/main/java/com/franco/dev/service/operaciones/DeliveryService.java
@@ -2,6 +2,7 @@ package com.franco.dev.service.operaciones;
 
 import com.franco.dev.domain.EmbebedPrimaryKey;
 import com.franco.dev.domain.operaciones.Delivery;
+import com.franco.dev.domain.operaciones.VentaPorSucursal;
 import com.franco.dev.domain.operaciones.enums.DeliveryEstado;
 import com.franco.dev.graphql.operaciones.publisher.DeliveryPublisher;
 import com.franco.dev.graphql.personas.publisher.PersonaPublisher;
@@ -10,7 +11,12 @@ import com.franco.dev.service.CrudService;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
+
+import static com.franco.dev.utilitarios.DateUtils.ajustarFinRangoGrafico;
+import static com.franco.dev.utilitarios.DateUtils.stringToDate;
 
 @Service
 @AllArgsConstructor
@@ -37,6 +43,26 @@ public class DeliveryService extends CrudService<Delivery, DeliveryRepository, E
 
     public Delivery findByIdAndSucursalId(Long id, Long sucId){
         return repository.findByIdAndSucursalId(id, sucId);
+    }
+
+    /**
+     * Total facturado en delivery por sucursal en un rango (gráfico "Ventas con Delivery").
+     * Reutiliza el DTO {@link VentaPorSucursal}: {@code cantidadVentas} = cantidad de deliveries concluidos.
+     */
+    public List<VentaPorSucursal> deliveryPorSucursal(String fechaInicio, String fechaFin) {
+        LocalDateTime inicio = stringToDate(fechaInicio);
+        LocalDateTime fin = ajustarFinRangoGrafico(fechaFin, stringToDate(fechaFin));
+        List<Object[]> results = repository.findTotalDeliveryPorSucursal(inicio, fin);
+        List<VentaPorSucursal> list = new ArrayList<>();
+        for (Object[] obj : results) {
+            VentaPorSucursal dto = new VentaPorSucursal();
+            dto.setSucId(obj[0] != null ? ((Number) obj[0]).longValue() : null);
+            dto.setNombre(obj[1] != null ? String.valueOf(obj[1]) : "");
+            dto.setTotal(obj[2] != null ? ((Number) obj[2]).doubleValue() : 0.0);
+            dto.setCantidadVentas(obj[3] != null ? ((Number) obj[3]).doubleValue() : 0.0);
+            list.add(dto);
+        }
+        return list;
     }
 
     @Override

--- a/src/main/java/com/franco/dev/service/operaciones/VentaItemService.java
+++ b/src/main/java/com/franco/dev/service/operaciones/VentaItemService.java
@@ -578,25 +578,24 @@ public class VentaItemService extends CrudService<VentaItem, VentaItemRepository
      */
     public List<RankingInflacionItem> obtenerRankingInflacionCosto(LocalDateTime inicio, LocalDateTime fin,
             Long sucursalId, Long familiaId, Integer limit, String orden) {
+        // El costo se registra de forma global (no por sucursal) en productos.costo_por_producto,
+        // por eso sucursalId no se usa. El precio se normaliza a guaranies con la cotizacion.
         StringBuilder filtros = new StringBuilder();
-        if (inicio != null) filtros.append("AND COALESCE(c.fecha, c.creado_en) >= :inicio ");
-        if (fin != null) filtros.append("AND COALESCE(c.fecha, c.creado_en) < :fin ");
-        if (sucursalId != null && sucursalId > 0) filtros.append("AND c.sucursal_id = :sucursalId ");
+        if (inicio != null) filtros.append("AND cpp.creado_en >= :inicio ");
+        if (fin != null) filtros.append("AND cpp.creado_en < :fin ");
         if (familiaId != null && familiaId > 0) filtros.append("AND sf.familia_id = :familiaId ");
 
         String sql = "WITH costos_mes AS ( " +
-                "  SELECT ci.producto_id AS producto_id, p.descripcion AS descripcion, " +
-                "         TO_CHAR(COALESCE(c.fecha, c.creado_en), 'YYYY-MM') AS periodo, " +
-                "         SUM(ci.precio_unitario * ci.cantidad) / NULLIF(SUM(ci.cantidad), 0) AS costo, " +
-                "         COUNT(DISTINCT c.id) AS compras " +
-                "  FROM operaciones.compra_item ci " +
-                "  JOIN operaciones.compra c ON c.id = ci.compra_id " +
-                "  JOIN productos.producto p ON p.id = ci.producto_id " +
+                "  SELECT cpp.producto_id AS producto_id, p.descripcion AS descripcion, " +
+                "         TO_CHAR(cpp.creado_en, 'YYYY-MM') AS periodo, " +
+                "         AVG(cpp.ultimo_precio_compra * COALESCE(NULLIF(cpp.cotizacion, 0), 1)) AS costo, " +
+                "         COUNT(*) AS compras " +
+                "  FROM productos.costo_por_producto cpp " +
+                "  JOIN productos.producto p ON p.id = cpp.producto_id " +
                 "  LEFT JOIN productos.subfamilia sf ON p.sub_familia_id = sf.id " +
-                "  WHERE c.estado = 'ACTIVO' AND ci.precio_unitario > 0 " +
-                "    AND (ci.bonificacion IS NULL OR ci.bonificacion = false) " +
+                "  WHERE cpp.ultimo_precio_compra > 0 " +
                 filtros.toString() +
-                "  GROUP BY ci.producto_id, p.descripcion, TO_CHAR(COALESCE(c.fecha, c.creado_en), 'YYYY-MM') " +
+                "  GROUP BY cpp.producto_id, p.descripcion, TO_CHAR(cpp.creado_en, 'YYYY-MM') " +
                 "), ranked AS ( " +
                 "  SELECT producto_id, descripcion, costo, compras, " +
                 "         ROW_NUMBER() OVER (PARTITION BY producto_id ORDER BY periodo ASC) AS rn_asc, " +
@@ -613,7 +612,6 @@ public class VentaItemService extends CrudService<VentaItem, VentaItemRepository
         javax.persistence.Query query = em.createNativeQuery(sql);
         if (inicio != null) query.setParameter("inicio", inicio);
         if (fin != null) query.setParameter("fin", fin);
-        if (sucursalId != null && sucursalId > 0) query.setParameter("sucursalId", sucursalId);
         if (familiaId != null && familiaId > 0) query.setParameter("familiaId", familiaId);
 
         @SuppressWarnings("unchecked")

--- a/src/main/java/com/franco/dev/service/operaciones/VentaItemService.java
+++ b/src/main/java/com/franco/dev/service/operaciones/VentaItemService.java
@@ -8,6 +8,10 @@ import com.franco.dev.domain.productos.CostoPorProducto;
 import com.franco.dev.domain.productos.Producto;
 import com.franco.dev.graphql.operaciones.dto.ProductoVendidoEstadistica;
 import com.franco.dev.graphql.operaciones.dto.ProductoCompraPorPeriodo;
+import com.franco.dev.graphql.operaciones.dto.ProductoCostoPorPeriodo;
+import com.franco.dev.graphql.operaciones.dto.EvolucionCostoResponse;
+import com.franco.dev.graphql.operaciones.dto.EvolucionCostoResumen;
+import com.franco.dev.graphql.operaciones.dto.RankingInflacionItem;
 import com.franco.dev.graphql.operaciones.dto.ProductoVentaPorPeriodo;
 import com.franco.dev.repository.operaciones.VentaItemRepository;
 import com.franco.dev.service.CrudService;
@@ -432,6 +436,209 @@ public class VentaItemService extends CrudService<VentaItem, VentaItemRepository
             periodos.add(new ProductoCompraPorPeriodo(periodo, cantidad, cantidadCompras));
         }
         return periodos;
+    }
+
+    /**
+     * Evolucion del costo unitario de compra de un producto: serie por periodo + resumen calculado.
+     * Fuente: operaciones.compra_item (precio_unitario real de factura) unido a compra.
+     * Solo compras ACTIVAS (interfieren en stock), con precio > 0 y excluyendo bonificaciones
+     * (items regalados con precio 0 que distorsionarian el promedio).
+     *
+     * @param agrupacion "dia" agrupa por fecha; cualquier otro valor (por defecto) agrupa por mes.
+     */
+    public EvolucionCostoResponse obtenerEvolucionCostoProducto(LocalDateTime inicio, LocalDateTime fin,
+            Long productoId, Long sucursalId, String agrupacion) {
+        // El costo de compra se lleva de forma global (no por sucursal), por eso sucursalId no se usa.
+        List<ProductoCostoPorPeriodo> periodos =
+                obtenerCostoCompraProductoPorPeriodo(inicio, fin, productoId, agrupacion);
+        return new EvolucionCostoResponse(periodos, calcularResumenCosto(periodos));
+    }
+
+    /** Calcula los indicadores agregados de la evolucion de costo (variacion, promedio ponderado, pico). */
+    private EvolucionCostoResumen calcularResumenCosto(List<ProductoCostoPorPeriodo> periodos) {
+        List<ProductoCostoPorPeriodo> conDato = new ArrayList<>();
+        for (ProductoCostoPorPeriodo p : periodos) {
+            if (p.getCostoPromedio() != null && p.getCostoPromedio() > 0) {
+                conDato.add(p);
+            }
+        }
+
+        if (conDato.isEmpty()) {
+            return new EvolucionCostoResumen(0.0, 0.0, 0.0, 0.0, "-", 0, false);
+        }
+
+        double costoInicial = conDato.get(0).getCostoPromedio();
+        double costoFinal = conDato.get(conDato.size() - 1).getCostoPromedio();
+        double variacion = costoInicial > 0 ? ((costoFinal - costoInicial) / costoInicial) * 100.0 : 0.0;
+
+        double sumaPonderada = 0.0;
+        double sumaCantidad = 0.0;
+        String periodoPico = conDato.get(0).getPeriodo();
+        double costoPico = -1.0;
+        int totalCompras = 0;
+        for (ProductoCostoPorPeriodo p : conDato) {
+            double cantidad = p.getCantidad() != null ? p.getCantidad() : 0.0;
+            sumaPonderada += p.getCostoPromedio() * cantidad;
+            sumaCantidad += cantidad;
+            if (p.getCostoPromedio() > costoPico) {
+                costoPico = p.getCostoPromedio();
+                periodoPico = p.getPeriodo();
+            }
+        }
+        for (ProductoCostoPorPeriodo p : periodos) {
+            totalCompras += p.getCantidadCompras() != null ? p.getCantidadCompras() : 0;
+        }
+        double promedioPonderado = sumaCantidad > 0 ? sumaPonderada / sumaCantidad : costoFinal;
+
+        return new EvolucionCostoResumen(costoInicial, costoFinal, variacion, promedioPonderado,
+                periodoPico, totalCompras, true);
+    }
+
+    /**
+     * Serie de costo de compra por periodo. El costo real se registra de forma global (no por sucursal)
+     * en productos.costo_por_producto, tabla que guarda el ultimo_precio_compra cada vez que se
+     * actualiza el costo de un producto. Las cantidades compradas y el numero de compras se toman de
+     * los movimientos de stock tipo COMPRA. El precio se normaliza a guaranies multiplicando por la
+     * cotizacion (1 para moneda local).
+     */
+    private List<ProductoCostoPorPeriodo> obtenerCostoCompraProductoPorPeriodo(LocalDateTime inicio, LocalDateTime fin,
+            Long productoId, String agrupacion) {
+        boolean porDia = "dia".equalsIgnoreCase(agrupacion);
+        String periodoCosto = porDia ? "CAST(cpp.creado_en AS DATE)" : "TO_CHAR(cpp.creado_en, 'YYYY-MM')";
+        String periodoCompra = porDia ? "CAST(ms.creado_en AS DATE)" : "TO_CHAR(ms.creado_en, 'YYYY-MM')";
+        String costoGs = "cpp.ultimo_precio_compra * COALESCE(NULLIF(cpp.cotizacion, 0), 1)";
+
+        StringBuilder filtroCosto = new StringBuilder();
+        StringBuilder filtroCompra = new StringBuilder();
+        if (inicio != null) {
+            filtroCosto.append("AND cpp.creado_en >= :inicio ");
+            filtroCompra.append("AND ms.creado_en >= :inicio ");
+        }
+        if (fin != null) {
+            filtroCosto.append("AND cpp.creado_en < :fin ");
+            filtroCompra.append("AND ms.creado_en < :fin ");
+        }
+
+        String sql = "WITH costos AS ( " +
+                "  SELECT " + periodoCosto + " AS periodo, " +
+                "         AVG(" + costoGs + ") AS costo_promedio, " +
+                "         MIN(" + costoGs + ") AS costo_minimo, " +
+                "         MAX(" + costoGs + ") AS costo_maximo " +
+                "  FROM productos.costo_por_producto cpp " +
+                "  WHERE cpp.producto_id = :productoId AND cpp.ultimo_precio_compra > 0 " +
+                filtroCosto.toString() +
+                "  GROUP BY " + periodoCosto + " " +
+                "), compras AS ( " +
+                // Se considera compra tanto un movimiento COMPRA como una TRANSFERENCIA cuyo origen es
+                // la sucursal COMPRAS (asi funcionaba el abastecimiento antes del modulo de compras).
+                "  SELECT " + periodoCompra + " AS periodo, " +
+                "         SUM(ms.cantidad) AS cantidad, " +
+                "         COUNT(*) AS cantidad_compras " +
+                "  FROM operaciones.movimiento_stock ms " +
+                "  WHERE ms.producto_id = :productoId AND " + sqlCondicionEntradasStock() + " " +
+                filtroCompra.toString() +
+                "  GROUP BY " + periodoCompra + " " +
+                ") " +
+                "SELECT c.periodo, c.costo_promedio, c.costo_minimo, c.costo_maximo, " +
+                "       COALESCE(cm.cantidad, 0) AS cantidad, COALESCE(cm.cantidad_compras, 0) AS cantidad_compras " +
+                "FROM costos c LEFT JOIN compras cm ON cm.periodo = c.periodo " +
+                "ORDER BY c.periodo ASC";
+
+        javax.persistence.Query query = em.createNativeQuery(sql);
+        query.setParameter("productoId", productoId);
+        if (inicio != null) query.setParameter("inicio", inicio);
+        if (fin != null) query.setParameter("fin", fin);
+
+        @SuppressWarnings("unchecked")
+        List<Object[]> resultados = query.getResultList();
+        return mapearCostoPeriodos(resultados);
+    }
+
+    private List<ProductoCostoPorPeriodo> mapearCostoPeriodos(List<Object[]> resultados) {
+        List<ProductoCostoPorPeriodo> periodos = new ArrayList<>();
+        for (Object[] fila : resultados) {
+            String periodo = fila[0] != null ? fila[0].toString() : "";
+            Double costoPromedio = fila[1] != null ? ((Number) fila[1]).doubleValue() : 0.0;
+            Double costoMinimo = fila[2] != null ? ((Number) fila[2]).doubleValue() : 0.0;
+            Double costoMaximo = fila[3] != null ? ((Number) fila[3]).doubleValue() : 0.0;
+            Double cantidad = fila[4] != null ? ((Number) fila[4]).doubleValue() : 0.0;
+            Integer cantidadCompras = fila[5] != null ? ((Number) fila[5]).intValue() : 0;
+            periodos.add(new ProductoCostoPorPeriodo(periodo, costoPromedio, costoMinimo, costoMaximo, cantidad,
+                    cantidadCompras));
+        }
+        return periodos;
+    }
+
+    /**
+     * Ranking de productos por variacion de costo de compra entre el primer y ultimo mes con compras
+     * dentro del periodo. Sirve para detectar inflacion de proveedores de un vistazo.
+     * Solo considera productos con al menos 2 meses distintos de compras (para que exista variacion).
+     *
+     * @param orden "baja" ordena por mayor reduccion; cualquier otro valor (default) por mayor suba.
+     */
+    public List<RankingInflacionItem> obtenerRankingInflacionCosto(LocalDateTime inicio, LocalDateTime fin,
+            Long sucursalId, Long familiaId, Integer limit, String orden) {
+        StringBuilder filtros = new StringBuilder();
+        if (inicio != null) filtros.append("AND COALESCE(c.fecha, c.creado_en) >= :inicio ");
+        if (fin != null) filtros.append("AND COALESCE(c.fecha, c.creado_en) < :fin ");
+        if (sucursalId != null && sucursalId > 0) filtros.append("AND c.sucursal_id = :sucursalId ");
+        if (familiaId != null && familiaId > 0) filtros.append("AND sf.familia_id = :familiaId ");
+
+        String sql = "WITH costos_mes AS ( " +
+                "  SELECT ci.producto_id AS producto_id, p.descripcion AS descripcion, " +
+                "         TO_CHAR(COALESCE(c.fecha, c.creado_en), 'YYYY-MM') AS periodo, " +
+                "         SUM(ci.precio_unitario * ci.cantidad) / NULLIF(SUM(ci.cantidad), 0) AS costo, " +
+                "         COUNT(DISTINCT c.id) AS compras " +
+                "  FROM operaciones.compra_item ci " +
+                "  JOIN operaciones.compra c ON c.id = ci.compra_id " +
+                "  JOIN productos.producto p ON p.id = ci.producto_id " +
+                "  LEFT JOIN productos.subfamilia sf ON p.sub_familia_id = sf.id " +
+                "  WHERE c.estado = 'ACTIVO' AND ci.precio_unitario > 0 " +
+                "    AND (ci.bonificacion IS NULL OR ci.bonificacion = false) " +
+                filtros.toString() +
+                "  GROUP BY ci.producto_id, p.descripcion, TO_CHAR(COALESCE(c.fecha, c.creado_en), 'YYYY-MM') " +
+                "), ranked AS ( " +
+                "  SELECT producto_id, descripcion, costo, compras, " +
+                "         ROW_NUMBER() OVER (PARTITION BY producto_id ORDER BY periodo ASC) AS rn_asc, " +
+                "         ROW_NUMBER() OVER (PARTITION BY producto_id ORDER BY periodo DESC) AS rn_desc, " +
+                "         COUNT(*) OVER (PARTITION BY producto_id) AS n_periodos " +
+                "  FROM costos_mes " +
+                ") " +
+                "SELECT producto_id, MAX(descripcion) AS descripcion, " +
+                "       MAX(CASE WHEN rn_asc = 1 THEN costo END) AS costo_inicial, " +
+                "       MAX(CASE WHEN rn_desc = 1 THEN costo END) AS costo_final, " +
+                "       MAX(n_periodos) AS periodos, SUM(compras) AS total_compras " +
+                "FROM ranked GROUP BY producto_id HAVING MAX(n_periodos) >= 2";
+
+        javax.persistence.Query query = em.createNativeQuery(sql);
+        if (inicio != null) query.setParameter("inicio", inicio);
+        if (fin != null) query.setParameter("fin", fin);
+        if (sucursalId != null && sucursalId > 0) query.setParameter("sucursalId", sucursalId);
+        if (familiaId != null && familiaId > 0) query.setParameter("familiaId", familiaId);
+
+        @SuppressWarnings("unchecked")
+        List<Object[]> resultados = query.getResultList();
+
+        List<RankingInflacionItem> items = new ArrayList<>();
+        for (Object[] fila : resultados) {
+            Long productoId = fila[0] != null ? ((Number) fila[0]).longValue() : null;
+            String descripcion = fila[1] != null ? fila[1].toString() : "";
+            Double costoInicial = fila[2] != null ? ((Number) fila[2]).doubleValue() : 0.0;
+            Double costoFinal = fila[3] != null ? ((Number) fila[3]).doubleValue() : 0.0;
+            Integer periodos = fila[4] != null ? ((Number) fila[4]).intValue() : 0;
+            Integer totalCompras = fila[5] != null ? ((Number) fila[5]).intValue() : 0;
+            Double variacion = costoInicial > 0 ? ((costoFinal - costoInicial) / costoInicial) * 100.0 : 0.0;
+            items.add(new RankingInflacionItem(productoId, descripcion, costoInicial, costoFinal, variacion,
+                    periodos, totalCompras));
+        }
+
+        boolean ascendente = "baja".equalsIgnoreCase(orden);
+        items.sort((a, b) -> ascendente
+                ? Double.compare(a.getVariacionPorcentual(), b.getVariacionPorcentual())
+                : Double.compare(b.getVariacionPorcentual(), a.getVariacionPorcentual()));
+
+        int tope = (limit != null && limit > 0) ? limit : 20;
+        return items.size() > tope ? new ArrayList<>(items.subList(0, tope)) : items;
     }
 
     private List<ProductoVentaPorPeriodo> mapearPeriodos(List<Object[]> resultados) {

--- a/src/main/resources/graphql/grafico/grafico.graphqls
+++ b/src/main/resources/graphql/grafico/grafico.graphqls
@@ -13,6 +13,7 @@ enum GraficoExcelTipo {
     PRODUCTOS_VENDIDOS
     INGRESO_GASTO
     VENTAS_HORA
+    DELIVERY_SUCURSAL
 }
 
 input GraficoExcelExportInput {
@@ -87,6 +88,10 @@ extend type Query {
     ): [GastoPorCategoria!]!
 
     ventasPorSucursalMulti(
+        periodos: [PeriodoGraficoInput!]!
+    ): [VentaPorSucursal!]!
+
+    deliveryPorSucursalMulti(
         periodos: [PeriodoGraficoInput!]!
     ): [VentaPorSucursal!]!
 

--- a/src/main/resources/graphql/operaciones/venta-item.graphqls
+++ b/src/main/resources/graphql/operaciones/venta-item.graphqls
@@ -58,6 +58,40 @@ type ProductoCompraPorPeriodo {
     cantidadCompras: Int
 }
 
+type ProductoCostoPorPeriodo {
+    periodo: String
+    costoPromedio: Float
+    costoMinimo: Float
+    costoMaximo: Float
+    cantidad: Float
+    cantidadCompras: Int
+}
+
+type EvolucionCostoResumen {
+    costoInicial: Float
+    costoFinal: Float
+    variacionPorcentual: Float
+    costoPromedioPonderado: Float
+    periodoConMayorCosto: String
+    totalCompras: Int
+    hayDatos: Boolean
+}
+
+type EvolucionCostoResponse {
+    periodos: [ProductoCostoPorPeriodo]
+    resumen: EvolucionCostoResumen
+}
+
+type RankingInflacionItem {
+    productoId: ID
+    descripcion: String
+    costoInicial: Float
+    costoFinal: Float
+    variacionPorcentual: Float
+    periodos: Int
+    totalCompras: Int
+}
+
 extend type Query {
     ventaItem(id:ID!, sucId: ID):VentaItem
     ventaItems(page:Int = 0, size:Int = 10, sucId: ID):[VentaItem]!
@@ -68,6 +102,8 @@ extend type Query {
     ventasProductoPorMes(inicio: String, fin: String, productoId: ID!, sucursalId: ID): [ProductoVentaPorPeriodo]
     comprasProductoPorDia(inicio: String, fin: String, productoId: ID!, sucursalId: ID): [ProductoCompraPorPeriodo]
     comprasProductoPorMes(inicio: String, fin: String, productoId: ID!, sucursalId: ID): [ProductoCompraPorPeriodo]
+    evolucionCostoProducto(inicio: String, fin: String, productoId: ID!, sucursalId: ID, agrupacion: String): EvolucionCostoResponse
+    rankingInflacionCosto(inicio: String, fin: String, sucursalId: ID, familiaId: ID, limit: Int, orden: String): [RankingInflacionItem]
 }
 
 extend type Mutation {


### PR DESCRIPTION
## Qué resuelve
Agrega la línea de gráficos analíticos del dashboard (backend):
- **Ventas con Delivery por sucursal** (`deliveryPorSucursalMulti`): suma el valor del precio de delivery de los deliveries CONCLUIDOS agrupado por sucursal, con soporte multi-período y comparativa de años. Incluye exportación Excel (`DELIVERY_SUCURSAL`).
- **Evolución de costos** y **ranking de inflación** por producto (commits previos de la rama).
- Compras vía transferencias desde COMPRAS y ranking sobre costo real.

## Cómo probarlo
- GraphiQL: `query { deliveryPorSucursalMulti(periodos: [{etiqueta:"2026", inicio:"2026-01-01 00:00:00", fin:"2026-12-31 23:59:59"}]) { sucId nombre total cantidadVentas } }`
- Verificar exportación Excel tipo `DELIVERY_SUCURSAL`.

## Impacto DB
Ninguno. Solo queries de lectura nuevas (nativa sobre `operaciones.delivery` + `precio_delivery`). Sin migraciones Flyway.

## Riesgo
Bajo. No modifica lógica existente; reutiliza el DTO `VentaPorSucursal` y helpers de agregación.

## Rollback
Revertir los commits. Sin efectos en DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)