### PR TITLE
fix(config): resolver homepath en runtime en vez de hornearlo en el build

### DIFF
--- a/src/main/java/com/franco/dev/service/media/ImagenMasterService.java
+++ b/src/main/java/com/franco/dev/service/media/ImagenMasterService.java
@@ -120,8 +120,7 @@ public class ImagenMasterService {
         if (configuredPath != null && !configuredPath.isEmpty()) {
             return configuredPath;
         }
-        String homePath = env.getProperty("homepath");
-        return homePath + "/FRC/";
+        return imageService.getHomePath() + "/FRC/";
     }
     
     public String getEntityPath(TipoReferencia tipoReferencia) {

--- a/src/main/java/com/franco/dev/service/utils/ImageService.java
+++ b/src/main/java/com/franco/dev/service/utils/ImageService.java
@@ -80,11 +80,29 @@ public class ImageService {
         return Base64Decoder.multipartFile(bytes, charArray[0]);
     }
 
+    /**
+     * Directorio base de los archivos de la instancia (logo, imagenes, reports).
+     *
+     * Se resuelve en runtime a proposito. La property `homepath` NO puede tener
+     * `${user.home}` como default en `application.properties`: el maven-resources-plugin
+     * esta configurado con el delimitador `${*}`, asi que Maven la reemplaza en tiempo de
+     * compilacion por el home de la maquina que buildea -- en CI, `/home/runner` -- y esa
+     * ruta queda horneada en el jar. Cada instancia define `HOMEPATH` en su `.env`; el
+     * fallback a `user.home` es para desarrollo local.
+     */
+    public String getHomePath() {
+        String configured = env.getProperty("homepath");
+        if (configured != null && !configured.isBlank()) {
+            return configured;
+        }
+        return System.getProperty("user.home");
+    }
+
     public String getResourcesPath() {
         if (isWindows) {
             return "C:\\\\FRC\\resources";
         } else {
-            return env.getProperty("homepath") + "/FRC/resources";
+            return getHomePath() + "/FRC/resources";
         }
     }
 
@@ -92,7 +110,7 @@ public class ImageService {
         if (isWindows) {
             return "C:\\\\FRC\\reports\\";
         } else {
-            return env.getProperty("homepath") + storageDirectoryPathReports + "/";
+            return getHomePath() + storageDirectoryPathReports + "/";
         }
     }
 
@@ -100,7 +118,7 @@ public class ImageService {
         if (isWindows) {
             return "C:\\\\FRC\\resources\\images\\productos\\presentaciones\\";
         } else {
-            return env.getProperty("homepath") + imagePresentaciones + "/";
+            return getHomePath() + imagePresentaciones + "/";
         }
     }
 
@@ -108,7 +126,7 @@ public class ImageService {
         if (isWindows) {
             return "C:\\\\FRC\\resources\\images\\productos\\presentaciones\\thumbnails\\";
         } else {
-            return env.getProperty("homepath") + imagePresentacionesThumb + "/";
+            return getHomePath() + imagePresentacionesThumb + "/";
         }
     }
 
@@ -116,7 +134,7 @@ public class ImageService {
         if (isWindows) {
             return "C:\\\\FRC\\resources\\images\\";
         } else {
-            return env.getProperty("homepath") + imagePath + "/";
+            return getHomePath() + imagePath + "/";
         }
     }
 
@@ -146,7 +164,7 @@ public class ImageService {
         List<String> images = new ArrayList<>();
 
         if (isPrefix) {
-            File dir = new File(env.getProperty("homepath") + imagePath + File.separator + folderPath + File.separator);
+            File dir = new File(getHomePath() + imagePath + File.separator + folderPath + File.separator);
             File[] matchingFiles = dir.listFiles(new FilenameFilter() {
                 public boolean accept(File dir, String name) {
                     return name.startsWith(imageName);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -93,8 +93,12 @@ graphql.servlet.async-mode-enabled=false
 sucursalId=0
 #home.path=
 #updateConfigFilePath=/Users/gabfranck/FRC/config.xml
-# Ruta del directorio home del usuario (usa user.home del sistema por defecto)
-homepath=${user.home}
+# Ruta base de los archivos de la instancia (logo, imagenes, reports).
+# NO declarar `homepath` aca apuntando a la property user.home de Java: el
+# maven-resources-plugin filtra los placeholders de este archivo, asi que Maven la resuelve
+# al COMPILAR y hornea en el jar el home de la maquina que buildea (en CI, /home/runner).
+# Cada instancia define HOMEPATH en su .env; si falta, ImageService.getHomePath() cae al
+# home del usuario en runtime.
 #image.root.path=/custom/path/to/images/
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## Que resuelve

`application.properties` declaraba `homepath=${user.home}`, pero el `maven-resources-plugin` filtra los placeholders de ese archivo, asi que Maven lo resolvia **en tiempo de compilacion** con el home de la maquina que buildea. Desde que el build corre en GitHub Actions (marzo 2026), todos los jars salen con:

```
homepath=/home/runner
```

Ese directorio no existe en ningun servidor. Verificado en los dos entornos:

```
$ unzip -p /opt/frc-backend-central/{alpha,farmacia}/current/frc-central-server.jar \
    BOOT-INF/classes/application.properties | grep homepath
homepath=/home/runner
$ ls -ld /home/runner
ls: cannot access '/home/runner': No such file or directory
```

Los sintomas reportados en alpha:

- `javax.imageio.IIOException: Can't read input file!` en `ImpresionService.printBalance` al imprimir el balance de caja.
- `JRException: Byte data not found at: /home/runner/FRC/resources/images//logo.png` en el reporte detallado de ventas.

El bug es latente desde marzo, pero recien aparece ahora porque hasta este ciclo el central delegaba estas operaciones a las filiales (que resuelven `user.home` en runtime y no estan afectadas). Dos cambios de julio hicieron que el central las ejecute por si mismo: `422a6cbb` (imprimir cierre de caja con la impresora local del desktop) y `983ba4a7` (reporte detallado de ventas).

## Solucion

Se saca `homepath` de `application.properties` y el default pasa a `ImageService.getHomePath()`, que se evalua en runtime:

- si la instancia define `HOMEPATH` en su `.env`, usa ese valor;
- si no, cae a `user.home` del usuario del proceso.

Las 6 llamadas de `ImageService` y la de `ImagenMasterService` pasan por ese unico metodo. `ImagenMasterService` conserva la precedencia de `image.root.path`, que no cambia.

Verificado que `homepath` era la **unica** property contaminada: las otras 10 con placeholder (`app.timezone`, `spring.flyway.*`, `SIFEN_*`, Firebase) llegan intactas al jar, porque Maven solo sustituye lo que puede resolver y `user.home` es la unica que conoce.

## Como probarlo

1. `HOMEPATH=/opt/frc-backend-central/alpha` en el `.env` de la instancia y reiniciar.
2. Cerrar una caja desde el desktop e imprimir el balance -> el ticket sale con el logo, sin `Can't read input file!` en el log.
3. Listado de ventas -> **Generar Reporte Detallado** -> el PDF se genera con el logo en el encabezado.
4. Sin `HOMEPATH` definido, la app arranca igual y resuelve contra el home del usuario del servicio (comportamiento de desarrollo local).

## Requiere accion de infra ANTES del deploy

Segun `CLAUDE.md` (seccion "Variables de entorno nuevas"), esto se avisa antes de mergear:

- **Variable nueva `HOMEPATH`** en el `.env` de cada instancia (alpha, farmacia, bodega). No es bloqueante para el arranque: si falta, la app levanta igual con el fallback, pero seguiria sin encontrar los archivos.
- **Carpetas en disco.** En farmacia el arbol ya existe con el logo (`/opt/frc-backend-central/farmacia/FRC/resources/images/logo.png`, creado en abril), asi que ahi alcanza con `HOMEPATH=/opt/frc-backend-central/farmacia` y no hay migracion de datos. En alpha **no existe** y hay que crearlo y copiar el `logo.png`.

## Impacto en DB

Ninguno. No hay migraciones.

## Impacto en rollback

Ninguno a nivel codigo: volver al jar anterior restaura el comportamiento actual (roto). La variable `HOMEPATH` en el `.env` es inofensiva para versiones viejas -- la ignoran, porque su `homepath` horneado tiene prioridad de todas formas.

## Riesgo

**Bajo.** Cambio de resolucion de una ruta, sin cambios de API GraphQL, esquema ni comportamiento de negocio. El unico modo de falla es que una instancia quede sin `HOMEPATH` **y** sin los archivos bajo el home de su usuario de servicio -- que es exactamente la situacion actual, o sea que no puede empeorar nada.

## Pendiente sugerido (fuera de scope)

`CLAUDE.md` pide crear las carpetas esperadas con `Files.createDirectories()`. Ninguna de estas rutas lo hace hoy. Lo dejo afuera para mantener el PR en una sola responsabilidad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
