### PR TITLE
feat(transferencias): permitir filtrar por multiples estados

### DIFF
--- a/src/main/java/com/franco/dev/graphql/operaciones/TransferenciaGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/TransferenciaGraphQL.java
@@ -316,7 +316,7 @@ public class TransferenciaGraphQL implements GraphQLQueryResolver, GraphQLMutati
     }
 
     public Page<Transferencia> transferenciasWithFilters(Long sucursalOrigenId, Long sucursalDestinoId,
-            TransferenciaEstado estado, TipoTransferencia tipo,
+            TransferenciaEstado estado, List<TransferenciaEstado> estados, TipoTransferencia tipo,
             EtapaTransferencia etapa, Boolean isOrigen, Boolean isDestino,
             String creadoDesde, String creadoHasta, Integer page, Integer size) {
         if (page == null)
@@ -324,7 +324,14 @@ public class TransferenciaGraphQL implements GraphQLQueryResolver, GraphQLMutati
         if (size == null)
             size = 20;
         Pageable pageable = PageRequest.of(page, size);
-        return service.findByFilter(sucursalOrigenId, sucursalDestinoId, estado, tipo, etapa, isOrigen, isDestino,
+        // `estado` (singular) se mantiene por compatibilidad con clientes viejos: si
+        // viene, se suma a la lista de estados a filtrar.
+        List<TransferenciaEstado> estadoList = new ArrayList<>();
+        if (estados != null)
+            estadoList.addAll(estados);
+        if (estado != null && !estadoList.contains(estado))
+            estadoList.add(estado);
+        return service.findByFilter(sucursalOrigenId, sucursalDestinoId, estadoList, tipo, etapa, isOrigen, isDestino,
                 stringToDate(creadoDesde), stringToDate(creadoHasta), pageable);
     }
 

--- a/src/main/java/com/franco/dev/repository/operaciones/TransferenciaRepository.java
+++ b/src/main/java/com/franco/dev/repository/operaciones/TransferenciaRepository.java
@@ -64,6 +64,28 @@ public interface TransferenciaRepository extends HelperRepository<Transferencia,
                         LocalDateTime creadoEnHasta,
                         Pageable pageable);
 
+        @Query("SELECT t FROM Transferencia t WHERE "
+                        + "(:sucursalOrigenId IS NULL OR t.sucursalOrigen.id = :sucursalOrigenId) AND "
+                        + "(:sucursalDestinoId IS NULL OR t.sucursalDestino.id = :sucursalDestinoId) AND "
+                        + "t.estado IN :estados AND "
+                        + "(t.tipo = :tipo or cast(:tipo as com.franco.dev.domain.operaciones.enums.TipoTransferencia) IS NULL) AND "
+                        + "(t.etapa = :etapa OR cast(:etapa as com.franco.dev.domain.operaciones.enums.EtapaTransferencia) IS NULL) AND "
+                        + "(:isOrigen IS NULL OR t.isOrigen = :isOrigen) AND "
+                        + "(:isDestino IS NULL OR t.isDestino = :isDestino) AND "
+                        + "(t.creadoEn >= :creadoEnDesde or cast(:creadoEnDesde as timestamp) IS NULL) AND "
+                        + "(t.creadoEn <= :creadoEnHasta or cast(:creadoEnHasta as timestamp) IS NULL ) order by t.id desc")
+        Page<Transferencia> findByFilterEstadoIn(
+                        @Param("sucursalOrigenId") Long sucursalOrigenId,
+                        @Param("sucursalDestinoId") Long sucursalDestinoId,
+                        @Param("estados") List<TransferenciaEstado> estados,
+                        @Param("tipo") TipoTransferencia tipo,
+                        @Param("etapa") EtapaTransferencia etapa,
+                        @Param("isOrigen") Boolean isOrigen,
+                        @Param("isDestino") Boolean isDestino,
+                        @Param("creadoEnDesde") LocalDateTime creadoEnDesde,
+                        @Param("creadoEnHasta") LocalDateTime creadoEnHasta,
+                        Pageable pageable);
+
         @Query("SELECT new com.franco.dev.domain.operaciones.dto.VencimientoProductoDto(" +
                         "t, " +
                         "p, " +

--- a/src/main/java/com/franco/dev/service/operaciones/TransferenciaService.java
+++ b/src/main/java/com/franco/dev/service/operaciones/TransferenciaService.java
@@ -58,6 +58,19 @@ public class TransferenciaService extends CrudService<Transferencia, Transferenc
                 creadoDesde, creadoHasta, pageable);
     }
 
+    public Page<Transferencia> findByFilter(Long sucursalOrigenId, Long sucursalDestinoId,
+            List<TransferenciaEstado> estados,
+            TipoTransferencia tipo, EtapaTransferencia etapa, Boolean isOrigen, Boolean isDestino,
+            LocalDateTime creadoDesde,
+            LocalDateTime creadoHasta, Pageable pageable) {
+        if (estados == null || estados.isEmpty()) {
+            return repository.findByFilter(sucursalOrigenId, sucursalDestinoId, null, tipo, etapa, isOrigen, isDestino,
+                    creadoDesde, creadoHasta, pageable);
+        }
+        return repository.findByFilterEstadoIn(sucursalOrigenId, sucursalDestinoId, estados, tipo, etapa, isOrigen,
+                isDestino, creadoDesde, creadoHasta, pageable);
+    }
+
     public List<VencimientoProductoDto> findProductosVencidos(Long sucId, LocalDateTime fechaInicio,
             LocalDateTime fechaFin) {
         return repository.findProductoVencido(sucId, fechaInicio, fechaFin);

--- a/src/main/resources/graphql/operaciones/transferencia.graphqls
+++ b/src/main/resources/graphql/operaciones/transferencia.graphqls
@@ -62,7 +62,7 @@ extend type Query {
     transferenciaPorFecha(inicio:String, fin:String):[Transferencia]!
     transferenciasPorUsuario(id: ID!):[Transferencia]!
     countTransferencia: Int
-    transferenciasWithFilters(sucursalOrigenId: Int, sucursalDestinoId: Int, estado: TransferenciaEstado, tipo: TipoTransferencia, etapa: EtapaTransferencia, isOrigen: Boolean, isDestino: Boolean, creadoDesde: String, creadoHasta: String, page: Int, size: Int): TransferenciaPage
+    transferenciasWithFilters(sucursalOrigenId: Int, sucursalDestinoId: Int, estado: TransferenciaEstado, estados: [TransferenciaEstado], tipo: TipoTransferencia, etapa: EtapaTransferencia, isOrigen: Boolean, isDestino: Boolean, creadoDesde: String, creadoHasta: String, page: Int, size: Int): TransferenciaPage
     imprimirTransferencia(id:ID!, ticket: Boolean, printerName:String!):String
     findProductoVencido(sucId: Int!, fechaInicio: String!, fechaFin: String!):[VencimientoProductoDto]
 }


### PR DESCRIPTION
## Qué resuelve

La query `transferenciasWithFilters` solo aceptaba **un** estado. Este PR agrega el argumento opcional `estados: [TransferenciaEstado]` para poder filtrar por varios a la vez, que es lo que necesita el nuevo filtro múltiple del desktop.

## Cambios

| Archivo | Cambio |
|---|---|
| `transferencia.graphqls` | Nuevo arg `estados: [TransferenciaEstado]` en `transferenciasWithFilters` |
| `TransferenciaGraphQL.java` | El resolver mergea `estado` (singular) + `estados` (lista) en una sola lista |
| `TransferenciaService.java` | Overload de `findByFilter` que recibe `List<TransferenciaEstado>`; lista vacía → cae al query existente |
| `TransferenciaRepository.java` | Nuevo `findByFilterEstadoIn` con `t.estado IN :estados`. El query original queda intacto |

## Retrocompatibilidad

El cambio es **puramente aditivo**. El argumento `estado` singular **se mantiene**:

- **frc-mobile** lo usa (`src/app/pages/transferencias/graphql/graphql-query.ts:461`) y sigue funcionando sin cambios. Con `estado: ABIERTA` la lista queda `[ABIERTA]` y el query pasa a `t.estado IN ('ABIERTA')` — semánticamente idéntico al `t.estado = 'ABIERTA'` anterior.
- Sin ninguno de los dos args, la lista queda vacía y se usa el `findByFilter` original sin filtro de estado. Mismo comportamiento que hoy.

## Cómo probarlo

1. Levantar el central (`./mvnw -o spring-boot:run -DskipFlyway=true`, puerto 8081).
2. Query con varios estados:

```graphql
query {
  data: transferenciasWithFilters(
    estados: [EN_TRANSITO, ABIERTA]
    creadoDesde: "2026-04-20 00:00:00"
    creadoHasta: "2026-04-23 23:59:59"
    page: 0, size: 20
  ) { getTotalElements getContent { id estado } }
}
```

3. Verificar que `getTotalElements` = suma de los estados elegidos y que todos los `estado` devueltos están en la lista.
4. Regresión: la misma query con `estado: ABIERTA` (singular) tiene que devolver lo mismo que antes del PR.

## Impacto en DB

**Ninguno.** Sin migraciones Flyway, sin cambios de esquema. Solo un JPQL nuevo de lectura.

## Riesgo

**Bajo.** Aditivo y retrocompatible; el query original no se tocó. Rollback = revertir el JAR, sin pasos de DB.

## Orden de despliegue

Este central va **primero**. El desktop (PR correspondiente en `frc-sistemas-integrados-angular`) manda `estados` y necesita este backend desplegado antes; al revés fallaría con "Unknown argument". Mobile no requiere coordinación.

## Verificación

- [x] `./mvnw -o clean compile -DskipFlyway=true` OK
- [x] Arranque limpio: `Started FrancoSystemsApplication in 31.5s` (kickstart valida la firma del resolver contra el schema al bootear)
- [x] Flyway: `Schema "public" is up to date. No migration necessary.`
- [x] Probado end-to-end en la UI del desktop contra este central

🤖 Generated with [Claude Code](https://claude.com/claude-code)