### PR TITLE
feat(compras): exponer monto total del pedido en graphql

### DIFF
--- a/src/main/java/com/franco/dev/graphql/operaciones/resolver/PedidoResolver.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/resolver/PedidoResolver.java
@@ -40,6 +40,10 @@ public class PedidoResolver implements GraphQLResolver<Pedido> {
     public List<ProcesoEtapa> getProcesoEtapas(Pedido pedido) {
         return procesoEtapaService.getEtapasByPedidoId(pedido.getId());
     }
+
+    public Double getMontoTotal(Pedido pedido) {
+        return pedidoService.getMontoTotal(pedido.getId());
+    }
     
     // All resolver methods removed since GraphQL schema now only includes entity fields
     // No computed fields = no resolvers needed

--- a/src/main/java/com/franco/dev/service/operaciones/PedidoService.java
+++ b/src/main/java/com/franco/dev/service/operaciones/PedidoService.java
@@ -134,6 +134,17 @@ public class PedidoService extends CrudService<Pedido, PedidoRepository, Long> {
     }
 
     /**
+     * Obtiene el monto total del pedido (suma de cantidad solicitada × precio unitario de cada ítem)
+     * @param pedidoId ID del pedido
+     * @return Monto total del pedido, 0.0 si no tiene ítems
+     */
+    public Double getMontoTotal(Long pedidoId) {
+        if (pedidoId == null) return 0.0;
+        Double montoTotal = repository.getValorTotalByPedidoId(pedidoId);
+        return montoTotal != null ? montoTotal : 0.0;
+    }
+
+    /**
      * Obtiene el resumen del pedido con información actualizada
      * @param pedidoId ID del pedido
      * @return PedidoResumen con etapa actual, cantidad de ítems, valor total y estadísticas de distribución

--- a/src/main/resources/graphql/operaciones/pedido.graphqls
+++ b/src/main/resources/graphql/operaciones/pedido.graphqls
@@ -13,6 +13,7 @@ type Pedido {
     sucursalEntregaList: [PedidoSucursalEntrega]
     sucursalInfluenciaList: [PedidoSucursalInfluencia]
     procesoEtapas: [ProcesoEtapa]
+    montoTotal: Float
 }
 
 type PedidoResumen {


### PR DESCRIPTION
## Qué resuelve

El desktop necesita mostrar el monto total de cada pedido en la lista de compras, pero el tipo `Pedido` de GraphQL no exponía ese dato — solo estaba disponible vía `getPedidoResumen`, que es una query por pedido individual.

Agrega el campo `montoTotal: Float` al tipo `Pedido`, resuelto en `PedidoResolver` con `PedidoService.getMontoTotal()`. Reusa la query ya existente `PedidoRepository.getValorTotalByPedidoId` (suma de `cantidad_solicitada × precio_unitario_solicitado` de los ítems), la misma que alimenta `valorTotalPedido` del resumen — así los dos valores no pueden divergir.

PR compañero en el desktop: `feat/compras-monto-total-pedido` en `frc-sistemas-integrados-angular`.

## Cómo probarlo

1. Levantar el central en 8081 y el desktop.
2. Compras → Lista de Compras: la columna **Monto Total** debe mostrar el total de cada pedido.
3. Contrastar contra `SELECT SUM(cantidad_solicitada * precio_unitario_solicitado) FROM operaciones.pedido_item WHERE pedido_id = X`.

Verificado localmente: `./mvnw clean compile -DskipFlyway=true` OK, y los valores en la UI coinciden con la suma directa en la DB.

## Impacto en DB

Ninguno. Sin migraciones — el campo es calculado sobre datos existentes.

## Riesgo

**Bajo.** Solo agrega un campo GraphQL; no toca ni elimina nada existente, así que es retrocompatible con las versiones actuales del desktop y del mobile.

Único punto a tener en cuenta: es un field resolver, así que dispara una query agregada por pedido de la página (N+1). Con el page size actual (15-100) son consultas livianas sobre un índice de `pedido_item.pedido_id`, y sigue el mismo patrón que los resolvers ya existentes de `procesoEtapas` / `sucursalEntregaList`. Si más adelante hace falta, se puede batchear con un `DataLoader`.

## Rollback

Revertir el commit. No requiere pasos de DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)