### PR TITLE
feat(personas): proveedor de servicios y vínculo con terminal POS

### DIFF
--- a/src/main/java/com/franco/dev/domain/personas/ProveedorServicio.java
+++ b/src/main/java/com/franco/dev/domain/personas/ProveedorServicio.java
@@ -1,8 +1,7 @@
-package com.franco.dev.domain.financiero;
+package com.franco.dev.domain.personas;
 
 import com.franco.dev.config.Identifiable;
-import com.franco.dev.domain.personas.ProveedorServicio;
-import com.franco.dev.domain.personas.Usuario;
+import com.franco.dev.domain.financiero.CuentaBancaria;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -12,12 +11,19 @@ import org.hibernate.annotations.GenericGenerator;
 import javax.persistence.*;
 import java.time.LocalDateTime;
 
+/**
+ * Proveedor de servicios: la empresa que provee las terminales POS y su soporte tecnico.
+ *
+ * Es independiente de {@link Proveedor}, que modela al proveedor de mercaderia (credito,
+ * plazo de cheque, vendedores, productos). Ambos son roles satelite de una {@link Persona},
+ * no hay herencia entre ellos.
+ */
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
-@Table(name = "terminal_pos", schema = "financiero")
-public class TerminalPos implements Identifiable<Long> {
+@Table(name = "proveedor_servicio", schema = "personas")
+public class ProveedorServicio implements Identifiable<Long> {
 
     private static final long serialVersionUID = 1L;
 
@@ -32,25 +38,22 @@ public class TerminalPos implements Identifiable<Long> {
     )
     private Long id;
 
-    private String descripcion;
-
-    private String codigo;
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "persona_id", nullable = true)
+    private Persona persona;
 
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "cuenta_bancaria_id", nullable = true)
     private CuentaBancaria cuentaBancaria;
 
-    @ManyToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name = "moneda_id", nullable = true)
-    private Moneda moneda;
+    @Column(name = "nombre_contacto")
+    private String nombreContacto;
 
-    @ManyToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name = "proveedor_servicio_id", nullable = true)
-    private ProveedorServicio proveedorServicio;
-
-    private Boolean activo;
+    @Column(name = "numero_contacto")
+    private String numeroContacto;
 
     @CreationTimestamp
+    @Column(name = "creado_en")
     private LocalDateTime creadoEn;
 
     @ManyToOne(fetch = FetchType.EAGER)

--- a/src/main/java/com/franco/dev/graphql/financiero/TerminalPosGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/TerminalPosGraphQL.java
@@ -5,6 +5,7 @@ import com.franco.dev.graphql.financiero.input.TerminalPosInput;
 import com.franco.dev.service.financiero.CuentaBancariaService;
 import com.franco.dev.service.financiero.MonedaService;
 import com.franco.dev.service.financiero.TerminalPosService;
+import com.franco.dev.service.personas.ProveedorServicioService;
 import com.franco.dev.service.personas.UsuarioService;
 import graphql.kickstart.tools.GraphQLMutationResolver;
 import graphql.kickstart.tools.GraphQLQueryResolver;
@@ -30,6 +31,9 @@ public class TerminalPosGraphQL implements GraphQLQueryResolver, GraphQLMutation
 
     @Autowired
     private MonedaService monedaService;
+
+    @Autowired
+    private ProveedorServicioService proveedorServicioService;
 
     public Optional<TerminalPos> terminalPos(Long id) {
         return service.findById(id);
@@ -63,6 +67,11 @@ public class TerminalPosGraphQL implements GraphQLQueryResolver, GraphQLMutation
         if (input.getMonedaId() != null) {
             e.setMoneda(monedaService.findById(input.getMonedaId()).orElse(null));
         }
+        // Se setea siempre (no solo cuando viene != null) para poder desvincular el
+        // proveedor de servicio de una terminal desde el desktop.
+        e.setProveedorServicio(input.getProveedorServicioId() != null
+                ? proveedorServicioService.findById(input.getProveedorServicioId()).orElse(null)
+                : null);
         return service.save(e);
     }
 

--- a/src/main/java/com/franco/dev/graphql/financiero/input/TerminalPosInput.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/input/TerminalPosInput.java
@@ -16,6 +16,8 @@ public class TerminalPosInput {
 
     private Long monedaId;
 
+    private Long proveedorServicioId;
+
     private Boolean activo;
 
     private LocalDateTime creadoEn;

--- a/src/main/java/com/franco/dev/graphql/personas/ProveedorServicioGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/personas/ProveedorServicioGraphQL.java
@@ -1,0 +1,98 @@
+package com.franco.dev.graphql.personas;
+
+import com.franco.dev.domain.personas.ProveedorServicio;
+import com.franco.dev.graphql.personas.input.ProveedorServicioInput;
+import com.franco.dev.service.financiero.CuentaBancariaService;
+import com.franco.dev.service.financiero.TerminalPosService;
+import com.franco.dev.service.personas.PersonaService;
+import com.franco.dev.service.personas.ProveedorServicioService;
+import com.franco.dev.service.personas.UsuarioService;
+import graphql.GraphQLException;
+import graphql.kickstart.tools.GraphQLMutationResolver;
+import graphql.kickstart.tools.GraphQLQueryResolver;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+public class ProveedorServicioGraphQL implements GraphQLQueryResolver, GraphQLMutationResolver {
+
+    @Autowired
+    private ProveedorServicioService service;
+
+    @Autowired
+    private UsuarioService usuarioService;
+
+    @Autowired
+    private PersonaService personaService;
+
+    @Autowired
+    private CuentaBancariaService cuentaBancariaService;
+
+    @Autowired
+    private TerminalPosService terminalPosService;
+
+    public Optional<ProveedorServicio> proveedorServicio(Long id) {
+        return service.findById(id);
+    }
+
+    public ProveedorServicio proveedorServicioPorPersona(Long personaId) {
+        return service.findByPersonaId(personaId);
+    }
+
+    public Page<ProveedorServicio> proveedorServicioSearchPage(String texto, Integer page, Integer size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("persona.nombre"));
+        if (texto == null || texto.trim().isEmpty()) {
+            return service.getRepository().findAll(pageable);
+        }
+        String pattern = "%" + texto.trim().replace(" ", "%") + "%";
+        return service.getRepository()
+                .findByPersonaNombreOrApodoOrDocumentoIgnoreCase(pattern, pattern, pattern, pageable);
+    }
+
+    public ProveedorServicio saveProveedorServicio(ProveedorServicioInput input) throws GraphQLException {
+        ModelMapper m = new ModelMapper();
+        ProveedorServicio e = m.map(input, ProveedorServicio.class);
+        e.setUsuario(input.getUsuarioId() != null
+                ? usuarioService.findById(input.getUsuarioId()).orElse(null) : null);
+        e.setPersona(input.getPersonaId() != null
+                ? personaService.findById(input.getPersonaId()).orElse(null) : null);
+        e.setCuentaBancaria(input.getCuentaBancariaId() != null
+                ? cuentaBancariaService.findById(input.getCuentaBancariaId()).orElse(null) : null);
+        try {
+            return service.save(e);
+        } catch (Exception ex) {
+            // El nombre del constraint suele quedar en la causa raiz (PSQLException),
+            // no en el mensaje del wrapper de Spring.
+            for (Throwable t = ex; t != null; t = t.getCause()) {
+                if (t.getMessage() != null && t.getMessage().contains("proveedor_servicio_un")) {
+                    throw new GraphQLException("Esta persona ya es un proveedor de servicio");
+                }
+            }
+            throw ex;
+        }
+    }
+
+    /**
+     * CrudService.deleteById se traga la excepcion y devuelve false, asi que la violacion
+     * de FK llegaria al desktop como un "eliminado con exito" mentiroso. Chequeamos antes.
+     */
+    public Boolean deleteProveedorServicio(Long id) throws GraphQLException {
+        Long terminales = terminalPosService.countByProveedorServicioId(id);
+        if (terminales != null && terminales > 0) {
+            throw new GraphQLException(
+                    "No se puede eliminar: hay " + terminales + " terminal(es) POS vinculada(s) a este proveedor de servicio");
+        }
+        return service.deleteById(id);
+    }
+
+    public Long countProveedorServicio() {
+        return service.count();
+    }
+}

--- a/src/main/java/com/franco/dev/graphql/personas/input/ProveedorServicioInput.java
+++ b/src/main/java/com/franco/dev/graphql/personas/input/ProveedorServicioInput.java
@@ -1,0 +1,13 @@
+package com.franco.dev.graphql.personas.input;
+
+import lombok.Data;
+
+@Data
+public class ProveedorServicioInput {
+    private Long id;
+    private Long personaId;
+    private Long cuentaBancariaId;
+    private String nombreContacto;
+    private String numeroContacto;
+    private Long usuarioId;
+}

--- a/src/main/java/com/franco/dev/repository/financiero/TerminalPosRepository.java
+++ b/src/main/java/com/franco/dev/repository/financiero/TerminalPosRepository.java
@@ -35,5 +35,7 @@ public interface TerminalPosRepository extends HelperRepository<TerminalPos, Lon
 
     TerminalPos findByCodigoIgnoreCase(String codigo);
 
+    Long countByProveedorServicioId(Long proveedorServicioId);
+
     Page<TerminalPos> findAll(Pageable pageable);
 }

--- a/src/main/java/com/franco/dev/repository/personas/ProveedorServicioRepository.java
+++ b/src/main/java/com/franco/dev/repository/personas/ProveedorServicioRepository.java
@@ -1,0 +1,24 @@
+package com.franco.dev.repository.personas;
+
+import com.franco.dev.domain.personas.ProveedorServicio;
+import com.franco.dev.repository.HelperRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+
+public interface ProveedorServicioRepository extends HelperRepository<ProveedorServicio, Long> {
+
+    default Class<ProveedorServicio> getEntityClass() {
+        return ProveedorServicio.class;
+    }
+
+    ProveedorServicio findByPersonaId(Long id);
+
+    /**
+     * Busqueda paginada ignorando mayusculas/minusculas en nombre, apodo y documento.
+     * Los patrones deben incluir % (ej. "%texto%" o "%palabra1%palabra2%").
+     */
+    @Query("SELECT p FROM ProveedorServicio p LEFT JOIN p.persona per " +
+            "WHERE UPPER(per.nombre) LIKE UPPER(?1) OR UPPER(per.apodo) LIKE UPPER(?2) OR UPPER(per.documento) LIKE UPPER(?3)")
+    Page<ProveedorServicio> findByPersonaNombreOrApodoOrDocumentoIgnoreCase(String patternNombre, String patternApodo, String patternDocumento, Pageable pageable);
+}

--- a/src/main/java/com/franco/dev/service/financiero/TerminalPosService.java
+++ b/src/main/java/com/franco/dev/service/financiero/TerminalPosService.java
@@ -22,6 +22,10 @@ public class TerminalPosService extends CrudService<TerminalPos, TerminalPosRepo
         return repository;
     }
 
+    public Long countByProveedorServicioId(Long proveedorServicioId) {
+        return repository.countByProveedorServicioId(proveedorServicioId);
+    }
+
     public TerminalPos findByCodigo(String codigo) {
         return repository.findByCodigoIgnoreCase(codigo);
     }

--- a/src/main/java/com/franco/dev/service/personas/ProveedorServicioService.java
+++ b/src/main/java/com/franco/dev/service/personas/ProveedorServicioService.java
@@ -1,0 +1,35 @@
+package com.franco.dev.service.personas;
+
+import com.franco.dev.domain.personas.ProveedorServicio;
+import com.franco.dev.repository.personas.ProveedorServicioRepository;
+import com.franco.dev.service.CrudService;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@AllArgsConstructor
+public class ProveedorServicioService extends CrudService<ProveedorServicio, ProveedorServicioRepository, Long> {
+
+    private final ProveedorServicioRepository repository;
+
+    @Override
+    public ProveedorServicioRepository getRepository() {
+        return repository;
+    }
+
+    public ProveedorServicio findByPersonaId(Long id) {
+        return repository.findByPersonaId(id);
+    }
+
+    /**
+     * @CreationTimestamp solo cubre el insert; el save defensivo evita quedarse con
+     * creado_en nulo si la fila viene de una edicion previa a esta columna.
+     */
+    @Override
+    public ProveedorServicio save(ProveedorServicio entity) {
+        if (entity.getCreadoEn() == null) entity.setCreadoEn(LocalDateTime.now());
+        return super.save(entity);
+    }
+}

--- a/src/main/resources/db/migration/V153.1__create_proveedor_servicio.sql
+++ b/src/main/resources/db/migration/V153.1__create_proveedor_servicio.sql
@@ -1,0 +1,28 @@
+-- Proveedor de servicios: empresas que proveen las terminales POS y su soporte tecnico.
+-- Entidad independiente de personas.proveedor (ese modela al proveedor de mercaderia).
+-- Se vincula a personas.persona porque "proveedor de servicio" es un rol de una persona,
+-- no un cliente nuestro.
+--
+-- La tabla y la columna de terminal_pos van juntas en una sola migracion para que la FK
+-- nunca apunte a una tabla inexistente.
+--
+-- OJO: financiero.terminal_pos esta replicada MAIN_TO_ALL. El ADD COLUMN de abajo exige
+-- que la columna ya exista en TODAS las filiales (migracion espejo V81.2 del filial),
+-- si no el apply worker se detiene con "missing replicated column".
+
+CREATE TABLE personas.proveedor_servicio (
+    id                 BIGSERIAL PRIMARY KEY,
+    persona_id         BIGINT REFERENCES personas.persona(id),
+    cuenta_bancaria_id BIGINT REFERENCES financiero.cuenta_bancaria(id),
+    nombre_contacto    VARCHAR(255),
+    numero_contacto    VARCHAR(50),
+    usuario_id         BIGINT REFERENCES personas.usuario(id),
+    creado_en          TIMESTAMP DEFAULT NOW(),
+    CONSTRAINT proveedor_servicio_un UNIQUE (persona_id)
+);
+
+CREATE INDEX idx_proveedor_servicio_persona ON personas.proveedor_servicio(persona_id);
+
+ALTER TABLE financiero.terminal_pos
+    ADD COLUMN proveedor_servicio_id BIGINT NULL
+    REFERENCES personas.proveedor_servicio(id);

--- a/src/main/resources/db/migration/V153.2__registrar_replicacion_proveedor_servicio.sql
+++ b/src/main/resources/db/migration/V153.2__registrar_replicacion_proveedor_servicio.sql
@@ -1,0 +1,52 @@
+-- Replicacion de personas.proveedor_servicio: central -> todas las filiales.
+-- La fuente de verdad es el central (el alta/edicion solo existe alli); la filial
+-- solo necesita la copia para poder resolver terminal_pos.proveedor_servicio_id.
+--
+-- financiero.terminal_pos NO se re-registra: ya esta replicada (V142.1). Agregarle una
+-- columna no requiere tocar la publicacion (una publicacion sin lista de columnas publica
+-- todas), pero SI requiere que la columna exista en cada filial -> migracion espejo V81.2
+-- del repo filial, que se despliega ANTES que esta.
+
+-- 1. Registro declarativo: alimenta la CREACION de publicaciones nuevas.
+INSERT INTO configuraciones.replication_table
+    (table_name, direction, description, enabled, replicate_central_to_branch_with_filter, creado_en)
+VALUES
+    ('personas.proveedor_servicio', 'MAIN_TO_ALL', 'Proveedor de Servicio', true, false, NOW())
+ON CONFLICT (table_name) DO NOTHING;
+
+-- 2. Publicaciones YA existentes: el INSERT de arriba no las toca, hay que alterarlas.
+--    MAIN_TO_ALL sin filtro va a central_pub (misma logica que V119).
+DO $$
+DECLARE
+    pub RECORD;
+BEGIN
+    FOR pub IN
+        SELECT pubname FROM pg_publication
+        WHERE (pubname = 'central_pub' OR pubname LIKE 'central\_%\_pub')
+          AND pubname NOT LIKE 'central%filial%pub'
+        ORDER BY pubname
+    LOOP
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_publication_tables
+            WHERE pubname = pub.pubname
+              AND schemaname = 'personas'
+              AND tablename = 'proveedor_servicio'
+        ) THEN
+            BEGIN
+                EXECUTE format(
+                    'ALTER PUBLICATION %I ADD TABLE personas.proveedor_servicio',
+                    pub.pubname
+                );
+                RAISE NOTICE 'Added personas.proveedor_servicio to %', pub.pubname;
+            EXCEPTION WHEN OTHERS THEN
+                RAISE WARNING 'No se pudo agregar personas.proveedor_servicio a %: %',
+                    pub.pubname, SQLERRM;
+            END;
+        END IF;
+    END LOOP;
+END $$;
+
+-- IMPORTANTE (post-deploy): cada filial necesita
+--   ALTER SUBSCRIPTION <sub> REFRESH PUBLICATION;
+-- para empezar a recibir la tabla nueva. Se hace desde el dialogo de replicacion del
+-- desktop o a mano. Sin el REFRESH la tabla queda vacia en la filial, sin error visible.

--- a/src/main/resources/graphql/financiero/terminalpos.graphqls
+++ b/src/main/resources/graphql/financiero/terminalpos.graphqls
@@ -3,6 +3,7 @@ type TerminalPos {
     descripcion: String
     codigo: String
     moneda: Moneda
+    proveedorServicio: ProveedorServicio
     activo: Boolean
     creadoEn: Date
     usuario: Usuario
@@ -25,6 +26,7 @@ input TerminalPosInput {
     codigo: String
     cuentaBancariaId: Int
     monedaId: Int
+    proveedorServicioId: Int
     activo: Boolean
     creadoEn: Date
     usuarioId: Int

--- a/src/main/resources/graphql/personas/proveedor-servicio.graphqls
+++ b/src/main/resources/graphql/personas/proveedor-servicio.graphqls
@@ -1,0 +1,41 @@
+type ProveedorServicio {
+    id:ID!
+    persona: Persona
+    cuentaBancaria: CuentaBancaria
+    nombreContacto: String
+    numeroContacto: String
+    creadoEn: Date
+    usuario: Usuario
+}
+
+input ProveedorServicioInput {
+    id:ID
+    personaId: Int
+    cuentaBancariaId: Int
+    nombreContacto: String
+    numeroContacto: String
+    usuarioId: Int
+}
+
+type ProveedorServicioPage {
+    getTotalPages: Int
+    getTotalElements: Int
+    getNumberOfElements: Int
+    isFirst: Boolean
+    isLast: Boolean
+    hasNext: Boolean
+    hasPrevious: Boolean
+    getContent: [ProveedorServicio]
+}
+
+extend type Query {
+    proveedorServicio(id:ID!): ProveedorServicio
+    proveedorServicioPorPersona(personaId:ID): ProveedorServicio
+    proveedorServicioSearchPage(texto: String, page: Int = 0, size: Int = 10): ProveedorServicioPage
+    countProveedorServicio: Int
+}
+
+extend type Mutation {
+    saveProveedorServicio(proveedorServicio:ProveedorServicioInput!): ProveedorServicio!
+    deleteProveedorServicio(id:ID!): Boolean!
+}


### PR DESCRIPTION
## Qué resuelve

`personas.proveedor` modela al proveedor de **mercadería** (crédito, plazo de cheque, vendedores, productos). No había forma de registrar a las empresas que proveen las **terminales POS** y su soporte técnico, ni de saber a quién reclamar cuando una terminal falla.

Este PR agrega una entidad nueva e independiente, `personas.proveedor_servicio`, con su contacto de soporte y su cuenta bancaria, y vincula cada terminal POS a un proveedor de servicio.

**Por qué `persona_id` y no `cliente_id`:** no hay herencia JPA acá — `Cliente` y `Proveedor` son tablas satélite con un `@ManyToOne` a `Persona`. Son roles que una persona cumple. Un proveedor de servicios no es cliente nuestro, así que `cliente_id` obligaría a crear un Cliente falso por cada uno.

## ⚠️ Orden de despliegue: el filial va PRIMERO

`financiero.terminal_pos` está replicada `MAIN_TO_ALL`. El `ADD COLUMN` de este PR exige que la columna **ya exista en todas las filiales**; si no, el apply worker falla con `missing replicated column` y detiene la suscripción completa de esa filial, acumulando WAL en el slot del central.

Mergear y desplegar primero GabFrank/franco-system-backend-filial#86, confirmar que llegó a todas las filiales (~15 min de auto-update), y recién entonces esto.

## Qué cambia

**Migraciones**
- `V153.1` — tabla `personas.proveedor_servicio` + `terminal_pos.proveedor_servicio_id` nullable, en una sola migración para que la FK nunca apunte a una tabla inexistente
- `V153.2` — registro `MAIN_TO_ALL` en `configuraciones.replication_table` (alimenta la creación de publicaciones nuevas) **más** `ALTER PUBLICATION ... ADD TABLE` sobre las publicaciones ya existentes, que el `INSERT` solo no toca

**Clases nuevas** (clon del patrón de `Proveedor`): entity, repository, service, input, resolver y `proveedor-servicio.graphqls`.

**TerminalPos**: `@ManyToOne` a `ProveedorServicio`, `proveedorServicioId` en el input, seteo en `saveTerminalPos`, y el campo agregado al `type` **y** al `input` del `.graphqls`.

## Tres decisiones que conviene mirar en el review

1. **El campo se agrega explícitamente al `type TerminalPos`.** Hoy ese type no expone `cuentaBancaria` aunque la entity la tiene y el input la acepta; si no lo agregábamos, el desktop guardaba bien y mostraba siempre vacío, sin ningún error. (El hueco de `cuentaBancaria` sigue ahí, no lo toqué para no ampliar el alcance.)

2. **En `saveTerminalPos` el proveedor se setea siempre**, no solo cuando viene `!= null`, para poder desvincularlo desde el desktop. Los bloques de `moneda` y `cuentaBancaria` siguen con el patrón viejo (`if != null`), que no permite limpiar.

3. **`deleteProveedorServicio` chequea terminales vinculadas antes de borrar.** `CrudService.deleteById` atrapa la excepción y devuelve `false`, y el `onDelete` genérico del desktop mira solo `res.errors` — así que una violación de FK llegaba como un "Eliminado con éxito" mentiroso, con el registro todavía ahí. Ahora tira `GraphQLException` con la cantidad de terminales vinculadas.

## Cómo probarlo

`./mvnw -o spring-boot:run -DskipFlyway=true` (8081, sin perfil `dev`).

```sql
\d personas.proveedor_servicio
select table_name, direction, enabled from configuraciones.replication_table
 where table_name = 'personas.proveedor_servicio';
select * from pg_publication_tables where tablename = 'proveedor_servicio';
```

Desde el desktop: Terminal POS → "Proveedores de servicios" → alta/edición; después vincular un proveedor a una terminal, guardar, **reabrir** y confirmar que quedó (esto es lo que detecta el bug del `type` incompleto).

Probado localmente: migraciones aplicadas (schema en `153.2`), arranque OK, tabla creada con sus FKs y el constraint `proveedor_servicio_un`, columna nullable en `terminal_pos`, registro en `replication_table`, y la tabla efectivamente agregada a `central_pub`.

## Impacto en DB

Solo aditivo: `CREATE TABLE`, `ADD COLUMN` nullable, `CREATE INDEX`, `INSERT` de configuración. Sin `DROP`/`RENAME`/cambio de tipo.

## Rollback

La versión anterior del backend ignora la tabla y la columna, así que un rollback de JAR no requiere tocar la DB. Lo que **no** se revierte solo es el `ALTER PUBLICATION`; si hiciera falta, hay que sacar la tabla de la publicación a mano.

## Post-deploy

Cada filial necesita `ALTER SUBSCRIPTION <sub> REFRESH PUBLICATION` para empezar a recibir la tabla nueva — desde el diálogo de replicación del desktop o a mano. Sin el REFRESH la tabla queda vacía en la filial, sin error visible. No lo puse como migración del filial porque, al desplegarse antes que el central, sería un no-op.

## Riesgo

**Medio**, todo concentrado en el orden de despliegue y en el REFRESH post-deploy. El código en sí es aditivo.

## PRs relacionados

- Filial: GabFrank/franco-system-backend-filial#86 — va **antes** de este
- Desktop: `GabFrank/frc-sistemas-integrados-angular`

🤖 Generated with [Claude Code](https://claude.com/claude-code)