### PR TITLE
fix(sifen): informar dTasaIVA y dPropIVA en items exentos

### DIFF
--- a/src/main/java/com/franco/dev/service/sifen/SifenService.java
+++ b/src/main/java/com/franco/dev/service/sifen/SifenService.java
@@ -37,6 +37,7 @@ import com.franco.dev.service.financiero.FacturaLegalItemService;
 import com.franco.dev.service.financiero.FacturaLegalService;
 import com.franco.dev.service.financiero.LoteDEService;
 import com.franco.dev.service.personas.ClienteService;
+import com.franco.dev.service.sifen.util.GCamIvaMapper;
 import com.franco.dev.service.sifen.util.SifenEventoParser;
 import com.franco.dev.service.sifen.util.SifenReceptorHelper;
 import com.roshka.sifen.Sifen;
@@ -1103,8 +1104,8 @@ public class SifenService {
         List<com.franco.dev.domain.financiero.DocumentoElectronico> documentos = 
             documentoElectronicoService.findByLoteDe(lote);
         
-        int aprobados = 0, rechazados = 0;
-        
+        int aprobados = 0, rechazados = 0, sinConfirmar = 0;
+
         for (com.franco.dev.domain.financiero.DocumentoElectronico documento : documentos) {
             // Buscar detalle individual por CDC
             DetalleDocumentoEnLote detalle = detallesDocumentos.stream()
@@ -1130,23 +1131,29 @@ public class SifenService {
                     log.debug("      ✗ Documento {} RECHAZADO: {}", documento.getCdc(), detalle.mensaje);
                 }
             } else {
-                // No se encontró detalle, usar estado general
-                EstadoDE estadoGeneral = loteAprobado ? EstadoDE.APROBADO : EstadoDE.RECHAZADO;
-                documento.setEstado(estadoGeneral);
-                log.warn("      ⚠️ Documento {} sin detalle individual - usando estado general", documento.getCdc());
+                // SIFEN no devolvió resultado para este CDC: no procesó el documento (típicamente
+                // porque el XML no pasó la validación del esquema). El estado del lote es el del
+                // resto de los documentos y no dice nada sobre éste, así que no se infiere: se deja
+                // como está (EN_LOTE) y sin fecha de recepción, para que figure como no confirmado
+                // en lugar de aparecer como aprobado por arrastre.
+                sinConfirmar++;
+                log.error("      ❌ Documento {} sin resultado individual en la respuesta del lote {} "
+                        + "- se mantiene en estado {} (no confirmado por SIFEN)",
+                    documento.getCdc(), lote.getId(), documento.getEstado());
+                continue;
             }
-            
+
             documento.setFechaRecepcionSifen(LocalDateTime.now());
             documentoElectronicoService.save(documento);
         }
-        
-        log.info("   📊 Resumen: {} aprobados, {} rechazados de {} totales", 
-            aprobados, rechazados, documentos.size());
-        
-        // 5. Ajustar estado final del lote si hay errores mixtos
-        if (aprobados > 0 && rechazados > 0) {
+
+        log.info("   📊 Resumen: {} aprobados, {} rechazados, {} sin confirmar de {} totales",
+            aprobados, rechazados, sinConfirmar, documentos.size());
+
+        // 5. Ajustar estado final del lote si hay errores mixtos o documentos sin confirmar
+        if ((aprobados > 0 && rechazados > 0) || sinConfirmar > 0) {
             lote.setEstado(EstadoLoteDE.PROCESADO_CON_ERRORES);
-            log.info("   ⚠️ Lote con resultados mixtos → PROCESADO_CON_ERRORES");
+            log.info("   ⚠️ Lote con resultados mixtos o incompletos → PROCESADO_CON_ERRORES");
         }
     }
 
@@ -1546,27 +1553,12 @@ public class SifenService {
             gValorItem.setgValorRestaItem(gValorRestaItem);
             gCamItem.setgValorItem(gValorItem);
 
-            TgCamIVA gCamIVA = new TgCamIVA();
             Integer iva = (producto != null && producto.getIva() != null) ? producto.getIva() : 10; // Default to 10
 
-            switch (iva) {
-                case 5:
-                    gCamIVA.setiAfecIVA(TiAfecIVA.GRAVADO);
-                    gCamIVA.setdPropIVA(BigDecimal.valueOf(100));
-                    gCamIVA.setdTasaIVA(BigDecimal.valueOf(5));
-                    gCamIVA.setdBasExe(BigDecimal.ZERO);
-                    break;
-                case 0:
-                    gCamIVA.setiAfecIVA(TiAfecIVA.EXENTO);
-                    break;
-                case 10:
-                default:
-                    gCamIVA.setiAfecIVA(TiAfecIVA.GRAVADO);
-                    gCamIVA.setdPropIVA(BigDecimal.valueOf(100));
-                    gCamIVA.setdTasaIVA(BigDecimal.valueOf(10));
-                    gCamIVA.setdBasExe(BigDecimal.ZERO);
-                    break;
-            }
+            // Mapeo a gCamIVA (E730) centralizado en GCamIvaMapper, que aplica las reglas
+            // 1904/1905/1907/1908 del MT v150 y evita dejar campos obligatorios en null.
+            TgCamIVA gCamIVA = GCamIvaMapper.construir(iva);
+
             gCamItem.setgCamIVA(gCamIVA);
 
             gCamItemList.add(gCamItem);

--- a/src/main/java/com/franco/dev/service/sifen/util/GCamIvaMapper.java
+++ b/src/main/java/com/franco/dev/service/sifen/util/GCamIvaMapper.java
@@ -1,0 +1,47 @@
+package com.franco.dev.service.sifen.util;
+
+import com.roshka.sifen.core.fields.request.de.TgCamIVA;
+import com.roshka.sifen.core.types.TiAfecIVA;
+
+import java.math.BigDecimal;
+
+/**
+ * Construye el grupo E730 (gCamIVA) de un item a partir del porcentaje de IVA resuelto.
+ *
+ * Reglas del MT v150 para los campos E731-E737:
+ *   - Gravado (E731=1): E733 dPropIVA = 100 (regla 1904) y E734 dTasaIVA = 5 o 10 (regla 1908).
+ *   - Exento  (E731=3): E733 dPropIVA = 0   (regla 1905) y E734 dTasaIVA = 0      (regla 1907).
+ *
+ * Los siete campos del grupo son obligatorios en el XSD, y jsifenlib los serializa con
+ * String.valueOf(): un BigDecimal en null se emite como el texto "null", el DE no valida
+ * contra el esquema y SIFEN lo descarta sin devolver resultado individual en el lote.
+ *
+ * dBasGravIVA, dLiqIVAItem y dBasExe no se setean aca a proposito: jsifenlib los calcula y
+ * los fuerza a 0 para exentos, que es lo que piden el MT (E735) y la NT13 (E737).
+ */
+public final class GCamIvaMapper {
+
+    private GCamIvaMapper() {
+    }
+
+    /**
+     * @param iva porcentaje de IVA del item (0, 5 o 10). Null se trata como 10, igual que el
+     *            default de {@code IvaResolver}.
+     */
+    public static TgCamIVA construir(Integer iva) {
+        TgCamIVA gCamIVA = new TgCamIVA();
+        int porcentaje = (iva != null) ? iva : 10;
+
+        if (porcentaje == 0) {
+            gCamIVA.setiAfecIVA(TiAfecIVA.EXENTO);
+            gCamIVA.setdPropIVA(BigDecimal.ZERO);
+            gCamIVA.setdTasaIVA(BigDecimal.ZERO);
+        } else {
+            gCamIVA.setiAfecIVA(TiAfecIVA.GRAVADO);
+            gCamIVA.setdPropIVA(BigDecimal.valueOf(100));
+            gCamIVA.setdTasaIVA(BigDecimal.valueOf(porcentaje == 5 ? 5 : 10));
+        }
+
+        return gCamIVA;
+    }
+}

--- a/src/test/java/com/franco/dev/service/sifen/util/GCamIvaMapperTest.java
+++ b/src/test/java/com/franco/dev/service/sifen/util/GCamIvaMapperTest.java
@@ -1,0 +1,70 @@
+package com.franco.dev.service.sifen.util;
+
+import com.roshka.sifen.core.fields.request.de.TgCamIVA;
+import com.roshka.sifen.core.types.TiAfecIVA;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class GCamIvaMapperTest {
+
+    /**
+     * Regresion: un item exento dejaba dTasaIVA en null, jsifenlib lo serializaba como el
+     * texto "null" y SIFEN descartaba el DE sin devolver resultado individual en el lote.
+     * MT v150: para E731=3 la proporcion gravada (regla 1905) y la tasa (regla 1907) son 0.
+     */
+    @Test
+    void exentoInformaProporcionYTasaEnCero() {
+        TgCamIVA g = GCamIvaMapper.construir(0);
+
+        assertEquals(TiAfecIVA.EXENTO, g.getiAfecIVA());
+        assertEquals(0, BigDecimal.ZERO.compareTo(g.getdPropIVA()));
+        assertEquals(0, BigDecimal.ZERO.compareTo(g.getdTasaIVA()));
+    }
+
+    @Test
+    void gravado10InformaProporcion100YTasa10() {
+        TgCamIVA g = GCamIvaMapper.construir(10);
+
+        assertEquals(TiAfecIVA.GRAVADO, g.getiAfecIVA());
+        assertEquals(0, BigDecimal.valueOf(100).compareTo(g.getdPropIVA()));
+        assertEquals(0, BigDecimal.TEN.compareTo(g.getdTasaIVA()));
+    }
+
+    @Test
+    void gravado5InformaProporcion100YTasa5() {
+        TgCamIVA g = GCamIvaMapper.construir(5);
+
+        assertEquals(TiAfecIVA.GRAVADO, g.getiAfecIVA());
+        assertEquals(0, BigDecimal.valueOf(100).compareTo(g.getdPropIVA()));
+        assertEquals(0, BigDecimal.valueOf(5).compareTo(g.getdTasaIVA()));
+    }
+
+    @Test
+    void ivaNuloODesconocidoCaeEn10() {
+        for (Integer iva : new Integer[]{null, 21}) {
+            TgCamIVA g = GCamIvaMapper.construir(iva);
+
+            assertEquals(TiAfecIVA.GRAVADO, g.getiAfecIVA());
+            assertEquals(0, BigDecimal.TEN.compareTo(g.getdTasaIVA()));
+        }
+    }
+
+    /**
+     * Ningun campo obligatorio del grupo puede quedar en null: jsifenlib los emite con
+     * String.valueOf(), asi que un null se convierte en el literal "null" y rompe el XSD.
+     */
+    @Test
+    void ningunPorcentajeDejaCamposObligatoriosEnNull() {
+        for (Integer iva : new Integer[]{null, 0, 5, 10, 21}) {
+            TgCamIVA g = GCamIvaMapper.construir(iva);
+
+            assertNotNull(g.getiAfecIVA(), "iAfecIVA nulo para iva=" + iva);
+            assertNotNull(g.getdPropIVA(), "dPropIVA nulo para iva=" + iva);
+            assertNotNull(g.getdTasaIVA(), "dTasaIVA nulo para iva=" + iva);
+        }
+    }
+}


### PR DESCRIPTION
Espejo en el central del fix aplicado en el filial: [franco-system-backend-filial#87](https://github.com/GabFrank/franco-system-backend-filial/pull/87). **El bug está activo en el filial, no acá** — ver "Riesgo" abajo.

## Qué resuelve

Un ítem con IVA 0 construía el grupo `gCamIVA` (E730) informando sólo `iAfecIVA`. Los otros campos quedaban en null, y jsifenlib los serializa con `String.valueOf()` — un `BigDecimal` nulo sale como el texto literal `null`.

En el central el síntoma es distinto al del filial: como la librería hace `dPropIVA.divide(...)` sin chequear null, acá se lanza **NPE** al generar el XML y la factura queda sin DE. En el filial, que sí seteaba `dPropIVA`, no había NPE pero salía `<dTasaIVA>null</dTasaIVA>`: el DE no valida contra el XSD (`tdTasaIVA` es `xs:integer`) y SIFEN lo descarta sin devolver `gResProcLote` para ese CDC.

Al no encontrar el detalle individual, `procesarRespuestaLoteConcluido` caía en una rama que **inferría el estado del documento a partir del estado general del lote**, marcando como APROBADO documentos que SIFEN nunca autorizó.

## Reglas aplicadas (MT v150)

| Regla | Exigencia para E731 = 3 (Exento) |
|---|---|
| 1905 | `dPropIVA` (E733) debe ser **0** |
| 1907 | `dTasaIVA` (E734) debe ser **0** |
| E735 | `dBasGravIVA` = 0 |
| NT13, E737 | `dBasExe` = 0 |

## Cambios

- **`GCamIvaMapper`** (nuevo): centraliza el mapeo de porcentaje de IVA a `gCamIVA`, siguiendo el patrón de `IvaResolver`. Es **idéntico al del filial**, para que ambos repos no vuelvan a divergir en esta lógica. Queda cubierto por tests, imposible con el `switch` embebido en el método privado.
- **`SifenService.procesarRespuestaLoteConcluido`**: cuando la respuesta del lote no trae resultado individual para un CDC, el documento ya no hereda el estado del lote. Queda en `EN_LOTE`, sin `fecha_recepcion_sifen`, el lote pasa a `PROCESADO_CON_ERRORES` y el log sube de WARN a ERROR.

Nota: el `switch` anterior seteaba `dBasExe = 0` para gravados. El mapper no lo hace, porque la librería recalcula y pisa ese campo cuando `sifen.habilitarNotaTecnica13=true` (que es el valor configurado). El XML resultante es el mismo.

## Cómo probarlo

```bash
./mvnw clean verify -B -DskipFlyway=true
```

67 tests, 0 fallos. Los 5 nuevos de `GCamIvaMapperTest` cubren exento, gravado 5/10, default e "ningún campo obligatorio en null". En el filial verifiqué que ese test detecta la regresión: revirtiendo el `setdTasaIVA(ZERO)` fallan 2 de los 5.

No hay prueba de punta a punta acá: `sifen.enabled=false` en el central.

## Impacto en DB

Ninguno. Sin migraciones. No se agregan valores al enum `financiero.estado_de_enum` — por eso los documentos sin confirmar quedan en `EN_LOTE` en vez de un estado nuevo.

Los registros históricos afectados están en la base compartida y **no se tocan en este PR**; se documentan en el PR del filial.

## Impacto en rollback

Bajo. Volver a la versión anterior restaura el comportamiento previo. Sin cambios de esquema ni de contrato GraphQL.

## Riesgo

**Bajo.** En el central este código está esencialmente inactivo:

- `sifen.enabled=false` en `application.properties`, así que `SifenSchedulerService` (`@ConditionalOnProperty`) ni se instancia.
- `SifenIntegrationService.crearDEAutomatico` no tiene callers y `procesarEnvioAutomatico` está vacío.
- La única entrada viva es la mutation GraphQL manual `crearDocumentoElectronico`.

Los DEs que hay en la base los genera y actualiza el filial, y llegan acá por replicación lógica (el mapeo de `lote_de_id` en la entidad del central es `insertable=false, updatable=false`, así que ni siquiera puede escribir esa columna).

El valor de este PR es que el central no quede con la misma mina si SIFEN se habilita, y que ambos repos compartan la misma lógica de mapeo. El cambio para gravados 5 y 10 es equivalente al anterior; el único cambio de comportamiento real es en exentos, que hoy lanzan NPE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)