### PR TITLE
fix(productos): busqueda por coincidencia parcial de codigo de barras

### DIFF
--- a/src/main/java/com/franco/dev/domain/productos/enums/TipoCoincidenciaBuscador.java
+++ b/src/main/java/com/franco/dev/domain/productos/enums/TipoCoincidenciaBuscador.java
@@ -6,6 +6,8 @@ package com.franco.dev.domain.productos.enums;
 public enum TipoCoincidenciaBuscador {
     CODIGO_EXACTO,
     CODIGO_PREFIJO,
+    /** Coincidencia parcial del código: tramo interno, terminación o sin ceros a la izquierda. */
+    CODIGO_PARCIAL,
     TEXTO,
     ID
 }

--- a/src/main/java/com/franco/dev/graphql/productos/ProductoGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/productos/ProductoGraphQL.java
@@ -30,7 +30,6 @@ import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
@@ -38,12 +37,10 @@ import org.springframework.stereotype.Component;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 @Component
 public class ProductoGraphQL implements GraphQLQueryResolver, GraphQLMutationResolver {
@@ -120,24 +117,8 @@ public class ProductoGraphQL implements GraphQLQueryResolver, GraphQLMutationRes
             Long sucursalId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
 
-        if (codigo != null && !codigo.trim().isEmpty()) {
-            List<Codigo> foundCondigoList = codigoService.findByCodigo(codigo);
-            if (foundCondigoList != null && foundCondigoList.size() > 0) {
-                if (foundCondigoList.size() == 1) {
-                    Producto foundProducto = foundCondigoList.get(0).getPresentacion().getProducto();
-                    return new PageImpl<>(Arrays.asList(foundProducto), pageable, 1);
-                } else {
-                    List<Producto> foundProductoList = foundCondigoList.stream()
-                            .map(c -> c.getPresentacion().getProducto()).collect(Collectors.toList());
-                    return new PageImpl<>(foundProductoList, pageable, foundProductoList.size());
-                }
-            } else {
-                return new PageImpl<>(new ArrayList<>(), pageable, 0);
-            }
-        }
-
-        return service.findWithFilters(texto, activo, stock, balanza, subfamilia, familia, vencimiento, costoCero, stockFiltro,
-                sucursalId, pageable);
+        return service.findWithFilters(texto, codigo, activo, stock, balanza, subfamilia, familia, vencimiento, costoCero,
+                stockFiltro, sucursalId, pageable);
     }
 
     public List<Producto> productos(int page, int size) {

--- a/src/main/java/com/franco/dev/repository/productos/CodigoRepository.java
+++ b/src/main/java/com/franco/dev/repository/productos/CodigoRepository.java
@@ -26,6 +26,28 @@ public interface CodigoRepository extends HelperRepository<Codigo, Long> {
             "LIMIT ?2", nativeQuery = true)
     List<Long> findProductoIdsByCodigoPrefijo(String prefijo, int limite);
 
+    /**
+     * Coincidencia parcial de código de barras en cualquier posición.
+     * Encuentra el producto tanto si el usuario escribe el código completo, como si
+     * omite ceros a la izquierda ({@code 78470...}) o escribe solo un tramo interno o
+     * la terminación ({@code 33233}).
+     *
+     * El orden prioriza exacto > prefijo > sufijo > infijo, y a igualdad, el código más corto.
+     */
+    @Query(value = "SELECT pr.producto_id FROM productos.codigo c " +
+            "INNER JOIN productos.presentacion pr ON pr.id = c.presentacion_id " +
+            "WHERE (c.activo IS NULL OR c.activo = true) " +
+            "AND UPPER(c.codigo) LIKE CONCAT('%', UPPER(?1), '%') " +
+            "GROUP BY pr.producto_id " +
+            "ORDER BY MIN(CASE " +
+            "  WHEN UPPER(c.codigo) = UPPER(?1) THEN 0 " +
+            "  WHEN UPPER(c.codigo) LIKE CONCAT(UPPER(?1), '%') THEN 1 " +
+            "  WHEN UPPER(c.codigo) LIKE CONCAT('%', UPPER(?1)) THEN 2 " +
+            "  ELSE 3 END) ASC, " +
+            "MIN(LENGTH(c.codigo)) ASC " +
+            "LIMIT ?2", nativeQuery = true)
+    List<Long> findProductoIdsByCodigoCoincidencia(String fragmento, int limite);
+
     public List<Codigo> findByPresentacionId(Long id);
 
     @Query(value = "select * from productos.presentacion p " +

--- a/src/main/java/com/franco/dev/repository/productos/ProductoRepository.java
+++ b/src/main/java/com/franco/dev/repository/productos/ProductoRepository.java
@@ -217,11 +217,11 @@ public interface ProductoRepository extends HelperRepository<Producto, Long> {
                         @Param("endDate") LocalDateTime endDate);
 
         @Query("select distinct p from Producto p " +
-                        "left join Presentacion pres on pres.producto.id = p.id " +
-                        "left join Codigo cod on cod.presentacion.id = pres.id " +
-                        "where  (CAST(p.id as string) like CONCAT('%', :texto, '%') or UPPER(p.descripcion) like CONCAT('%', UPPER(:texto), '%') "
-                        +
-                        "or UPPER(p.descripcionFactura) like CONCAT('%', UPPER(:texto), '%')) " +
+                        "where  ((:soloCodigo) = true or CAST(p.id as string) like CONCAT('%', :texto, '%') " +
+                        "or UPPER(p.descripcion) like CONCAT('%', UPPER(:texto), '%') " +
+                        "or UPPER(p.descripcionFactura) like CONCAT('%', UPPER(:texto), '%') " +
+                        "or p.id in (:idsCodigo)) " +
+                        "and ((:soloCodigo) = false or p.id in (:idsCodigo)) " +
                         "and ((:activo) is null or p.activo = :activo) " +
                         "and ((:stock) is null or p.stock = :stock) " +
                         "and ((:balanza) is null or p.balanza = :balanza) " +
@@ -252,6 +252,8 @@ public interface ProductoRepository extends HelperRepository<Producto, Long> {
                         "order by p.id asc")
         public Page<Producto> searchWithFilters(
                         @Param("texto") String texto,
+                        @Param("idsCodigo") List<Long> idsCodigo,
+                        @Param("soloCodigo") boolean soloCodigo,
                         @Param("activo") Boolean activo,
                         @Param("stock") Boolean stock,
                         @Param("balanza") Boolean balanza,

--- a/src/main/java/com/franco/dev/service/productos/ProductoService.java
+++ b/src/main/java/com/franco/dev/service/productos/ProductoService.java
@@ -14,6 +14,7 @@ import com.franco.dev.domain.empresarial.Sucursal;
 import com.franco.dev.graphql.productos.input.ProductoInput;
 import com.franco.dev.repository.productos.ProductoRepository;
 import com.franco.dev.service.CrudService;
+import com.franco.dev.service.productos.search.CodigoSearchService;
 import com.franco.dev.service.productos.search.ProductoSearchIndexSyncService;
 import com.franco.dev.service.productos.search.ProductoSearchService;
 import com.franco.dev.service.operaciones.MovimientoStockService;
@@ -80,9 +81,14 @@ public class ProductoService extends CrudService<Producto, ProductoRepository, L
     private final ProductoSearchService productoSearchService;
     @Autowired
     private final ProductoSearchIndexSyncService productoSearchIndexSyncService;
+    @Autowired
+    private final CodigoSearchService codigoSearchService;
 
     @Value("${app.search.producto.enabled:true}")
     private boolean productoSearchEnabled;
+
+    /** Tope de productos a resolver por coincidencia de código de barras. */
+    private static final int LIMITE_IDS_CODIGO = 200;
 
     @Override
     public ProductoRepository getRepository() {
@@ -128,7 +134,10 @@ public class ProductoService extends CrudService<Producto, ProductoRepository, L
             String conStockStr,
             Boolean activo) {
         int fetchSize = Math.min(Math.max(offset + 10, 50), 200);
-        List<Long> ids = productoSearchService.buscarIdsPorTexto(texto, fetchSize, activo, false, null, null);
+        // Lucene solo indexa descripción: el código de barras se resuelve aparte y se antepone.
+        List<Long> ids = unirIds(
+                codigoSearchService.buscarProductoIdsPorCoincidencia(texto, fetchSize),
+                productoSearchService.buscarIdsPorTexto(texto, fetchSize, activo, false, null, null));
         if (ids.isEmpty()) {
             return Collections.emptyList();
         }
@@ -148,7 +157,10 @@ public class ProductoService extends CrudService<Producto, ProductoRepository, L
             encontrados = repository.searchWithFiltersByIds(
                     ids, activo, null, null, null, null, null, null, null, sucursalId);
         } else {
-            encontrados = new ArrayList<>(repository.findAllById(ids));
+            // Los ids que llegan por código no pasaron por el filtro de activo de Lucene.
+            encontrados = repository.findAllById(ids).stream()
+                    .filter(p -> activo == null || activo.equals(p.getActivo()))
+                    .collect(Collectors.toList());
         }
 
         Map<Long, Producto> porId = encontrados.stream()
@@ -192,17 +204,56 @@ public class ProductoService extends CrudService<Producto, ProductoRepository, L
     public Page<Producto> findWithFilters(String texto, Boolean activo, Boolean stock, Boolean balanza,
             Long subfamiliaId, Long familiaId, Boolean vencimiento, Boolean costoCero, String stockFiltro, Long sucursalId,
             Pageable page) {
-        if (productoSearchEnabled && productoSearchService.textoBusquedaValido(texto)) {
-            return buscarConFiltrosLucene(texto, activo, stock, balanza, subfamiliaId, familiaId, vencimiento,
+        return findWithFilters(texto, null, activo, stock, balanza, subfamiliaId, familiaId, vencimiento, costoCero,
+                stockFiltro, sucursalId, page);
+    }
+
+    /**
+     * Búsqueda de la lista de productos. El texto libre matchea id / descripción y además
+     * código de barras por coincidencia parcial (con o sin ceros a la izquierda, o solo un
+     * tramo del código). Si viene {@code codigo}, la búsqueda se restringe a códigos.
+     */
+    public Page<Producto> findWithFilters(String texto, String codigo, Boolean activo, Boolean stock, Boolean balanza,
+            Long subfamiliaId, Long familiaId, Boolean vencimiento, Boolean costoCero, String stockFiltro, Long sucursalId,
+            Pageable page) {
+        boolean soloCodigo = codigo != null && !codigo.trim().isEmpty();
+        String fragmentoCodigo = soloCodigo ? codigo : texto;
+        List<Long> idsCodigo = codigoSearchService.buscarProductoIdsPorCoincidencia(fragmentoCodigo, LIMITE_IDS_CODIGO);
+
+        if (!soloCodigo && productoSearchEnabled && productoSearchService.textoBusquedaValido(texto)) {
+            return buscarConFiltrosLucene(texto, idsCodigo, activo, stock, balanza, subfamiliaId, familiaId, vencimiento,
                     costoCero, stockFiltro, sucursalId, page);
         }
         String textoSql = texto != null ? texto.replace(" ", "%").toUpperCase() : "";
-        return repository.searchWithFilters(textoSql, activo, stock, balanza, subfamiliaId, familiaId, vencimiento,
-                costoCero, stockFiltro, sucursalId, page);
+        return repository.searchWithFilters(textoSql, idsParaConsulta(idsCodigo), soloCodigo, activo, stock, balanza,
+                subfamiliaId, familiaId, vencimiento, costoCero, stockFiltro, sucursalId, page);
     }
 
-    private Page<Producto> buscarConFiltrosLucene(String texto, Boolean activo, Boolean stock, Boolean balanza,
-            Long subfamiliaId, Long familiaId, Boolean vencimiento, Boolean costoCero, String stockFiltro,
+    /**
+     * JPQL no admite {@code in ()} vacío; se usa un id inexistente como centinela.
+     */
+    private List<Long> idsParaConsulta(List<Long> ids) {
+        return (ids == null || ids.isEmpty()) ? Collections.singletonList(-1L) : ids;
+    }
+
+    /**
+     * Une los ids resueltos por código (primero, por ser la coincidencia más precisa) con
+     * los de Lucene, sin repetir.
+     */
+    private List<Long> unirIds(List<Long> prioritarios, List<Long> resto) {
+        LinkedHashSet<Long> unidos = new LinkedHashSet<>();
+        if (prioritarios != null) {
+            unidos.addAll(prioritarios);
+        }
+        if (resto != null) {
+            unidos.addAll(resto);
+        }
+        unidos.remove(null);
+        return new ArrayList<>(unidos);
+    }
+
+    private Page<Producto> buscarConFiltrosLucene(String texto, List<Long> idsCodigo, Boolean activo, Boolean stock,
+            Boolean balanza, Long subfamiliaId, Long familiaId, Boolean vencimiento, Boolean costoCero, String stockFiltro,
             Long sucursalId, Pageable page) {
         final int overFetch;
         if (page.isUnpaged()) {
@@ -213,8 +264,10 @@ public class ProductoService extends CrudService<Producto, ProductoRepository, L
             overFetch = Math.max(Math.min(2000, (page.getPageNumber() + 1) * page.getPageSize() * 8), 100);
         }
 
-        List<Long> ids = productoSearchService.buscarIdsPorTexto(
-                texto, overFetch, activo, null, familiaId, subfamiliaId);
+        // Los matches por código van primero: son la coincidencia más precisa y Lucene solo
+        // indexa descripción, así que un código de barras nunca llegaría por esa vía.
+        List<Long> ids = unirIds(idsCodigo, productoSearchService.buscarIdsPorTexto(
+                texto, overFetch, activo, null, familiaId, subfamiliaId));
         if (ids.isEmpty()) {
             return new PageImpl<>(Collections.emptyList(), page, 0);
         }
@@ -459,8 +512,11 @@ public class ProductoService extends CrudService<Producto, ProductoRepository, L
             boolean puedeVerStockCompras,
             boolean puedeVerCostos) throws FileNotFoundException {
 
+        // `codigo` es el check "Buscar por código" de la lista: el término viaja en `texto`.
+        boolean buscarPorCodigo = Boolean.TRUE.equals(codigo);
         Page<Producto> productoPage = findWithFilters(
-                texto,
+                buscarPorCodigo ? null : texto,
+                buscarPorCodigo ? texto : null,
                 activo,
                 stock,
                 balanza,

--- a/src/main/java/com/franco/dev/service/productos/search/BuscadorProductoInteligenteService.java
+++ b/src/main/java/com/franco/dev/service/productos/search/BuscadorProductoInteligenteService.java
@@ -7,7 +7,6 @@ import com.franco.dev.domain.productos.enums.TipoCoincidenciaBuscador;
 import com.franco.dev.repository.productos.ProductoProveedorRepository;
 import com.franco.dev.repository.productos.ProductoRepository;
 import com.franco.dev.service.productos.ProductoService;
-import com.franco.dev.utilitarios.BarcodeSearchUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
@@ -59,7 +58,7 @@ public class BuscadorProductoInteligenteService {
         LinkedHashMap<Long, BuscadorProductoResultado> ordenados = new LinkedHashMap<>();
 
         agregarCoincidenciaExacta(texto, ordenados);
-        agregarCoincidenciasPrefijoCodigo(texto, fetchLimit, ordenados);
+        agregarCoincidenciasCodigo(texto, fetchLimit, ordenados);
         agregarCoincidenciaPorId(texto, ordenados);
         agregarCoincidenciasTexto(texto, fetchLimit, activoFiltro, ordenados);
 
@@ -90,7 +89,12 @@ public class BuscadorProductoInteligenteService {
         }
     }
 
-    private void agregarCoincidenciasPrefijoCodigo(
+    /**
+     * Coincidencia parcial de código en cualquier posición: encuentra el producto tanto por el
+     * código completo como omitiendo los ceros a la izquierda o escribiendo solo un tramo
+     * interno o la terminación.
+     */
+    private void agregarCoincidenciasCodigo(
             String texto,
             int fetchLimit,
             Map<Long, BuscadorProductoResultado> destino) {
@@ -98,24 +102,14 @@ public class BuscadorProductoInteligenteService {
             return;
         }
 
-        Set<String> prefijos = new LinkedHashSet<>();
-        prefijos.add(texto.toUpperCase());
-        for (String candidato : BarcodeSearchUtils.codigosParaBuscar(texto)) {
-            if (candidato.length() >= MIN_CODIGO_PREFIJO) {
-                prefijos.add(candidato.toUpperCase());
+        String fragmento = texto.toUpperCase();
+        for (Long id : codigoSearchService.buscarProductoIdsPorCoincidencia(texto, fetchLimit)) {
+            if (id == null || destino.containsKey(id)) {
+                continue;
             }
-        }
-
-        for (String prefijo : prefijos) {
-            List<Long> ids = codigoSearchService.buscarProductoIdsPorPrefijo(prefijo, fetchLimit);
-            for (Long id : ids) {
-                if (id == null || destino.containsKey(id)) {
-                    continue;
-                }
-                productoRepository.findById(id).ifPresent(producto -> destino.put(
-                        id,
-                        new BuscadorProductoResultado(producto, prefijo, TipoCoincidenciaBuscador.CODIGO_PREFIJO)));
-            }
+            productoRepository.findById(id).ifPresent(producto -> destino.put(
+                    id,
+                    new BuscadorProductoResultado(producto, fragmento, TipoCoincidenciaBuscador.CODIGO_PARCIAL)));
         }
     }
 

--- a/src/main/java/com/franco/dev/service/productos/search/CodigoSearchService.java
+++ b/src/main/java/com/franco/dev/service/productos/search/CodigoSearchService.java
@@ -2,6 +2,7 @@ package com.franco.dev.service.productos.search;
 
 import com.franco.dev.domain.productos.Codigo;
 import com.franco.dev.repository.productos.CodigoRepository;
+import com.franco.dev.utilitarios.BarcodeSearchUtils;
 import org.hibernate.search.engine.search.query.SearchResult;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
@@ -35,6 +36,60 @@ public class CodigoSearchService {
 
     public CodigoSearchService(CodigoRepository codigoRepository) {
         this.codigoRepository = codigoRepository;
+    }
+
+    /**
+     * Punto único de búsqueda "inteligente" por código de barras, compartido por lista de
+     * productos, transferencias y gestión de compras.
+     *
+     * Encuentra el producto escribiendo el código completo, sin los ceros a la izquierda,
+     * o solo un tramo interno / la terminación. Los resultados vienen ordenados por
+     * calidad de coincidencia (exacto > prefijo > sufijo > infijo).
+     */
+    public List<Long> buscarProductoIdsPorCoincidencia(String texto, int maxResults) {
+        if (texto == null) {
+            return Collections.emptyList();
+        }
+        String base = texto.trim();
+        if (base.length() < MIN_PREFIJO || base.contains(" ")) {
+            return Collections.emptyList();
+        }
+        int limit = maxResults > 0 ? maxResults : 50;
+
+        Set<Long> ids = new LinkedHashSet<>();
+        for (String fragmento : fragmentosDeBusqueda(base)) {
+            if (ids.size() >= limit) {
+                break;
+            }
+            for (Long id : codigoRepository.findProductoIdsByCodigoCoincidencia(fragmento, limit)) {
+                if (id != null) {
+                    ids.add(id);
+                }
+            }
+        }
+        return ids.stream().limit(limit).collect(Collectors.toList());
+    }
+
+    /**
+     * Variantes a probar, de más específica a más amplia: el texto tal cual, los candidatos
+     * derivados del escaneo (pesable, GTIN GS1, token alfanumérico) y el texto sin los ceros
+     * a la izquierda, para que "078470" y "78470" lleguen al mismo producto.
+     */
+    private Set<String> fragmentosDeBusqueda(String base) {
+        Set<String> fragmentos = new LinkedHashSet<>();
+        fragmentos.add(base.toUpperCase());
+
+        for (String candidato : BarcodeSearchUtils.codigosParaBuscar(base)) {
+            if (candidato.length() >= MIN_PREFIJO) {
+                fragmentos.add(candidato.toUpperCase());
+            }
+        }
+
+        String sinCeros = base.replaceFirst("^0+", "");
+        if (sinCeros.length() >= MIN_PREFIJO) {
+            fragmentos.add(sinCeros.toUpperCase());
+        }
+        return fragmentos;
     }
 
     public List<Long> buscarProductoIdsPorPrefijo(String prefijo, int maxResults) {

--- a/src/main/resources/db/migration/V151__add_trigram_index_codigo_barras.sql
+++ b/src/main/resources/db/migration/V151__add_trigram_index_codigo_barras.sql
@@ -1,0 +1,21 @@
+-- Búsqueda parcial de código de barras (tramo interno / terminación / sin ceros a la izquierda).
+-- El índice btree existente (codigo_codigo_idx) no sirve para LIKE '%x%', que degrada a seq scan.
+-- pg_trgm + GIN resuelve la coincidencia en cualquier posición.
+--
+-- CREATE EXTENSION requiere superusuario: si no está disponible la migración no falla,
+-- la búsqueda sigue funcionando (más lenta) con el plan secuencial.
+
+DO $$
+BEGIN
+    CREATE EXTENSION IF NOT EXISTS pg_trgm;
+EXCEPTION WHEN OTHERS THEN
+    RAISE NOTICE 'pg_trgm no disponible, se omite el indice trigram: %', SQLERRM;
+END $$;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_trgm') THEN
+        CREATE INDEX IF NOT EXISTS codigo_codigo_upper_trgm_idx
+            ON productos.codigo USING gin (UPPER(codigo) gin_trgm_ops);
+    END IF;
+END $$;

--- a/src/main/resources/graphql/productos/producto/buscador-producto.graphqls
+++ b/src/main/resources/graphql/productos/producto/buscador-producto.graphqls
@@ -1,6 +1,7 @@
 enum TipoCoincidenciaBuscador {
     CODIGO_EXACTO
     CODIGO_PREFIJO
+    CODIGO_PARCIAL
     TEXTO
     ID
 }


### PR DESCRIPTION
## Qué resuelve

La búsqueda por código de barras no encontraba el producto salvo escribiendo el código exacto y completo. El pedido era que encuentre igual escribiendo el cero inicial, omitiéndolo, o solo un tramo/la terminación del código — de forma global en **lista de productos, transferencias y gestión de compras**.

Las causas eran distintas en cada módulo:

| Módulo | Causa |
|---|---|
| Lista de productos | `searchWithFilters` hacía `left join Codigo` pero **nunca usaba el código en el `WHERE`** (join muerto). La rama del checkbox "Buscar por código" resolvía por **igualdad exacta** y descartaba el resto de los filtros. |
| Transferencias / diálogo compartido | El SQL de `findbyAll` sí tenía `c.codigo like`, pero con Lucene activo (default) nunca se ejecutaba, y `ProductoSearchService` solo indexa `descripcion` / `descripcionFactura`. |
| Gestión de compras | El buscador inteligente solo hacía **prefijo** (`LIKE 'x%'`). |

## Cómo está resuelto

Se centraliza en `CodigoSearchService.buscarProductoIdsPorCoincidencia()`, que matchea en cualquier posición con ranking **exacto > prefijo > sufijo > infijo**, y prueba variantes del término (candidatos de escaneo pesable/GS1 vía `BarcodeSearchUtils`, y el texto sin ceros a la izquierda). Los tres módulos pasan por ese punto único.

- `CodigoRepository` — nueva query `findProductoIdsByCodigoCoincidencia`
- `ProductoRepository.searchWithFilters` — recibe los ids por código y un flag `soloCodigo`; se elimina el join muerto
- `ProductoService` — los matches por código se anteponen a los de Lucene en ambos buscadores
- `ProductoGraphQL` — se elimina el bypass de match exacto
- `BuscadorProductoInteligenteService` — prefijo → coincidencia parcial

## Cómo probarlo

Con el código real `070847033233` (producto 980), en los tres módulos:

| Se escribe | Debe encontrar |
|---|---|
| `070847033233` (completo) | 980 |
| `70847033233` (sin el cero inicial) | 980 |
| `33233` (terminación) | 980 primero |
| `0847033` (tramo interno) | 980 primero |

Validado con un test JPA temporal contra una base real (incluida la count query de la paginación) y ejecutando la query directamente en Postgres. El test no se incluye en el PR porque requería una URL de DB hardcodeada que rompería CI.

## Impacto en DB

`V151__add_trigram_index_codigo_barras.sql` crea un índice **GIN trigram** sobre `UPPER(codigo)` — el btree existente (`codigo_codigo_idx`) no sirve para `LIKE '%x%'`.

- Solo `CREATE EXTENSION` + `CREATE INDEX IF NOT EXISTS`. No hay `DROP`, `RENAME` ni cambio de tipo.
- `pg_trgm` requiere superusuario / `postgresql-contrib`: si no está disponible, el `DO` block lo captura y **la migración se auto-omite sin fallar**. La búsqueda funciona igual (seq scan).
- Retrocompatible con la versión anterior del backend.

## Impacto en rollback

Ninguno: el índice es aditivo y la versión anterior del backend funciona sin él.

## Cambios de comportamiento a tener en cuenta

El checkbox "Buscar por código" antes ignoraba el resto de los filtros (estado, familia, stock) y podía devolver el mismo producto repetido una vez por código. Ahora **respeta todos los filtros** y devuelve productos distintos.

## API GraphQL

Cambio **aditivo**: se agrega el valor `CODIGO_PARCIAL` al enum `TipoCoincidenciaBuscador`. No se elimina ni renombra nada. Verificado que `frc-mobile` no consume ese enum; el desktop se actualiza en el PR gemelo de `frc-sistemas-integrados-angular`.

## Riesgo

**Bajo.** Compila (`./mvnw compile`), la migración es aditiva y auto-omitible, y el cambio de GraphQL es aditivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)