### PR TITLE
fix(productos): buscador tolerante a letras faltantes y typos

### DIFF
--- a/src/main/java/com/franco/dev/service/productos/search/ProductoSearchService.java
+++ b/src/main/java/com/franco/dev/service/productos/search/ProductoSearchService.java
@@ -1,9 +1,9 @@
 package com.franco.dev.service.productos.search;
 
 import com.franco.dev.domain.productos.Producto;
+import org.hibernate.search.engine.search.predicate.dsl.BooleanPredicateClausesStep;
 import org.hibernate.search.engine.search.predicate.dsl.PredicateFinalStep;
 import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
-import org.hibernate.search.engine.search.query.SearchResult;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.springframework.stereotype.Service;
@@ -12,19 +12,50 @@ import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
  * Búsqueda textual de productos vía Lucene (fuzzy, prefijo, orden libre, ranking).
  * Sin diccionarios ni reglas de negocio sobre el texto.
+ *
+ * <p>Trabaja en dos pasadas. La primera es estricta (prefijo + subcadena) y es la
+ * que responde la enorme mayoría de las búsquedas. Sólo si esa pasada no devuelve
+ * nada se corre una segunda pasada tolerante que agrega subsecuencia, fuzzy,
+ * token partido y coincidencia parcial de palabras. De esa forma el ruido de la
+ * búsqueda flexible nunca contamina un resultado que ya era bueno: aparece
+ * únicamente cuando la alternativa era "Producto no encontrado".
  */
 @Service
 public class ProductoSearchService {
 
+    private static final String[] CAMPOS = { "descripcion", "descripcionFactura" };
+
     private static final float BOOST_PREFIJO = 8.0f;
+    private static final float BOOST_INFIJO = 2.0f;
+    private static final float BOOST_PARTIDO = 1.0f;
+    private static final float BOOST_SUBSECUENCIA = 0.6f;
     private static final float BOOST_FUZZY = 0.4f;
     private static final int DEFAULT_MAX_RESULTS = 50;
+
+    /**
+     * Longitud minima para habilitar el wildcard de subcadena. Con 1 caracter el
+     * patron `*x*` matchea practicamente todo el catalogo y deja de ser util.
+     */
+    static final int MIN_LONGITUD_INFIJO = 2;
+
+    /** Debajo de 3 caracteres la subsecuencia `a*b*` no discrimina nada. */
+    static final int MIN_LONGITUD_SUBSECUENCIA = 3;
+
+    /** Para partir un token pegado ("cocacola") hacen falta 2 mitades utiles. */
+    static final int MIN_LONGITUD_PARTE = 3;
+    static final int MIN_LONGITUD_TOKEN_PARTIDO = MIN_LONGITUD_PARTE * 2;
+
+    private enum Modo {
+        ESTRICTA, TOLERANTE
+    }
 
     @PersistenceContext
     private EntityManager entityManager;
@@ -64,54 +95,171 @@ public class ProductoSearchService {
         String[] tokens = consulta.split("\\s+");
         SearchSession session = Search.session(entityManager);
 
-        SearchResult<Producto> result = session.search(Producto.class)
+        List<Producto> hits = ejecutar(session, tokens, limit, Modo.ESTRICTA, activo, isEnvase, familiaId,
+                subfamiliaId);
+        if (hits.isEmpty()) {
+            hits = ejecutar(session, tokens, limit, Modo.TOLERANTE, activo, isEnvase, familiaId, subfamiliaId);
+        }
+
+        return ordenarPorRelevancia(hits, consulta);
+    }
+
+    private List<Producto> ejecutar(
+            SearchSession session,
+            String[] tokens,
+            int limit,
+            Modo modo,
+            Boolean activo,
+            Boolean isEnvase,
+            Long familiaId,
+            Long subfamiliaId) {
+        return session.search(Producto.class)
                 .where(f -> {
                     var bool = f.bool();
                     aplicarFiltrosIndexados(bool, f, activo, isEnvase, familiaId, subfamiliaId);
-                    for (String token : tokens) {
-                        bool.must(crearPredicadoToken(f, token));
-                    }
+                    aplicarTokens(bool, f, tokens, modo);
                     return bool;
                 })
-                .fetch(limit);
-
-        return ordenarPorRelevancia(result.hits(), consulta);
+                .fetch(limit)
+                .hits();
     }
 
-    private PredicateFinalStep crearPredicadoToken(SearchPredicateFactory f, String token) {
+    private void aplicarTokens(
+            BooleanPredicateClausesStep<?> bool,
+            SearchPredicateFactory f,
+            String[] tokens,
+            Modo modo) {
+        if (modo == Modo.ESTRICTA || tokens.length < 2) {
+            for (String token : tokens) {
+                bool.must(crearPredicadoToken(f, token, modo));
+            }
+            return;
+        }
+        // Tolerante y multi-palabra: se permite que una palabra quede sin matchear,
+        // asi "coca colaa mal tipeada" no devuelve cero por culpa de un solo termino.
+        bool.must(f.bool(tokenBool -> {
+            for (String token : tokens) {
+                tokenBool.should(crearPredicadoToken(f, token, modo));
+            }
+            tokenBool.minimumShouldMatchNumber(Math.max(1, tokens.length - 1));
+        }));
+    }
+
+    private PredicateFinalStep crearPredicadoToken(SearchPredicateFactory f, String token, Modo modo) {
+        // wildcard() no pasa el patron por el analyzer del campo (a diferencia de match()),
+        // por lo que hay que normalizarlo a mano para que coincida con el indice (lowercase + sin tildes).
+        String base = ProductoTextoRelevanceScorer.normalizar(token);
+        String patron = escaparWildcard(base);
+
         return f.bool(tokenBool -> {
-            // wildcard() no pasa el patron por el analyzer del campo (a diferencia de match()),
-            // por lo que hay que normalizarlo a mano para que coincida con el indice (lowercase + sin tildes).
-            String tokenWildcard = ProductoTextoRelevanceScorer.normalizar(token);
             tokenBool.should(f.wildcard()
-                    .fields("descripcion", "descripcionFactura")
-                    .matching(tokenWildcard + "*")
+                    .fields(CAMPOS)
+                    .matching(patron + "*")
                     .boost(BOOST_PREFIJO));
 
-            int fuzzyDistance = ProductoTextoRelevanceScorer.distanciaFuzzyMaxima(token.length());
-            if (fuzzyDistance > 0) {
-                tokenBool.should(f.match()
-                        .fields("descripcion", "descripcionFactura")
-                        .matching(token)
-                        .fuzzy(fuzzyDistance)
-                        .boost(BOOST_FUZZY));
+            // Subcadena: cubre escribir un fragmento del medio de la palabra
+            // o comerse las primeras letras ("onti" -> "CONTI").
+            if (base.length() >= MIN_LONGITUD_INFIJO) {
+                tokenBool.should(f.wildcard()
+                        .fields(CAMPOS)
+                        .matching("*" + patron + "*")
+                        .boost(BOOST_INFIJO));
+            }
+
+            if (modo == Modo.TOLERANTE) {
+                agregarPredicadosTolerantes(tokenBool, f, token, base);
             }
 
             tokenBool.minimumShouldMatchNumber(1);
         });
     }
 
+    private void agregarPredicadosTolerantes(
+            BooleanPredicateClausesStep<?> tokenBool,
+            SearchPredicateFactory f,
+            String token,
+            String base) {
+        // Subsecuencia: omitir letras preserva el orden de las que quedan, asi que
+        // "cnti"/"coa"/"piln" siguen siendo subsecuencia de CONTI/COCA/PILSEN.
+        // Cubre cualquier cantidad de letras faltantes, en cualquier posicion.
+        if (base.length() >= MIN_LONGITUD_SUBSECUENCIA) {
+            tokenBool.should(f.wildcard()
+                    .fields(CAMPOS)
+                    .matching(patronSubsecuencia(base))
+                    .boost(BOOST_SUBSECUENCIA));
+        }
+
+        // Fuzzy: cubre la otra familia de errores, letra cambiada o de mas.
+        int fuzzyDistance = ProductoTextoRelevanceScorer.distanciaFuzzyMaxima(base.length());
+        if (fuzzyDistance > 0) {
+            tokenBool.should(f.match()
+                    .fields(CAMPOS)
+                    .matching(token)
+                    .fuzzy(fuzzyDistance)
+                    .boost(BOOST_FUZZY));
+        }
+
+        // Token partido: "cocacola" -> COCA + COLA, dos terminos distintos del indice.
+        if (base.length() >= MIN_LONGITUD_TOKEN_PARTIDO) {
+            for (int corte = MIN_LONGITUD_PARTE; corte <= base.length() - MIN_LONGITUD_PARTE; corte++) {
+                String izquierda = escaparWildcard(base.substring(0, corte));
+                String derecha = escaparWildcard(base.substring(corte));
+                tokenBool.should(f.bool()
+                        .must(f.wildcard().fields(CAMPOS).matching(izquierda + "*"))
+                        .must(f.wildcard().fields(CAMPOS).matching(derecha + "*"))
+                        .boost(BOOST_PARTIDO));
+            }
+        }
+    }
+
+    /** Construye `c*o*a*`: cada letra del token, en orden, con huecos entre medio. */
+    static String patronSubsecuencia(String base) {
+        StringBuilder patron = new StringBuilder(base.length() * 2);
+        for (int i = 0; i < base.length(); i++) {
+            char caracter = base.charAt(i);
+            if (esMetacaracterWildcard(caracter)) {
+                patron.append('\\');
+            }
+            patron.append(caracter).append('*');
+        }
+        return patron.toString();
+    }
+
+    /** Evita que un `*` o `?` tipeado por el usuario se interprete como comodin. */
+    static String escaparWildcard(String texto) {
+        StringBuilder escapado = new StringBuilder(texto.length());
+        for (int i = 0; i < texto.length(); i++) {
+            char caracter = texto.charAt(i);
+            if (esMetacaracterWildcard(caracter)) {
+                escapado.append('\\');
+            }
+            escapado.append(caracter);
+        }
+        return escapado.toString();
+    }
+
+    private static boolean esMetacaracterWildcard(char caracter) {
+        return caracter == '*' || caracter == '?' || caracter == '\\';
+    }
+
     private List<Producto> ordenarPorRelevancia(List<Producto> productos, String consulta) {
+        // El comparador se invoca O(n log n) veces y puntuar() calcula Levenshtein:
+        // precalcular el score una sola vez por producto evita que las exportaciones
+        // (que traen decenas de miles de filas) se vuelvan lentas.
+        Map<Producto, Integer> puntajes = new IdentityHashMap<>();
+        for (Producto producto : productos) {
+            puntajes.put(producto, ProductoTextoRelevanceScorer.puntuar(producto, consulta));
+        }
         return productos.stream()
                 .sorted(Comparator
-                        .comparingInt((Producto producto) -> -ProductoTextoRelevanceScorer.puntuar(producto, consulta))
+                        .comparingInt((Producto producto) -> -puntajes.get(producto))
                         .thenComparing(Producto::getId, Comparator.nullsLast(Comparator.naturalOrder())))
                 .collect(Collectors.toList());
     }
 
     private void aplicarFiltrosIndexados(
-            org.hibernate.search.engine.search.predicate.dsl.BooleanPredicateClausesStep<?> bool,
-            org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory f,
+            BooleanPredicateClausesStep<?> bool,
+            SearchPredicateFactory f,
             Boolean activo,
             Boolean isEnvase,
             Long familiaId,

--- a/src/main/java/com/franco/dev/service/productos/search/ProductoTextoRelevanceScorer.java
+++ b/src/main/java/com/franco/dev/service/productos/search/ProductoTextoRelevanceScorer.java
@@ -7,20 +7,30 @@ import java.util.Locale;
 
 /**
  * Puntúa coincidencias texto/descripción para ordenar resultados del buscador.
- * Prioriza prefijos al inicio, luego prefijos por palabra, subcadenas y por último fuzzy.
+ * Prioriza prefijos al inicio, luego prefijos por palabra, subcadenas y por último
+ * coincidencias aproximadas.
+ *
+ * <p>El tier aproximado se gradúa por distancia de edición real en vez de usar un
+ * puntaje plano: la pasada tolerante del buscador puede traer muchos candidatos
+ * flojos, y sin graduar quedarían todos empatados y ordenados por id, escondiendo
+ * el producto correcto entre ellos.
  */
 public final class ProductoTextoRelevanceScorer {
 
     private static final int SCORE_INICIO_DESCRIPCION = 10_000;
     private static final int SCORE_PALABRA_PREFIJO = 8_000;
     private static final int SCORE_CONTIENE = 6_000;
-    private static final int SCORE_FUZZY_PALABRA = 2_000;
+    private static final int SCORE_APROXIMADO = 4_000;
     private static final int SCORE_LUCENE_DEBIL = 100;
     private static final int SCORE_BASE_MULTI_TOKEN = 5_000;
+    private static final int SCORE_PARCIAL_MULTI_TOKEN = 3_000;
     private static final int BONUS_ORDEN_PALABRAS = 1_000;
     private static final int PUNTOS_PALABRA_PREFIJO = 1_000;
     private static final int PUNTOS_CONTIENE = 500;
-    private static final int PUNTOS_FUZZY = 200;
+    private static final int PUNTOS_APROXIMADO = 300;
+    private static final int PENALIZACION_EDICION = 400;
+    private static final int PENALIZACION_EDICION_TOKEN = 60;
+    private static final int PENALIZACION_TOKEN_SIN_MATCH = 600;
 
     private ProductoTextoRelevanceScorer() {
     }
@@ -50,10 +60,12 @@ public final class ProductoTextoRelevanceScorer {
     }
 
     static int distanciaFuzzyMaxima(int longitudToken) {
-        if (longitudToken < 5) {
+        // Con menos de 3 caracteres una edicion cambia demasiado el token
+        // ("co" -> "ca"/"lo"/"do") y el resultado es ruido puro.
+        if (longitudToken < 3) {
             return 0;
         }
-        if (longitudToken <= 7) {
+        if (longitudToken < 6) {
             return 1;
         }
         return 2;
@@ -70,13 +82,25 @@ public final class ProductoTextoRelevanceScorer {
         }
 
         int score = SCORE_BASE_MULTI_TOKEN;
+        int sinMatch = 0;
         for (String token : tokens) {
             int tokenScore = puntuarTokenIndividual(texto, token);
             if (tokenScore <= 0) {
-                return SCORE_LUCENE_DEBIL;
+                sinMatch++;
+            } else {
+                score += tokenScore;
             }
-            score += tokenScore;
         }
+
+        if (sinMatch > 0) {
+            // Coincidencia parcial: siempre por debajo de cualquier match completo,
+            // pero ordenada por cuantas palabras si pegaron y que tan bien.
+            int parcial = SCORE_PARCIAL_MULTI_TOKEN
+                    - sinMatch * PENALIZACION_TOKEN_SIN_MATCH
+                    + (score - SCORE_BASE_MULTI_TOKEN) / 10;
+            return Math.max(SCORE_LUCENE_DEBIL, parcial);
+        }
+
         if (aparecenEnOrden(texto, tokens)) {
             score += BONUS_ORDEN_PALABRAS;
         }
@@ -95,8 +119,9 @@ public final class ProductoTextoRelevanceScorer {
         if (indice >= 0) {
             return SCORE_CONTIENE - Math.min(indice, 999);
         }
-        if (coincidenciaFuzzyEnPalabra(texto, token)) {
-            return SCORE_FUZZY_PALABRA;
+        int distancia = distanciaMinimaPorPalabra(texto, token);
+        if (esDistanciaSignificativa(distancia, token)) {
+            return Math.max(SCORE_LUCENE_DEBIL + 1, SCORE_APROXIMADO - distancia * PENALIZACION_EDICION);
         }
         return SCORE_LUCENE_DEBIL;
     }
@@ -108,10 +133,33 @@ public final class ProductoTextoRelevanceScorer {
         if (texto.contains(token)) {
             return PUNTOS_CONTIENE;
         }
-        if (coincidenciaFuzzyEnPalabra(texto, token)) {
-            return PUNTOS_FUZZY;
+        int distancia = distanciaMinimaPorPalabra(texto, token);
+        if (esDistanciaSignificativa(distancia, token)) {
+            return Math.max(1, PUNTOS_APROXIMADO - distancia * PENALIZACION_EDICION_TOKEN);
         }
         return 0;
+    }
+
+    /**
+     * Descarta distancias que no aportan senal: si hacen falta tantas ediciones
+     * como letras tiene lo tipeado, la coincidencia es casualidad.
+     */
+    private static boolean esDistanciaSignificativa(int distancia, String token) {
+        return distancia >= 0 && distancia < token.length();
+    }
+
+    private static int distanciaMinimaPorPalabra(String texto, String token) {
+        int mejor = -1;
+        for (String palabra : texto.split("\\s+")) {
+            if (palabra.isEmpty()) {
+                continue;
+            }
+            int distancia = distanciaLevenshtein(palabra, token);
+            if (mejor < 0 || distancia < mejor) {
+                mejor = distancia;
+            }
+        }
+        return mejor;
     }
 
     private static boolean palabraEmpiezaCon(String texto, String prefijo) {
@@ -127,19 +175,6 @@ public final class ProductoTextoRelevanceScorer {
             posicion += palabra.length() + 1;
         }
         return -1;
-    }
-
-    private static boolean coincidenciaFuzzyEnPalabra(String texto, String token) {
-        int maxEdits = distanciaFuzzyMaxima(token.length());
-        if (maxEdits == 0) {
-            return false;
-        }
-        for (String palabra : texto.split("\\s+")) {
-            if (distanciaLevenshtein(palabra, token) <= maxEdits) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private static boolean aparecenEnOrden(String texto, String[] tokens) {

--- a/src/test/java/com/franco/dev/service/productos/search/ProductoTextoRelevanceScorerTest.java
+++ b/src/test/java/com/franco/dev/service/productos/search/ProductoTextoRelevanceScorerTest.java
@@ -36,9 +36,74 @@ class ProductoTextoRelevanceScorerTest {
 
     @Test
     void distanciaFuzzyEsAdaptativaSegunLongitud() {
-        assertTrue(ProductoTextoRelevanceScorer.distanciaFuzzyMaxima(4) == 0);
+        assertTrue(ProductoTextoRelevanceScorer.distanciaFuzzyMaxima(2) == 0);
+        assertTrue(ProductoTextoRelevanceScorer.distanciaFuzzyMaxima(3) == 1);
         assertTrue(ProductoTextoRelevanceScorer.distanciaFuzzyMaxima(5) == 1);
+        assertTrue(ProductoTextoRelevanceScorer.distanciaFuzzyMaxima(6) == 2);
         assertTrue(ProductoTextoRelevanceScorer.distanciaFuzzyMaxima(8) == 2);
+    }
+
+    @Test
+    void coincidenciaAproximadaSeOrdenaPorDistanciaDeEdicion() {
+        // Lo que hace usable la pasada tolerante: entre varios candidatos flojos,
+        // el mas parecido tiene que quedar arriba y no empatar con el resto.
+        Producto coca = producto("COCA COLA 2LT");
+        Producto chocolate = producto("CHOCOLATE BLANCO 90G");
+
+        int scoreCoca = ProductoTextoRelevanceScorer.puntuar(coca, "COA");
+        int scoreChocolate = ProductoTextoRelevanceScorer.puntuar(chocolate, "COA");
+
+        assertTrue(scoreCoca > scoreChocolate,
+                "COCA (1 letra omitida) debe rankear sobre CHOCOLATE (coincidencia casual)");
+    }
+
+    @Test
+    void coincidenciaAproximadaQuedaDebajoDeSubcadenaYPrefijo() {
+        Producto prefijo = producto("CONTI BIER LATA 269ML");
+        Producto contiene = producto("BEBIDA GARCONTI 500ML");
+        Producto aproximado = producto("CANTI ALGO 500ML");
+
+        int scorePrefijo = ProductoTextoRelevanceScorer.puntuar(prefijo, "CONTI");
+        int scoreContiene = ProductoTextoRelevanceScorer.puntuar(contiene, "CONTI");
+        int scoreAproximado = ProductoTextoRelevanceScorer.puntuar(aproximado, "CONTI");
+
+        assertTrue(scorePrefijo > scoreContiene);
+        assertTrue(scoreContiene > scoreAproximado);
+    }
+
+    @Test
+    void multiTokenParcialQuedaDebajoDeMultiTokenCompleto() {
+        // Con minimumShouldMatch la pasada tolerante deja pasar resultados a los que
+        // les falta una palabra: tienen que quedar siempre debajo de los completos.
+        Producto completo = producto("CONTI GASEOSA UVA 2LT");
+        Producto parcial = producto("CONTI BIER LATA 269ML");
+
+        int scoreCompleto = ProductoTextoRelevanceScorer.puntuar(completo, "CONTI GASEOSA");
+        int scoreParcial = ProductoTextoRelevanceScorer.puntuar(parcial, "CONTI GASEOSA");
+
+        assertTrue(scoreCompleto > scoreParcial);
+    }
+
+    @Test
+    void subcadenaSinLaPrimeraLetraPuntuaPorEncimaDeCoincidenciaDebil() {
+        Producto conti = producto("CONTI BIER LATA 269ML");
+        Producto ajeno = producto("PILSEN LATA 350ML");
+
+        int scoreConti = ProductoTextoRelevanceScorer.puntuar(conti, "ONTI");
+        int scoreAjeno = ProductoTextoRelevanceScorer.puntuar(ajeno, "ONTI");
+
+        assertTrue(scoreConti > scoreAjeno);
+    }
+
+    @Test
+    void prefijoExactoRankeaPorEncimaDeSubcadena() {
+        Producto conti = producto("CONTI BIER LATA 269ML");
+        Producto subcadena = producto("BEBIDA GARCONTI 500ML");
+
+        int scorePrefijo = ProductoTextoRelevanceScorer.puntuar(conti, "CONTI");
+        int scoreSubcadena = ProductoTextoRelevanceScorer.puntuar(subcadena, "CONTI");
+
+        assertTrue(scorePrefijo > scoreSubcadena);
     }
 
     private static Producto producto(String descripcion) {

--- a/src/test/java/com/franco/dev/service/productos/search/ProductoWildcardBusquedaTest.java
+++ b/src/test/java/com/franco/dev/service/productos/search/ProductoWildcardBusquedaTest.java
@@ -1,0 +1,205 @@
+package com.franco.dev.service.productos.search;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.custom.CustomAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.FuzzyQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.WildcardQuery;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.Directory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifica sobre un indice Lucene real (in-memory) los predicados que arma
+ * {@link ProductoSearchService}: prefijo, subcadena, subsecuencia, fuzzy y token
+ * partido. Replica el analyzer de {@code ProductoAnalysisConfigurer}
+ * (standard + lowercase + asciifolding) para que los terminos indexados sean los
+ * mismos que en produccion.
+ */
+class ProductoWildcardBusquedaTest {
+
+    private static final String CAMPO = "descripcion";
+
+    private Directory directory;
+    private Analyzer analyzer;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        analyzer = CustomAnalyzer.builder()
+                .withTokenizer("standard")
+                .addTokenFilter("lowercase")
+                .addTokenFilter("asciifolding")
+                .build();
+
+        directory = new ByteBuffersDirectory();
+        try (IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig(analyzer))) {
+            indexar(writer, "CONTI BIER BOT 600ML");
+            indexar(writer, "CONTI MALZBIER 350ML");
+            indexar(writer, "CONTI GASEOSA UVA 2LT");
+            indexar(writer, "PILSEN LATA 350ML");
+            indexar(writer, "COCA COLA 2LT");
+        }
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        directory.close();
+        analyzer.close();
+    }
+
+    // ---------- pasada estricta ----------
+
+    @Test
+    void prefijoSoloNoEncuentraCuandoFaltaLaPrimeraLetra() throws IOException {
+        // Comportamiento viejo: unicamente wildcard de prefijo. Este era el bug.
+        assertEquals(0, cantidadHits(prefijo("onti")));
+    }
+
+    @Test
+    void subcadenaEncuentraCuandoFaltaLaPrimeraLetra() throws IOException {
+        // "onti" -> CONTI: los 3 productos CONTI del indice.
+        assertEquals(3, cantidadHits(subcadena("onti")));
+    }
+
+    @Test
+    void prefijoSigueFuncionandoParaElTextoCompleto() throws IOException {
+        assertEquals(3, cantidadHits(prefijo("conti")));
+    }
+
+    @Test
+    void subcadenaNoTraeProductosAjenos() throws IOException {
+        // La subcadena es match exacto: no inventa coincidencias.
+        assertEquals(0, cantidadHits(subcadena("zzz")));
+        assertEquals(1, cantidadHits(subcadena("ilsen")));
+    }
+
+    // ---------- pasada tolerante: subsecuencia ----------
+
+    @Test
+    void subsecuenciaEncuentraLetraFaltanteEnElMedio() throws IOException {
+        // "cnti" no es subcadena de "conti", pero si subsecuencia.
+        assertEquals(0, cantidadHits(subcadena("cnti")));
+        assertEquals(3, cantidadHits(subsecuencia("cnti")));
+    }
+
+    @Test
+    void subsecuenciaEncuentraConTokenCortoDeTresLetras() throws IOException {
+        // El hueco que quedaba: 3 caracteres con una omision al medio.
+        assertEquals(0, cantidadHits(subcadena("coa")));
+        assertTrue(cantidadHits(subsecuencia("coa")) >= 1, "\"coa\" debe alcanzar a COCA COLA");
+    }
+
+    @Test
+    void subsecuenciaEncuentraDosLetrasFaltantesEnPalabraCorta() throws IOException {
+        // "piln" = PILSEN sin S ni E. Fuera del alcance de fuzzy en un token de 4.
+        assertEquals(0, cantidadHits(subcadena("piln")));
+        assertEquals(1, cantidadHits(subsecuencia("piln")));
+    }
+
+    @Test
+    void subsecuenciaEstaAncladaEnLaPrimeraLetra() throws IOException {
+        // No lleva `*` inicial a proposito: la primera letra ancla y recorta el ruido.
+        // El caso "falta la primera letra" ya lo cubre la subcadena.
+        assertEquals(0, cantidadHits(subsecuencia("nti")));
+        assertEquals(3, cantidadHits(subcadena("nti")));
+    }
+
+    // ---------- pasada tolerante: fuzzy y token partido ----------
+
+    @Test
+    void fuzzyCubreLetraCambiadaQueLaSubsecuenciaNoAlcanza() throws IOException {
+        // "ponti" no es subsecuencia de "conti" (letra cambiada, no omitida).
+        assertEquals(0, cantidadHits(subsecuencia("ponti")));
+        int maxEdits = ProductoTextoRelevanceScorer.distanciaFuzzyMaxima("ponti".length());
+        assertTrue(maxEdits >= 1);
+        assertEquals(3, cantidadHits(new FuzzyQuery(new Term(CAMPO, "ponti"), maxEdits)));
+    }
+
+    @Test
+    void tokenPartidoEncuentraPalabrasPegadas() throws IOException {
+        // "cocacola" no es ningun termino del indice: hay que partirlo en COCA + COLA.
+        assertEquals(0, cantidadHits(prefijo("cocacola")));
+        assertEquals(0, cantidadHits(subcadena("cocacola")));
+        assertEquals(0, cantidadHits(subsecuencia("cocacola")));
+        assertEquals(1, cantidadHits(partido("cocacola")));
+    }
+
+    @Test
+    void umbralesHabilitanCadaMecanismoEnElLargoEsperado() {
+        assertTrue("co".length() >= ProductoSearchService.MIN_LONGITUD_INFIJO);
+        assertTrue("coa".length() >= ProductoSearchService.MIN_LONGITUD_SUBSECUENCIA);
+        assertTrue("cocaco".length() >= ProductoSearchService.MIN_LONGITUD_TOKEN_PARTIDO);
+        assertTrue("cocac".length() < ProductoSearchService.MIN_LONGITUD_TOKEN_PARTIDO);
+    }
+
+    @Test
+    void metacaracteresTipeadosNoSeInterpretanComoComodin() throws IOException {
+        // Un "*" tipeado por el usuario debe buscarse literal, no matchear todo.
+        assertEquals(0, cantidadHits(prefijo("con*i")));
+    }
+
+    // ---------- helpers: replican los patrones que arma ProductoSearchService ----------
+
+    private static void indexar(IndexWriter writer, String descripcion) throws IOException {
+        Document doc = new Document();
+        doc.add(new TextField(CAMPO, descripcion, Field.Store.YES));
+        writer.addDocument(doc);
+    }
+
+    private Query prefijo(String token) {
+        return wildcard(ProductoSearchService.escaparWildcard(normalizar(token)) + "*");
+    }
+
+    private Query subcadena(String token) {
+        return wildcard("*" + ProductoSearchService.escaparWildcard(normalizar(token)) + "*");
+    }
+
+    private Query subsecuencia(String token) {
+        return wildcard(ProductoSearchService.patronSubsecuencia(normalizar(token)));
+    }
+
+    /** Reproduce el OR de cortes que genera {@code agregarPredicadosTolerantes}. */
+    private Query partido(String token) {
+        String base = normalizar(token);
+        BooleanQuery.Builder cortes = new BooleanQuery.Builder();
+        int minParte = ProductoSearchService.MIN_LONGITUD_PARTE;
+        for (int corte = minParte; corte <= base.length() - minParte; corte++) {
+            BooleanQuery.Builder mitades = new BooleanQuery.Builder();
+            mitades.add(wildcard(base.substring(0, corte) + "*"), BooleanClause.Occur.MUST);
+            mitades.add(wildcard(base.substring(corte) + "*"), BooleanClause.Occur.MUST);
+            cortes.add(mitades.build(), BooleanClause.Occur.SHOULD);
+        }
+        return cortes.build();
+    }
+
+    private static String normalizar(String token) {
+        return ProductoTextoRelevanceScorer.normalizar(token);
+    }
+
+    private Query wildcard(String patron) {
+        return new WildcardQuery(new Term(CAMPO, patron));
+    }
+
+    private int cantidadHits(Query query) throws IOException {
+        try (DirectoryReader reader = DirectoryReader.open(directory)) {
+            return new IndexSearcher(reader).search(query, 100).scoreDocs.length;
+        }
+    }
+}


### PR DESCRIPTION
## Qué resuelve

Escribir `CONTI` traía los productos CONTI, pero escribir `ONTI` no traía nada — "Producto no encontrado".

La causa está en `ProductoSearchService.crearPredicadoToken`: por cada palabra armaba solo dos cláusulas, wildcard de **prefijo** (`onti*`, que no matchea `CONTI` porque no empieza con "onti") y **fuzzy**, que `distanciaFuzzyMaxima()` desactivaba para tokens de menos de 5 caracteres. Con 4 caracteres, "ONTI" se quedaba sin ningún camino de match.

Detalle: el fallback SQL (`LIKE '%texto%'`) sí encontraba CONTI. La ruta Lucene, que es la activa por defecto, era la menos tolerante de las dos.

## Cómo funciona ahora

**Cascada de dos pasadas.** Primero corre la búsqueda estricta de siempre (prefijo + subcadena). Sólo si devuelve **cero** resultados corre una segunda pasada tolerante. Cuando la búsqueda ya andaba bien, no cambia nada: mismos productos, mismo orden, mismo costo. La flexibilidad aparece únicamente cuando la alternativa era "Producto no encontrado".

**Subsecuencia** como mecanismo principal para letras faltantes: omitir letras preserva el orden de las que quedan, así que `CNTI` se busca como `c*n*t*i*` y encuentra CONTI. Cubre cualquier cantidad de letras omitidas, en cualquier posición, de una sola vez.

| Caso | Antes | Ahora | Mecanismo |
|---|---|---|---|
| `CONT` → CONTI (falta la última) | ✅ | ✅ | Prefijo |
| `ONTI` → CONTI (falta la primera) | ❌ | ✅ | Subcadena |
| `CNTI` → CONTI (falta una del medio) | ❌ | ✅ | Subsecuencia |
| `COA` → COCA (3 letras, falta del medio) | ❌ | ✅ | Subsecuencia |
| `PILN` → PILSEN (faltan 2 del medio) | ❌ | ✅ | Subsecuencia |
| `PONTI` → CONTI (letra cambiada) | ❌ | ✅ | Fuzzy |
| `COCACOLA` → COCA COLA (pegadas) | ❌ | ✅ | Token partido |
| `conti gaseosa` con una palabra mal | ❌ | ✅ | minimumShouldMatch n-1 |

## Ranking

El tier aproximado del scorer se gradúa por distancia de edición real en vez de un puntaje plano. Sin esto los candidatos flojos empataban en 2000 y se ordenaban por id, escondiendo el producto correcto entre el ruido: buscando `COA`, COCA ahora queda arriba y CHOCOLATE (que también contiene c…o…a) abajo.

También se precalcula el score una vez por producto en lugar de recalcularlo en cada comparación del sort. El comparador se invoca O(n log n) veces y ahora hace Levenshtein; sin esto la exportación de productos (hasta 50.000 filas, `Pageable.unpaged()`) se degradaba.

## Alcance

Aplica a los tres buscadores que pasan por `buscarIdsPorTexto`: grilla de productos, picker del POS y `buscarProductoInteligente` de Compras.

## Cómo probarlo

1. Lista de productos → escribir `ONTI` → deben aparecer los productos CONTI.
2. Escribir `CONTI` → mismo resultado y mismo orden que antes del cambio (sin regresión).
3. Probar `CNTI`, `COA`, `COCACOLA`.
4. `./mvnw test` → 62 tests.

`ProductoWildcardBusquedaTest` monta un índice Lucene in-memory replicando el analyzer de producción (standard + lowercase + asciifolding) y verifica cada mecanismo por separado. Incluye un test que reproduce el bug original (`prefijoSoloNoEncuentraCuandoFaltaLaPrimeraLetra` → 0 hits).

## Impacto en DB

Ninguno. Sin migraciones. **No hace falta reindexar**: los cambios son del lado de la consulta, el analyzer quedó igual. Alcanza con reiniciar el servidor.

## Riesgo

**Bajo.** La cascada garantiza que las búsquedas que ya funcionaban toman exactamente el mismo camino que antes. La pasada tolerante sólo se ejecuta sobre búsquedas que hoy devuelven cero resultados, así que el peor caso es una segunda query Lucene sobre un catálogo de 8k–14k productos.

Rollback: revertir el commit y reiniciar. Sin estado que deshacer.

## Fuera de alcance

Quedan sin cubrir, a propósito, dos casos donde cualquier resultado sería azar: faltar la primera letra **y** una del medio a la vez (`OTI` → CONTI, la subsecuencia está anclada en la primera letra y ese ancla es lo que acota el ruido), y omisiones que dejan 1 o 2 letras (`UA` → UVA).

No incluye el cambio local de `application.properties` (`spring.profiles.active=user-dev`), que queda sin commitear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)