### PR TITLE
fix(security): responder 401 cuando falta el token en /graphql

### DIFF
--- a/src/main/java/com/franco/dev/security/JwtAuthenticationTokenFilter.java
+++ b/src/main/java/com/franco/dev/security/JwtAuthenticationTokenFilter.java
@@ -1,6 +1,7 @@
 package com.franco.dev.security;
 
 import com.franco.dev.security.model.JwtAuthenticationToken;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
@@ -24,7 +25,11 @@ public class JwtAuthenticationTokenFilter extends AbstractAuthenticationProcessi
         String header = httpServletRequest.getHeader("Authorization");
 
         if (header == null || !header.startsWith("Token ")) {
-            return null;
+            // No devolver null: AbstractAuthenticationProcessingFilter interpreta el null
+            // como "autenticacion aun sin terminar", corta el doFilter y NO escribe nada
+            // en la respuesta. El cliente recibe un HTTP 200 con cuerpo vacio, que Apollo
+            // no puede parsear. Lanzando la excepcion se responde el 401 que corresponde.
+            throw new InsufficientAuthenticationException("Falta el token de autenticacion");
         }
 
         String authenticationToken = header.substring(6);


### PR DESCRIPTION
## Que resuelve

Una request a `/graphql` **sin header `Authorization`** recibia **HTTP 200 con cuerpo vacio** en lugar de un 401.

`JwtAuthenticationTokenFilter` extiende `AbstractAuthenticationProcessingFilter`, cuyo `doFilter` hace:

```java
Authentication authResult = attemptAuthentication(request, response);
if (authResult == null) {
    // subclass indicated it hasn't completed authentication
    return;          // ni sigue la cadena, ni escribe nada en la respuesta
}
```

Y `attemptAuthentication` devolvia `null` justo cuando falta el header:

```java
if (header == null || !header.startsWith("Token ")) {
    return null;
}
```

Resultado: Spring cierra la respuesta sin cuerpo. El `JwtAuthenticationEntryPoint` configurado en `SecurityConfig` —que existe precisamente para devolver el 401— nunca se llegaba a invocar.

### Impacto en el cliente

El desktop consulta `sucursalActual` en su `APP_INITIALIZER`, **antes del login**, o sea sin token. Recibia el 200 vacio y Apollo se rompia: el link `onError` lee `result.errors` sobre un cuerpo `null` y lanza `Cannot read properties of null (reading 'errors')`. La operacion quedaba sin resultado, el dialogo "Buscando..." colgado y el arranque esperando hasta el timeout de 5s.

## Cambios

Una linea de fondo en `JwtAuthenticationTokenFilter`: lanzar `InsufficientAuthenticationException` en vez de `return null`. Spring Security enruta al manejo de fallo y responde **401**.

## Como probarlo

```bash
curl -i -X POST http://localhost:8081/graphql \
  -H 'Content-Type: application/json' \
  -d '{"query":"{ sucursalActual { id nombre } }"}'
```

- Antes: `HTTP/1.1 200` con `Content-Length: 0`.
- Ahora: `HTTP/1.1 401`.

Con token valido, sin cambios.

## Impacto en DB

Ninguno. No hay migraciones.

## Riesgo

**Bajo.** No cambia ningun camino que hoy funcione: sin token la respuesta ya era inutilizable, solo que se disfrazaba de exito. Rollback trivial (un commit, sin estado persistido).

`./mvnw clean verify -B -DskipFlyway=true` en verde (62 tests).

## Cross-proyecto

- `franco-system-backend-filial` tiene el mismo bug — PR paralelo.
- `frc-sistemas-integrados-angular` recibe en paralelo un guard para no romperse ante un cuerpo vacio venga de donde venga.

🤖 Generated with [Claude Code](https://claude.com/claude-code)