### PR TITLE
fix(sifen): persistir codigo de respuesta en la consulta individual

### DIFF
--- a/src/main/java/com/franco/dev/service/sifen/SifenService.java
+++ b/src/main/java/com/franco/dev/service/sifen/SifenService.java
@@ -38,6 +38,7 @@ import com.franco.dev.service.financiero.FacturaLegalService;
 import com.franco.dev.service.financiero.LoteDEService;
 import com.franco.dev.service.personas.ClienteService;
 import com.franco.dev.service.sifen.util.SifenEventoParser;
+import com.franco.dev.service.sifen.util.SifenXmlParser;
 import com.franco.dev.service.sifen.util.SifenReceptorHelper;
 import com.roshka.sifen.Sifen;
 import com.roshka.sifen.core.beans.response.RespuestaConsultaDE;
@@ -60,6 +61,7 @@ import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Servicio para integración con SIFEN (Sistema Integrado de Facturación Electrónica Nacional).
@@ -615,51 +617,79 @@ public class SifenService {
                 log.info("   📋 Protocolo de autorización: {}", protocoloAutorizacion);
             }
             
+            // Extraer el resultado de procesamiento del documento (gResProc). Es el mismo par
+            // código/mensaje que persiste el flujo de lote; el primer dCodRes del XML es el de
+            // la consulta (0422 = CDC encontrado) y no dice nada sobre el documento.
+            String codigoRespuesta = SifenXmlParser.extractGResProcValue(xmlRespuesta, "dCodRes");
+            String mensajeRespuesta = SifenXmlParser.extractGResProcValue(xmlRespuesta, "dMsgRes");
+
+            if (codigoRespuesta != null) {
+                log.info("   📥 Resultado del DE: {} - {}", codigoRespuesta, mensajeRespuesta);
+            }
+
             // Extraer estado del resultado (dEstRes) del DE
             // Este campo indica si el documento fue Aprobado, Aprobado con observación, o Rechazado
             String estadoResultado = extraerEstadoResultadoDE(xmlRespuesta);
-            
+
             if (estadoResultado == null) {
                 log.warn("   ⚠️ No se pudo determinar estado del DE desde respuesta");
-                return;
+            } else {
+                log.info("   📊 Estado en SIFEN: {}", estadoResultado);
             }
-            
-            log.info("   📊 Estado en SIFEN: {}", estadoResultado);
-            
+
             // Mapear estado de SIFEN a estado local
             EstadoDE nuevoEstado = null;
-            boolean actualizar = false;
-            
-            if ("Aprobado".equalsIgnoreCase(estadoResultado) || 
+
+            if (estadoResultado == null) {
+                // Sin dEstRes no se toca el estado, pero el código de respuesta sí se persiste.
+            } else if ("Aprobado".equalsIgnoreCase(estadoResultado) ||
                 estadoResultado.toLowerCase().contains("aprobado con observación") ||
                 estadoResultado.toLowerCase().contains("aprobado con observacion")) {
-                
+
                 // Solo actualizar a APROBADO si no está ya en un estado final más específico
-                if (de.getEstado() != EstadoDE.APROBADO && 
+                if (de.getEstado() != EstadoDE.APROBADO &&
                     de.getEstado() != EstadoDE.CANCELADO) {
                     nuevoEstado = EstadoDE.APROBADO;
-                    actualizar = true;
                     log.info("   ✅ DE aprobado por SIFEN");
                 }
-                
+
             } else if ("Rechazado".equalsIgnoreCase(estadoResultado)) {
-                
+
                 // Actualizar a RECHAZADO si no está ya en ese estado
                 if (de.getEstado() != EstadoDE.RECHAZADO) {
                     nuevoEstado = EstadoDE.RECHAZADO;
-                    actualizar = true;
                     log.info("   ❌ DE rechazado por SIFEN");
                 }
             }
-            
-            // Actualizar en BD si corresponde
-            if (actualizar && nuevoEstado != null) {
+
+            // Actualizar en BD si corresponde. El código y el mensaje se persisten aunque el
+            // estado no cambie: antes esta vía sólo escribía el estado, y los DEs actualizados
+            // por consulta individual quedaban sin código de respuesta en BD.
+            boolean cambios = false;
+
+            if (nuevoEstado != null) {
                 de.setEstado(nuevoEstado);
                 de.setFechaRecepcionSifen(LocalDateTime.now());
+                cambios = true;
+            }
+
+            if (codigoRespuesta != null
+                    && (!codigoRespuesta.equals(de.getCodigoRespuestaSifen())
+                        || !Objects.equals(mensajeRespuesta, de.getMensajeRespuestaSifen()))) {
+                de.setCodigoRespuestaSifen(codigoRespuesta);
+                de.setMensajeRespuestaSifen(mensajeRespuesta);
+                if (de.getFechaRecepcionSifen() == null) {
+                    de.setFechaRecepcionSifen(LocalDateTime.now());
+                }
+                cambios = true;
+            }
+
+            if (cambios) {
                 documentoElectronicoService.save(de);
-                log.info("   💾 Estado del DE actualizado a: {}", nuevoEstado);
+                log.info("   💾 DE actualizado - estado: {}, código: {}",
+                    de.getEstado(), de.getCodigoRespuestaSifen());
             } else {
-                log.info("   ℹ️ Estado del DE no requiere actualización (actual: {})", de.getEstado());
+                log.info("   ℹ️ El DE no requiere actualización (estado actual: {})", de.getEstado());
             }
             
         } catch (Exception e) {

--- a/src/main/java/com/franco/dev/service/sifen/util/SifenXmlParser.java
+++ b/src/main/java/com/franco/dev/service/sifen/util/SifenXmlParser.java
@@ -52,6 +52,54 @@ public class SifenXmlParser {
     }
 
     /**
+     * Extrae un campo del bloque gResProc de una respuesta de consulta individual de SIFEN.
+     *
+     * Ese bloque contiene el resultado de procesamiento del documento (dCodRes / dMsgRes), que
+     * es el par que el flujo de lote persiste en codigo_respuesta_sifen / mensaje_respuesta_sifen.
+     * Se acota la búsqueda al bloque porque el primer dCodRes del XML es el de la consulta en sí
+     * (0422 = CDC encontrado) y no dice nada sobre el documento.
+     *
+     * Prueba con el prefijo ns2 y sin prefijo, igual que el resto del parseo de respuestas.
+     *
+     * @param xml El XML de respuesta completo
+     * @param campo Nombre del elemento a extraer, sin prefijo (ej: "dCodRes")
+     * @return El valor encontrado, o null si la respuesta no trae bloque gResProc
+     */
+    public static String extractGResProcValue(String xml, String campo) {
+        if (xml == null || xml.isEmpty() || campo == null || campo.isEmpty()) {
+            return null;
+        }
+
+        for (String prefijo : new String[]{"ns2:", ""}) {
+            int inicioBloque = xml.indexOf("<" + prefijo + "gResProc>");
+            if (inicioBloque == -1) {
+                continue;
+            }
+
+            int finBloque = xml.indexOf("</" + prefijo + "gResProc>", inicioBloque);
+            if (finBloque == -1) {
+                continue;
+            }
+
+            String bloque = xml.substring(inicioBloque, finBloque);
+            String openTag = "<" + prefijo + campo + ">";
+            String closeTag = "</" + prefijo + campo + ">";
+
+            int desde = bloque.indexOf(openTag);
+            int hasta = bloque.indexOf(closeTag, desde + 1);
+
+            if (desde != -1 && hasta > desde) {
+                String valor = bloque.substring(desde + openTag.length(), hasta).trim();
+                if (!valor.isEmpty()) {
+                    return decodeHtmlEntities(valor);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Extrae el valor de un tag XML específico con un namespace/prefijo.
      * 
      * @param xml El XML completo como String

--- a/src/test/java/com/franco/dev/service/sifen/util/SifenXmlParserGResProcTest.java
+++ b/src/test/java/com/franco/dev/service/sifen/util/SifenXmlParserGResProcTest.java
@@ -1,0 +1,68 @@
+package com.franco.dev.service.sifen.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * El resultado de procesamiento del documento vive en gResProc. El dCodRes de nivel de
+ * respuesta es el de la consulta en si (0422 = CDC encontrado), asi que tomar el primero
+ * del XML guardaria un codigo que no corresponde al documento.
+ */
+class SifenXmlParserGResProcTest {
+
+    /** Respuesta tipica de consulta individual: 0422 arriba, resultado del DE en gResProc. */
+    private static final String RESPUESTA_CON_NS2 =
+        "<env:Envelope><env:Body><ns2:rEnviConsDeResponse xmlns:ns2=\"http://ekuatia.set.gov.py/sifen/xsd\">"
+            + "<ns2:dCodRes>0422</ns2:dCodRes>"
+            + "<ns2:dMsgRes>CDC encontrado</ns2:dMsgRes>"
+            + "<ns2:xContenDE><ns2:xProtDe>"
+            + "<ns2:dEstRes>Aprobado</ns2:dEstRes>"
+            + "<ns2:dProtAut>2658109949</ns2:dProtAut>"
+            + "<ns2:gResProc>"
+            + "<ns2:dCodRes>0260</ns2:dCodRes>"
+            + "<ns2:dMsgRes>Autorización del DE &amp; su timbrado</ns2:dMsgRes>"
+            + "</ns2:gResProc>"
+            + "</ns2:xProtDe></ns2:xContenDE>"
+            + "</ns2:rEnviConsDeResponse></env:Body></env:Envelope>";
+
+    private static final String RESPUESTA_SIN_PREFIJO =
+        "<rEnviConsDeResponse>"
+            + "<dCodRes>0422</dCodRes><dMsgRes>CDC encontrado</dMsgRes>"
+            + "<gResProc><dCodRes>0420</dCodRes><dMsgRes>DE rechazado</dMsgRes></gResProc>"
+            + "</rEnviConsDeResponse>";
+
+    @Test
+    void tomaElCodigoDelDocumentoNoElDeLaConsulta() {
+        assertEquals("0260", SifenXmlParser.extractGResProcValue(RESPUESTA_CON_NS2, "dCodRes"));
+    }
+
+    @Test
+    void extraeElMensajeDecodificandoEntidades() {
+        assertEquals("Autorización del DE & su timbrado",
+            SifenXmlParser.extractGResProcValue(RESPUESTA_CON_NS2, "dMsgRes"));
+    }
+
+    @Test
+    void funcionaSinPrefijoDeNamespace() {
+        assertEquals("0420", SifenXmlParser.extractGResProcValue(RESPUESTA_SIN_PREFIJO, "dCodRes"));
+        assertEquals("DE rechazado", SifenXmlParser.extractGResProcValue(RESPUESTA_SIN_PREFIJO, "dMsgRes"));
+    }
+
+    @Test
+    void devuelveNullSiNoHayBloqueGResProc() {
+        String sinBloque = "<rEnviConsDeResponse><dCodRes>0420</dCodRes>"
+            + "<dMsgRes>CDC no encontrado</dMsgRes></rEnviConsDeResponse>";
+
+        assertNull(SifenXmlParser.extractGResProcValue(sinBloque, "dCodRes"));
+    }
+
+    @Test
+    void devuelveNullConEntradasVacias() {
+        assertNull(SifenXmlParser.extractGResProcValue(null, "dCodRes"));
+        assertNull(SifenXmlParser.extractGResProcValue("", "dCodRes"));
+        assertNull(SifenXmlParser.extractGResProcValue(RESPUESTA_CON_NS2, null));
+        assertNull(SifenXmlParser.extractGResProcValue(RESPUESTA_CON_NS2, "dNoExiste"));
+    }
+}


### PR DESCRIPTION
Tercer hueco detectado en la investigación del DE 170.548, independiente de los otros dos ([central#175](https://github.com/GabFrank/franco-system-backend-servidor/pull/175), [filial#87](https://github.com/GabFrank/franco-system-backend-filial/pull/87)). No toca las mismas líneas, así que mergea sin conflicto en cualquier orden.

## Qué resuelve

`actualizarEstadoDesdeRespuesta` — el path de `consultarDE`, la consulta individual por CDC — escribía el estado del DE y la fecha de recepción, pero **nunca** `codigo_respuesta_sifen` ni `mensaje_respuesta_sifen`. Un documento actualizado por esta vía quedaba con estado final y sin rastro del resultado que devolvió SIFEN, a diferencia del flujo de lote que sí los persiste.

Además sólo guardaba cuando el estado cambiaba (`if (actualizar && nuevoEstado != null)`), así que a un DE ya APROBADO al que se le corriera la consulta no se le completaban nunca esos campos.

## Cambios

- **`SifenXmlParser.extractGResProcValue`** (nuevo): extrae `dCodRes`/`dMsgRes` acotando la búsqueda al bloque `gResProc`. Esto es lo delicado del PR — el primer `dCodRes` del XML es el de la consulta en sí (`0422` = CDC encontrado), no el del documento (`0260` = autorización satisfactoria). Tomar el primero guardaría un código que no corresponde. Prueba con prefijo `ns2` y sin prefijo, igual que el resto del parseo de respuestas.
- **`actualizarEstadoDesdeRespuesta`**: persiste código y mensaje aunque el estado no cambie. La fecha de recepción sólo se pisa cuando cambia el estado o cuando estaba vacía — no se sobrescribe una fecha histórica válida.
- Si la respuesta no trae `dEstRes`, ya no se corta antes de tiempo: no se toca el estado, pero el código igual se guarda.

## Efecto secundario útil

Como ahora completa los campos sin depender de un cambio de estado, correr la mutation de consulta sobre un DE con `codigo_respuesta_sifen` en null lo completa desde SIFEN. Sirve para sanear registros existentes uno por uno, sin script de migración.

## Cómo probarlo

```bash
./mvnw clean verify -B -DskipFlyway=true
```

67 tests, 0 fallos. Los 5 nuevos de `SifenXmlParserGResProcTest` cubren: que tome el código del documento y no el de la consulta, decodificación de entidades, respuesta sin prefijo de namespace, respuesta sin bloque `gResProc`, y entradas nulas/vacías.

Los XML de los tests están armados a mano siguiendo la estructura `rEnviConsDeResponse` → `xContenDE` → `xProtDe` → `gResProc`. **Conviene contrastarlos contra una respuesta real de SIFEN** antes de aprobar — es la parte que no pude verificar contra el ambiente.

## Impacto en DB

Ninguno. Sin migraciones. Sólo se completan dos columnas que hoy quedan en null por esta vía.

## Impacto en rollback

Bajo. Volver atrás deja de completar los campos; no corrompe nada de lo ya escrito.

## Riesgo

**Bajo.** En el central este código está inactivo (`sifen.enabled=false`, la única entrada es la mutation GraphQL manual). El mismo fix va al filial, que es donde corre de verdad.

El único cambio de comportamiento sobre datos existentes es que ahora se escriben dos columnas que antes quedaban en null, y que un DE sin `fecha_recepcion_sifen` puede recibirla. No se pisan estados ni fechas ya establecidas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)