### PR TITLE
fix(productos): detectar indice Lucene vacio contando documentos

### DIFF
--- a/src/main/java/com/franco/dev/service/productos/search/ProductoSearchIndexEstadoService.java
+++ b/src/main/java/com/franco/dev/service/productos/search/ProductoSearchIndexEstadoService.java
@@ -1,26 +1,36 @@
 package com.franco.dev.service.productos.search;
 
-import org.springframework.beans.factory.annotation.Value;
+import com.franco.dev.domain.productos.Codigo;
+import com.franco.dev.domain.productos.Producto;
+import org.hibernate.search.mapper.orm.Search;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.stream.Stream;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
 
 /**
  * Detecta si los índices Lucene de productos y códigos están listos.
  * Usado para reindexación automática al arrancar, sin intervención manual.
+ *
+ * El estado se resuelve contando documentos indexados, NO mirando el directorio.
+ * Con `hibernate.search.schema_management.strategy=create-or-update` Hibernate Search
+ * crea el índice vacío -- con su archivo `segments_N` -- durante el bootstrap, o sea
+ * antes del ApplicationReadyEvent que dispara la reindexacion. Un chequeo por archivos
+ * no distingue ese indice recien creado de uno poblado, asi que la reindexacion
+ * automatica nunca se dispara y el buscador queda mudo sin un solo error en el log.
  */
 @Service
 public class ProductoSearchIndexEstadoService {
 
-    private static final String ENTIDAD_PRODUCTO = "Producto";
-    private static final String ENTIDAD_CODIGO = "Codigo";
+    private static final Logger log = LoggerFactory.getLogger(ProductoSearchIndexEstadoService.class);
 
-    @Value("${spring.jpa.properties.hibernate.search.backend.directory.root:./data/lucene/productos}")
-    private String luceneDirectory;
+    private final EntityManagerFactory entityManagerFactory;
+
+    public ProductoSearchIndexEstadoService(EntityManagerFactory entityManagerFactory) {
+        this.entityManagerFactory = entityManagerFactory;
+    }
 
     /**
      * @deprecated Usar {@link #requiereReindexacionAutomatica()}.
@@ -31,58 +41,48 @@ public class ProductoSearchIndexEstadoService {
     }
 
     /**
-     * Verdadero si falta el índice general, el de productos o el de códigos.
+     * Verdadero si el indice de productos o el de codigos esta vacio.
      */
     public boolean requiereReindexacionAutomatica() {
-        Path root = Paths.get(luceneDirectory);
-        if (!Files.isDirectory(root)) {
-            return true;
-        }
-        if (!indiceEntidadPresente(root, ENTIDAD_PRODUCTO)) {
-            return true;
-        }
-        return !indiceEntidadPresente(root, ENTIDAD_CODIGO);
+        return !indiceProductoPresente() || !indiceCodigoPresente();
     }
 
     /**
-     * Verdadero cuando productos ya están indexados pero códigos aún no
-     * (por ejemplo, tras agregar el índice de códigos en una versión nueva).
+     * Verdadero cuando productos ya estan indexados pero codigos aun no
+     * (por ejemplo, tras agregar el indice de codigos en una version nueva).
      */
     public boolean requiereReindexacionSoloCodigos() {
-        Path root = Paths.get(luceneDirectory);
-        if (!Files.isDirectory(root)) {
-            return false;
-        }
-        return indiceEntidadPresente(root, ENTIDAD_PRODUCTO)
-                && !indiceEntidadPresente(root, ENTIDAD_CODIGO);
+        return indiceProductoPresente() && !indiceCodigoPresente();
     }
 
     public boolean indiceProductoPresente() {
-        Path root = Paths.get(luceneDirectory);
-        return Files.isDirectory(root) && indiceEntidadPresente(root, ENTIDAD_PRODUCTO);
+        return tieneDocumentos(Producto.class);
     }
 
     public boolean indiceCodigoPresente() {
-        Path root = Paths.get(luceneDirectory);
-        return Files.isDirectory(root) && indiceEntidadPresente(root, ENTIDAD_CODIGO);
+        return tieneDocumentos(Codigo.class);
     }
 
-    private boolean indiceEntidadPresente(Path root, String nombreEntidad) {
-        try (Stream<Path> directorios = Files.walk(root, 4)) {
-            return directorios
-                    .filter(Files::isDirectory)
-                    .filter(path -> path.getFileName().toString().contains(nombreEntidad))
-                    .anyMatch(this::directorioTieneSegmentos);
-        } catch (IOException e) {
+    /**
+     * Ante cualquier error al consultar el indice devuelve false, o sea "hay que reindexar".
+     * Reindexar de mas cuesta unos segundos al arrancar; no reindexar deja al buscador
+     * devolviendo cero resultados en silencio, que es mucho peor.
+     */
+    private boolean tieneDocumentos(Class<?> entidad) {
+        EntityManager entityManager = entityManagerFactory.createEntityManager();
+        try {
+            long documentos = Search.session(entityManager)
+                    .search(entidad)
+                    .where(f -> f.matchAll())
+                    .fetchTotalHitCount();
+            log.debug("Indice Lucene de {}: {} documentos", entidad.getSimpleName(), documentos);
+            return documentos > 0;
+        } catch (RuntimeException e) {
+            log.warn("No se pudo consultar el indice Lucene de {} ({}). Se asume vacio y se reindexa.",
+                    entidad.getSimpleName(), e.getMessage());
             return false;
-        }
-    }
-
-    private boolean directorioTieneSegmentos(Path directorio) {
-        try (Stream<Path> archivos = Files.list(directorio)) {
-            return archivos.anyMatch(path -> path.getFileName().toString().startsWith("segments"));
-        } catch (IOException e) {
-            return false;
+        } finally {
+            entityManager.close();
         }
     }
 }


### PR DESCRIPTION
## Que resuelve

La reindexacion automatica de Lucene al arrancar **nunca se disparaba** cuando el indice desaparecia. `ProductoSearchIndexEstadoService` decidia si faltaba el indice mirando si existia algun archivo que empezara con `segments`:

```java
archivos.anyMatch(path -> path.getFileName().toString().startsWith("segments"))
```

Pero con `hibernate.search.schema_management.strategy=create-or-update`, Hibernate Search crea el indice vacio —con su `segments_N`— durante el bootstrap, o sea **antes** del `ApplicationReadyEvent` que dispara la reindexacion. Cuando el indexer preguntaba "¿falta el indice?", ya habia un `segments_N` ahi y la respuesta era que no.

Un indice vacio y uno poblado eran indistinguibles para ese chequeo.

Lo peor es que no deja rastro: ni excepcion, ni warning. El buscador de productos simplemente devuelve cero resultados.

### Caso real que lo destapo

En el central de **bodega** el indice ademas se pierde en cada update, porque su unit tiene `WorkingDirectory=/opt/frc-backend-central/bodega/current` —el symlink a la release— y `directory.root=./data/lucene/productos` es relativo. Hay un indice abandonado por version:

| Release | Indice |
|---|---|
| 4.4.0 | 732K |
| 4.5.0 | 116K |
| 4.6.0 | 912K |
| 4.7.0 (actual) | **16K** = solo `segments_1` de 69 bytes |

`frc-farmacia` y `frc-beta` usan el directorio de instancia y conservan el indice (farmacia: 1020K intacto). Ese `WorkingDirectory` de bodega se corrige aparte, en el servidor; este PR arregla la otra mitad — que cuando el indice desaparece, se reconstruya solo.

## Solucion

El estado se resuelve **contando documentos indexados**, que es lo que la propiedad `app.search.producto.auto-reindex-if-empty` promete:

```java
long documentos = Search.session(entityManager)
        .search(entidad)
        .where(f -> f.matchAll())
        .fetchTotalHitCount();
return documentos > 0;
```

Ante cualquier error al consultar el indice se asume vacio y se reindexa. Reindexar de mas cuesta unos segundos al arrancar; no reindexar deja el buscador mudo en silencio.

Se elimina el recorrido del filesystem y la property `luceneDirectory`, que ya no hacen falta.

## Como probarlo

Verificado en local contra la base `bodega`, en los dos sentidos:

1. **Sin indice** (`data/lucene` ausente) → arranca y reindexa:
   ```
   ProductoSearchStartupIndexer : Índice Lucene incompleto. Reindexando productos y códigos automáticamente...
   ProductoSearchIndexer        : Reindexación masiva finalizada para: [Producto, Codigo]
   ```
   Queda en 664K (Producto) + 280K (Codigo).

2. **Con el indice ya poblado** → reinicio y **no** reindexa (cero menciones de reindex en el log). Esto es lo que evita que el fix degenere en una reindexacion en cada arranque.

Flyway reporto `Schema is up to date. No migration necessary.` en ambos arranques.

## Impacto en DB

Ninguno. No hay migraciones.

## Impacto en rollback

Ninguno. Volver al JAR anterior restaura el comportamiento actual (no reindexar). No hay estado persistente nuevo.

## Riesgo

**Bajo.** Solo cambia la deteccion; ni la logica de busqueda ni la de indexacion se tocan. El unico cambio de comportamiento es que ahora si reindexa cuando el indice esta vacio, que es justamente lo que faltaba. El costo es una consulta de conteo por entidad al arrancar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
