### PR TITLE
feat(financiero): exponer la edicion de montos de caja desde el central [1/3]

### DIFF
--- a/src/main/java/com/franco/dev/domain/financiero/Conteo.java
+++ b/src/main/java/com/franco/dev/domain/financiero/Conteo.java
@@ -31,6 +31,13 @@ public class Conteo implements Serializable {
 
     private String observacion;
 
+    /**
+     * Versionado: id del conteo que esta version reemplaza. NULL en la version original.
+     * Se completa cuando un ADMIN edita los montos de apertura/cierre en la filial.
+     */
+    @Column(name = "conteo_anterior_id")
+    private Long conteoAnteriorId;
+
     @CreationTimestamp
     private LocalDateTime creadoEn;
 

--- a/src/main/java/com/franco/dev/graphql/financiero/PdvCajaGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/PdvCajaGraphQL.java
@@ -376,6 +376,57 @@ public class PdvCajaGraphQL implements GraphQLQueryResolver, GraphQLMutationReso
         }
     }
 
+    /**
+     * Corrige los montos de un conteo de apertura o cierre ya cargado. Solo para rol ADMIN.
+     * <p>
+     * La escritura se delega a la filial, que es la duena del dato: alli se crea una nueva version
+     * del conteo enlazada a la anterior y el central la recibe por replicacion. Si la filial rechaza
+     * la operacion, su mensaje se propaga tal cual para que el usuario sepa por que.
+     */
+    public CajaFilialOperacionResult editarConteoCajaDesdeServidor(Long cajaId, Long sucursalId, Long conteoAnteriorId,
+                                                                  Boolean apertura, ConteoInput conteoInput,
+                                                                  List<ConteoMonedaInput> conteoMonedaInputList) {
+        String logPrefix = "EDITAR CONTEO CAJA";
+        long inicioMs = System.currentTimeMillis();
+        log.info("====== [{}] INICIO -> cajaId={}, sucursalId={}, conteoAnteriorId={}, apertura={} ======",
+                logPrefix, cajaId, sucursalId, conteoAnteriorId, apertura);
+
+        if (conteoInput == null || conteoInput.getUsuarioId() == null) {
+            throw new GraphQLException("No se recibio el usuario que realiza la edicion");
+        }
+        if (sucursalId == null) {
+            throw new GraphQLException("No se recibio la sucursal de la caja");
+        }
+        Long usuarioId = conteoInput.getUsuarioId();
+        if (!usuarioService.tieneRol(usuarioId, "ADMIN")) {
+            log.warn("[{}] Usuario id={} sin rol ADMIN intento editar el conteo de la caja id={}", logPrefix, usuarioId, cajaId);
+            throw new GraphQLException("Solo un usuario ADMIN puede editar los montos de una caja");
+        }
+        // Chequeo temprano contra la copia replicada, para no salir a la red si la caja ya esta congelada.
+        PdvCaja cajaLocal = service.findById(cajaId, sucursalId);
+        if (cajaLocal != null && Boolean.TRUE.equals(cajaLocal.getVerificado())) {
+            throw new GraphQLException("La caja ya fue verificada, no se pueden editar sus montos");
+        }
+
+        try {
+            Long nuevoConteoId = filialCajaProxyService.editarConteoEnFilial(cajaId, sucursalId, conteoAnteriorId,
+                    apertura, conteoInput, conteoMonedaInputList, usuarioId);
+            log.info("[{}] ====== EXITO. cajaId={}, nuevoConteoId={}, tiempo={}ms ======",
+                    logPrefix, cajaId, nuevoConteoId, (System.currentTimeMillis() - inicioMs));
+            return CajaFilialOperacionResult.ok(cajaId);
+        } catch (org.springframework.web.client.ResourceAccessException e) {
+            log.error("[{}] FALLO DE CONEXION con la filial (sucursalId={}). Detalle: {}", logPrefix, sucursalId, e.getMessage(), e);
+            throw new GraphQLException("No se pudo conectar con la sucursal. No se modifico ningun monto.");
+        } catch (org.springframework.web.client.RestClientException e) {
+            log.error("[{}] Error de cliente REST con la filial (sucursalId={}). Detalle: {}", logPrefix, sucursalId, e.getMessage(), e);
+            throw new GraphQLException("Error de comunicacion con la sucursal. No se modifico ningun monto.");
+        } catch (Exception e) {
+            log.error("[{}] No se pudo editar el conteo (cajaId={}, sucursalId={}). Detalle: {}",
+                    logPrefix, cajaId, sucursalId, e.getMessage(), e);
+            throw new GraphQLException(e.getMessage());
+        }
+    }
+
     public Boolean verificarCaja(Long cajaId, Long sucursalId, Long usuarioId, Boolean verificado){
         try {
             PdvCaja caja = service.findById(cajaId, sucursalId);

--- a/src/main/java/com/franco/dev/graphql/financiero/input/ConteoInput.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/input/ConteoInput.java
@@ -15,4 +15,5 @@ public class ConteoInput implements Serializable {
     private Double totalRs;
     private Double totalDs;
     private Long sucursalId;
+    private Long conteoAnteriorId;
 }

--- a/src/main/java/com/franco/dev/graphql/financiero/resolver/ConteoResolver.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/resolver/ConteoResolver.java
@@ -23,6 +23,13 @@ public class ConteoResolver implements GraphQLResolver<Conteo> {
         return conteoMonedaService.findByConteoId(e.getId(), e.getSucursalId());
     }
 
+    public Conteo conteoAnterior(Conteo e) {
+        if (e.getConteoAnteriorId() == null || e.getSucursalId() == null) {
+            return null;
+        }
+        return conteoService.findByIdAndSucursalId(e.getConteoAnteriorId(), e.getSucursalId());
+    }
+
     public Double totalGs(Conteo e) {
         return conteoService.getTotalPorMoneda(e.getId(), (long) 1, e.getSucursalId());
     }

--- a/src/main/java/com/franco/dev/service/financiero/FilialCajaProxyService.java
+++ b/src/main/java/com/franco/dev/service/financiero/FilialCajaProxyService.java
@@ -145,6 +145,46 @@ public class FilialCajaProxyService {
         }
     }
 
+    /**
+     * Reenvia a la filial la edicion de los montos de un conteo de apertura o cierre.
+     * La escritura ocurre siempre en la filial; el central recibe el cambio por replicacion.
+     *
+     * @return id de la nueva version del conteo creada en la filial
+     */
+    public Long editarConteoEnFilial(Long cajaId, Long sucursalId, Long conteoAnteriorId, Boolean apertura,
+                                     Object conteoInput, List<?> conteoMonedaInputList, Long usuarioId) throws Exception {
+        Sucursal sucursal = sucursalService.findById(sucursalId).orElse(null);
+        if (sucursal == null || sucursal.getIp() == null || sucursal.getIp().isBlank()) {
+            log.error("[EDITAR CONTEO FILIAL] Sucursal id={} inexistente o sin IP configurada", sucursalId);
+            throw new Exception("La sucursal no tiene IP configurada, no se puede editar el conteo");
+        }
+        String url = buildFilialUrl(sucursal);
+        String query = "mutation($conteo: ConteoInput!, $conteoMonedaInputList: [ConteoMonedaInput], "
+                + "$cajaId: Int!, $conteoAnteriorId: ID!, $apertura: Boolean!, $usuarioId: Int!) { "
+                + "editarConteoCaja(conteo: $conteo, conteoMonedaInputList: $conteoMonedaInputList, "
+                + "cajaId: $cajaId, conteoAnteriorId: $conteoAnteriorId, apertura: $apertura, usuarioId: $usuarioId) "
+                + "{ id conteoAnteriorId } }";
+        Map<String, Object> variables = new HashMap<>();
+        variables.put("conteo", objectMapper.convertValue(conteoInput, Map.class));
+        variables.put("conteoMonedaInputList", conteoMonedaInputList);
+        variables.put("cajaId", cajaId);
+        variables.put("conteoAnteriorId", conteoAnteriorId);
+        variables.put("apertura", apertura);
+        variables.put("usuarioId", usuarioId);
+
+        log.info("[EDITAR CONTEO FILIAL] >>> Enviando editarConteoCaja a {} -> cajaId={}, conteoAnteriorId={}, apertura={}, usuarioId={}",
+                url, cajaId, conteoAnteriorId, apertura, usuarioId);
+        Map<String, Object> data = executeGraphQLOrThrow(url, buildAuthHeaders(), query, variables);
+        Map<String, Object> conteo = data != null ? (Map<String, Object>) data.get("editarConteoCaja") : null;
+        if (conteo == null || conteo.get("id") == null) {
+            throw new Exception("La filial no devolvio el conteo editado");
+        }
+        Long nuevoConteoId = Long.valueOf(conteo.get("id").toString());
+        log.info("[EDITAR CONTEO FILIAL] <<< Conteo editado en filial -> nuevoConteoId={}, reemplaza a {}",
+                nuevoConteoId, conteoAnteriorId);
+        return nuevoConteoId;
+    }
+
     public String buildFilialUrl(Sucursal sucursal) {
         Integer puerto = sucursal.getPuertoServidor() != null ? sucursal.getPuertoServidor() : DEFAULT_FILIAL_PORT;
         return "http://" + sucursal.getIp() + ":" + puerto + "/graphql";
@@ -192,6 +232,33 @@ public class FilialCajaProxyService {
         if (response.getBody() == null || response.getBody().containsKey("errors")) {
             log.warn("Error GraphQL en filial {}: {}", url, response.getBody());
             return null;
+        }
+        return (Map<String, Object>) response.getBody().get("data");
+    }
+
+    /**
+     * Igual que {@link #executeGraphQL} pero propaga el mensaje de error de la filial en vez de
+     * devolver null. Se usa en operaciones donde el motivo del rechazo ("la caja ya fue verificada",
+     * "el conteo fue editado por otro usuario") tiene que llegar al usuario.
+     */
+    private Map<String, Object> executeGraphQLOrThrow(String url, HttpHeaders headers, String query,
+                                                      Map<String, Object> variables) throws Exception {
+        Map<String, Object> body = new HashMap<>();
+        body.put("query", query);
+        body.put("variables", variables);
+        HttpEntity<String> request = new HttpEntity<>(objectMapper.writeValueAsString(body), headers);
+        ResponseEntity<Map> response = restTemplate.postForEntity(url, request, Map.class);
+        if (response.getBody() == null) {
+            throw new Exception("La filial no devolvio respuesta");
+        }
+        Object errors = response.getBody().get("errors");
+        if (errors instanceof List && !((List<?>) errors).isEmpty()) {
+            Object primerError = ((List<?>) errors).get(0);
+            String mensaje = primerError instanceof Map && ((Map<?, ?>) primerError).get("message") != null
+                    ? ((Map<?, ?>) primerError).get("message").toString()
+                    : errors.toString();
+            log.warn("Error GraphQL en filial {}: {}", url, mensaje);
+            throw new Exception(mensaje);
         }
         return (Map<String, Object>) response.getBody().get("data");
     }

--- a/src/main/resources/db/migration/V156.1__add_conteo_anterior_id_a_conteo.sql
+++ b/src/main/resources/db/migration/V156.1__add_conteo_anterior_id_a_conteo.sql
@@ -1,0 +1,12 @@
+-- Versionado de conteos de apertura/cierre de caja.
+-- Al editar un conteo no se sobreescriben los montos: se inserta un conteo nuevo
+-- y se enlaza con el que reemplaza, de modo que quede el historial completo
+-- (quien edito y cuando salen de usuario_id y creado_en del conteo nuevo).
+-- Sin FK a proposito: la tabla se replica y una self-FK depende del orden de apply.
+ALTER TABLE financiero.conteo ADD COLUMN IF NOT EXISTS conteo_anterior_id bigint;
+
+CREATE INDEX IF NOT EXISTS conteo_conteo_anterior_id_idx
+    ON financiero.conteo (conteo_anterior_id, sucursal_id);
+
+COMMENT ON COLUMN financiero.conteo.conteo_anterior_id IS
+    'Versionado: apunta al conteo que esta version reemplaza. NULL = version original.';

--- a/src/main/resources/graphql/financiero/conteo.graphqls
+++ b/src/main/resources/graphql/financiero/conteo.graphqls
@@ -4,6 +4,8 @@ type Conteo {
     observacion: String
     creadoEn: Date
     usuario: Usuario
+    conteoAnteriorId: ID
+    conteoAnterior: Conteo
     conteoMonedaList: [ConteoMoneda]
     totalGs: Float
     totalRs: Float
@@ -19,6 +21,7 @@ input ConteoInput {
     totalRs: Float
     totalDs: Float
     sucursalId: Int
+    conteoAnteriorId: ID
 }
 
 extend type Query {

--- a/src/main/resources/graphql/financiero/pdv-caja.graphqls
+++ b/src/main/resources/graphql/financiero/pdv-caja.graphqls
@@ -83,6 +83,7 @@ extend type Mutation {
     savePdvCaja(pdvCaja:PdvCajaInput!):PdvCaja!
     savePdvCajaPorSucursal(pdvCaja:PdvCajaInput!):PdvCaja!
     abrirCajaDesdeServidor(input:PdvCajaInput!, conteoInput: ConteoInput!, conteoMonedaInputList: [ConteoMonedaInput], cajaId: ID):CajaFilialOperacionResult
+    editarConteoCajaDesdeServidor(cajaId: Int!, sucursalId: Int!, conteoAnteriorId: ID!, apertura: Boolean!, conteoInput: ConteoInput!, conteoMonedaInputList: [ConteoMonedaInput]):CajaFilialOperacionResult
 }
 
 enum PdvCajaEstado {


### PR DESCRIPTION
## Qué resuelve

Un error de carga en el conteo de apertura o cierre no se podía corregir desde la aplicación: los montos quedaban congelados y la diferencia contaminaba el análisis entre maletines para siempre.

Este PR es la **parte del central** de esa funcionalidad. Expone `editarConteoCajaDesdeServidor`, que valida rol ADMIN y **delega la escritura en la filial** vía `FilialCajaProxyService`, siguiendo el patrón de `abrirCajaDesdeServidor`. La filial es la dueña del dato y el central lo recibe por replicación, así que escribir acá desincronizaría ambas bases.

Se agrega `executeGraphQLOrThrow`, porque `executeGraphQL` devuelve `null` y sólo loguea: acá el motivo del rechazo de la filial ("la caja ya fue verificada", "el conteo fue editado por otro usuario") tiene que llegar al usuario. No se modifica `executeGraphQL` para no alterar las consultas existentes.

## Cómo probarlo

1. Levantar central (8081) y filial (8082), con una sucursal cuya `ip`/`puerto_servidor` apunte a la filial.
2. Sobre una caja **no verificada**, ejecutar `editarConteoCajaDesdeServidor` con el `conteoAnteriorId` vigente → `exito: true`.
3. Negativos esperados: usuario sin ADMIN, caja verificada, `conteoAnteriorId` desactualizado y filial apagada — los cuatro deben devolver un mensaje explícito.

Verificado end-to-end contra una caja real: versionado correcto, conteo original intacto, movimientos viejos desactivados sin duplicar efectivo, y réplica al central OK.

## Impacto en DB

Migración **aditiva** `V156.1__add_conteo_anterior_id_a_conteo.sql`: agrega `financiero.conteo.conteo_anterior_id` (nullable, sin FK) más un índice. No hay `DROP` ni `RENAME`.

⚠️ **Orden de despliegue: este PR va primero, antes que el de la filial.** El central es el suscriptor; si la filial empieza a publicar la columna antes de que exista acá, el apply del suscriptor falla y frena el slot de replicación.

`financiero.conteo` se publica sin lista de columnas, así que no requiere `ALTER PUBLICATION` ni `REFRESH`.

## Rollback

La columna es nullable y el código anterior la ignora, así que volver al JAR previo no rompe nada. La migración no se revierte (Flyway no hace down migrations), pero no hace falta.

## Riesgo

**Bajo.** No modifica ningún flujo existente: agrega una mutation nueva y un método nuevo en el proxy. `ConteoGraphQL` del central no se toca.

## Cross-proyecto

Requiere los PRs hermanos: filial (mutation `editarConteoCaja`) y desktop (UI). Sin la filial actualizada, esta mutation devuelve error de la filial; sin el desktop, no hay quien la invoque.

🤖 Generated with [Claude Code](https://claude.com/claude-code)