### PR TITLE
fix(ventas): ordenar por creadoEn desc al empatar el nro. de venta

### DIFF
--- a/src/main/java/com/franco/dev/service/operaciones/VentaService.java
+++ b/src/main/java/com/franco/dev/service/operaciones/VentaService.java
@@ -588,7 +588,15 @@ public class VentaService extends CrudService<Venta, VentaRepository, EmbebedPri
             VentaEstado estado,
             Pageable pageable, Boolean isDelivery, Long monedaId, Boolean isAsc, Boolean conDescuento,
             Boolean conAumento, Boolean conObservacion, Long clienteId, String fechaInicio, String fechaFin) {
-        Sort sort = isAsc == false ? Sort.by("id").descending() : Sort.by("id").ascending();
+        // Al filtrar por nro. de venta todas las filas comparten el id (la PK es
+        // compuesta: id + sucursal_id), por eso se desempata por creadoEn desc para
+        // que la venta mas reciente quede primera. sucursalId cierra el orden para
+        // que la paginacion sea determinista.
+        Sort sort = isAsc == Boolean.TRUE
+                ? Sort.by(Sort.Order.asc("id"), Sort.Order.desc("creadoEn").nullsLast(),
+                        Sort.Order.desc("sucursalId"))
+                : Sort.by(Sort.Order.desc("id"), Sort.Order.desc("creadoEn").nullsLast(),
+                        Sort.Order.desc("sucursalId"));
         Pageable newPageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
 
         return this.repository.findAll((root, query, cb) -> {


### PR DESCRIPTION
## Qué resuelve

Al buscar en **Operaciones → Ventas** por nro. de venta (ej. `7644`), el listado devolvía las filas ordenadas por `sucursal_id` ascendente, con las fechas en desorden. El usuario necesita ver primero la venta **más reciente** con ese número.

**Causa:** `operaciones.venta` tiene PK compuesta `(id, sucursal_id)`, así que el mismo nro. de venta existe en cada sucursal. `findWithGenericFiltersCriteria` ordenaba solo por `Sort.by("id")`, de modo que al filtrar por `idVenta` **todas** las filas empataban en el único criterio y Postgres las devolvía en orden de heap — que en la práctica sale como sucursal ascendente.

## Qué cambia

Un solo `Sort` en `VentaService.findWithGenericFiltersCriteria`:

```java
Sort sort = isAsc == Boolean.TRUE
        ? Sort.by(Sort.Order.asc("id"),  Sort.Order.desc("creadoEn").nullsLast(), Sort.Order.desc("sucursalId"))
        : Sort.by(Sort.Order.desc("id"), Sort.Order.desc("creadoEn").nullsLast(), Sort.Order.desc("sucursalId"));
```

- `creadoEn DESC` desempata → la venta más reciente queda primera.
- `nullsLast()` porque `creado_en` es nullable en el DDL (tiene `DEFAULT now()`, pero una fila insertada fuera del flujo de la app podría quedar en null); sin esto, `DESC` en Postgres es `NULLS FIRST` y se treparía al tope.
- `sucursalId DESC` cierra el orden para que la paginación sea determinista.
- `isAsc == false` → `isAsc == Boolean.TRUE`: el original desreferenciaba un `Boolean` que puede venir null (el arg `$asc` del schema es opcional) → NPE. Comportamiento actual preservado (null cae en la rama descendente, igual que antes).

**El listado sin filtro por nro. de venta no cambia:** `id` sigue siendo el criterio primario, y el nuevo orden solo actúa sobre empates.

## Alcance

Afecta a los 3 resolvers que pasan por `onGenericSearch`:

| Resolver | Consumidor |
|---|---|
| `ventasGenericFilter` | `generic-list-venta.component.ts` (el fix pedido) |
| `reporteGenericVentas` | botón *Generar reporte* del mismo componente |
| `reporteGenericVentasDetallado` | ídem, versión detallada |

Los reportes hacen `PageRequest.of(0, Integer.MAX_VALUE)` y consumen `getContent()` en orden, así que sus filas se reordenan igual que la tabla — **deseado**: el PDF queda consistente con lo que se ve en pantalla.

**Fuera de alcance a propósito:** `findWithFiltersCriteria` (línea 472, método viejo con el mismo patrón, usado por `ventasPorCajaId` / `list-venta.component.ts`) y el repo `filial` — la query `ventasGenericFilter` existe solo en central.

## Cómo probarlo

Levantar central contra una DB con varias sucursales y buscar un nro. de venta que exista en más de una.

Contraste en `bodega` con `id = 7644` (existe en 24 sucursales):

| ORDER BY viejo (`id DESC`) | ORDER BY nuevo |
|---|---|
| suc **1** — 2023-06-02 | suc **25** — 2025-07-30 ← más reciente |
| suc 3 — 2023-02-05 | suc 24 — 2025-03-04 |
| suc 4 — 2022-11-24 | suc 23 — 2024-07-01 |
| suc 5 — 2023-04-09 | suc 22 — 2024-05-13 |

Sanity check: la misma query **sin** `idVenta` debe salir idéntica a antes del cambio (id descendente).

Verificado: `./mvnw -o compile -DskipFlyway=true` limpio, y la app levanta OK en 8081 contra `bodega`. La comparación de arriba se corrió por SQL directo; **falta la verificación end-to-end desde la UI**.

## Impacto DB

Ninguno. Sin migración Flyway, sin cambio de schema GraphQL (`venta.graphqls` intacto), sin cambio de frontend.

## Performance

El nuevo `ORDER BY` está respaldado por `idx_venta_creado_en` y el compuesto `(creado_en, sucursal_id)` de `V97.3__add_indexes_graficos_performance.sql`. El filtro por `id` es muy selectivo (≤ N filas, N = cantidad de sucursales), así que el sort extra es despreciable.

## Riesgo / rollback

**Bajo.** Cambio aislado a una expresión, sin estado persistido. Rollback = revertir el commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)