### PR TITLE
feat(financiero): permitir cancelar gastos desde el central

### DIFF
--- a/src/main/java/com/franco/dev/domain/financiero/Gasto.java
+++ b/src/main/java/com/franco/dev/domain/financiero/Gasto.java
@@ -65,6 +65,12 @@ public class Gasto extends EmbeddedEntity implements Serializable {
 
     private Boolean finalizado;
 
+    /**
+     * NULL = no cancelado. Un gasto cancelado no descuenta del balance de la caja
+     * ni suma en los reportes agregados de gastos.
+     */
+    private Boolean cancelado;
+
     private Double retiroGs;
     private Double retiroRs;
     private Double retiroDs;

--- a/src/main/java/com/franco/dev/graphql/financiero/GastoGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/GastoGraphQL.java
@@ -129,6 +129,15 @@ public class GastoGraphQL implements GraphQLQueryResolver, GraphQLMutationResolv
         }
     }
 
+    public Boolean cancelarGasto(Long id, Long sucId) {
+        Gasto gasto = service.findByIdAndSucursalId(id, sucId);
+        if (gasto != null) {
+            return service.cancelarGasto(gasto);
+        } else {
+            throw new GraphQLException("No se pudo cancelar el gasto");
+        }
+    }
+
     public Long countGasto() {
         return service.count();
     }

--- a/src/main/java/com/franco/dev/repository/financiero/GastoRepository.java
+++ b/src/main/java/com/franco/dev/repository/financiero/GastoRepository.java
@@ -58,6 +58,7 @@ public interface GastoRepository extends HelperRepository<Gasto, EmbebedPrimaryK
                         "WHERE g.creado_en BETWEEN :inicio AND :fin " +
                         "AND g.sucursal_id = :sucId " +
                         "AND g.activo = true " +
+                        "AND (g.cancelado IS NOT TRUE) " +
                         "GROUP BY tg.descripcion " +
                         "ORDER BY SUM(g.retiro_gs) DESC", nativeQuery = true)
         List<Object[]> gastosPorCategoria(
@@ -71,6 +72,7 @@ public interface GastoRepository extends HelperRepository<Gasto, EmbebedPrimaryK
                         "LEFT JOIN financiero.tipo_gasto tg ON g.tipo_gasto_id = tg.id " +
                         "WHERE g.creado_en BETWEEN :inicio AND :fin " +
                         "AND g.activo = true " +
+                        "AND (g.cancelado IS NOT TRUE) " +
                         "GROUP BY tg.descripcion " +
                         "ORDER BY SUM(g.retiro_gs) DESC", nativeQuery = true)
         List<Object[]> gastosPorCategoriaSinSucursal(
@@ -83,6 +85,7 @@ public interface GastoRepository extends HelperRepository<Gasto, EmbebedPrimaryK
                         "WHERE g.creado_en BETWEEN :inicio AND :fin " +
                         "AND g.sucursal_id = :sucId " +
                         "AND g.activo = true " +
+                        "AND (g.cancelado IS NOT TRUE) " +
                         "GROUP BY extract(month from g.creado_en) " +
                         "ORDER BY extract(month from g.creado_en)", nativeQuery = true)
         List<Object[]> gastosPorMes(@Param("inicio") LocalDateTime inicio,
@@ -93,6 +96,7 @@ public interface GastoRepository extends HelperRepository<Gasto, EmbebedPrimaryK
                         "FROM financiero.gasto g " +
                         "WHERE g.creado_en BETWEEN :inicio AND :fin " +
                         "AND g.activo = true " +
+                        "AND (g.cancelado IS NOT TRUE) " +
                         "GROUP BY extract(month from g.creado_en) " +
                         "ORDER BY extract(month from g.creado_en)", nativeQuery = true)
         List<Object[]> gastosPorMesSinSucursal(@Param("inicio") LocalDateTime inicio,

--- a/src/main/java/com/franco/dev/service/financiero/GastoService.java
+++ b/src/main/java/com/franco/dev/service/financiero/GastoService.java
@@ -4,10 +4,12 @@ import com.franco.dev.domain.EmbebedPrimaryKey;
 import com.franco.dev.domain.financiero.*;
 import com.franco.dev.repository.financiero.GastoRepository;
 import com.franco.dev.service.CrudService;
+import graphql.GraphQLException;
 import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.text.DecimalFormat;
 import java.util.List;
@@ -55,6 +57,30 @@ public class GastoService extends CrudService<Gasto, GastoRepository, EmbebedPri
         Gasto e = super.save(entity);
         publisher.publishEvent(new com.franco.dev.fmc.event.GastoRealizadoEvent(this, e));
         return e;
+    }
+
+    /**
+     * Cancela o rehabilita un gasto, igual que RetiroService.cancelarRetiro: es un
+     * toggle cancelado <-> no cancelado.
+     *
+     * No recalcula ningun balance. El monto vuelve a la caja porque
+     * PdvCajaService.generarBalance ignora los gastos cancelados, y la filial hace
+     * lo mismo cuando el flag le llega por replicacion.
+     *
+     * Persiste con repository.save() a proposito, y no con this.save(): el override
+     * de save() publica GastoRealizadoEvent, que dispara la push notification de
+     * gasto realizado. Cancelar no es realizar un gasto.
+     */
+    @Transactional
+    public Boolean cancelarGasto(Gasto gasto) {
+        try {
+            gasto.setCancelado(!Boolean.TRUE.equals(gasto.getCancelado()));
+            repository.save(gasto);
+            return true;
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new GraphQLException("No se pudo cancelar el gasto");
+        }
     }
 
     public List<com.franco.dev.domain.financiero.GastoPorCategoria> gastosPorCategoria(String inicio, String fin,

--- a/src/main/java/com/franco/dev/service/financiero/PdvCajaService.java
+++ b/src/main/java/com/franco/dev/service/financiero/PdvCajaService.java
@@ -310,6 +310,14 @@ public class PdvCajaService extends CrudService<PdvCaja, PdvCajaRepository, Long
                 }
             }
             for (Gasto gasto : gastoList) {
+                // Un gasto cancelado no descuenta de la caja: la plata volvio. Mismo
+                // mecanismo que el filtro de RetiroDetalle mas arriba en este metodo.
+                // La comparacion va en Java y no en la query a proposito: en SQL un
+                // "cancelado <> true" descartaria tambien las filas con cancelado NULL,
+                // que son todos los gastos historicos.
+                if (Boolean.TRUE.equals(gasto.getCancelado())) {
+                    continue;
+                }
                 totalGastoGs += (gasto.getRetiroGs() - gasto.getVueltoGs());
                 totalGastoRs += (gasto.getRetiroRs() - gasto.getVueltoRs());
                 totalGastoDs += (gasto.getRetiroDs() - gasto.getVueltoDs());

--- a/src/main/resources/db/migration/V157.1__add_cancelado_gasto.sql
+++ b/src/main/resources/db/migration/V157.1__add_cancelado_gasto.sql
@@ -1,0 +1,8 @@
+-- Marca un gasto de cajero como cancelado. Solo el central escribe esta columna
+-- (mutation cancelarGasto); la filial la recibe por replicacion y la usa para
+-- descontar el gasto de su propio generarBalance.
+--
+-- Nullable a proposito: NULL = no cancelado, y asi los gastos historicos no
+-- necesitan backfill. Por eso el chequeo es Boolean.TRUE.equals(...) en Java y
+-- IS NOT TRUE en SQL, nunca "= false".
+ALTER TABLE financiero.gasto ADD COLUMN IF NOT EXISTS cancelado BOOLEAN;

--- a/src/main/resources/db/migration/V158.1__replicar_gasto_central_a_filial.sql
+++ b/src/main/resources/db/migration/V158.1__replicar_gasto_central_a_filial.sql
@@ -1,0 +1,18 @@
+-- Cancelar gasto se ejecuta en el central, pero el balance de caja tambien se
+-- calcula en la filial (PdvCajaService.generarBalance). Para que la filial vea la
+-- cancelacion, financiero.gasto tiene que bajar del central a la filial dueña.
+--
+-- La fila ya existe en replication_table desde V112 como BRANCH_TO_MAIN. Activando
+-- replicate_central_to_branch_with_filter, LogicalReplicationService agrega la tabla
+-- a central_<db>_filialN_pub con WHERE (sucursal_id = N) y refresca las
+-- suscripciones. Mismo esquema que financiero.retiro (ver V155.1) y operaciones.venta.
+--
+-- gasto_detalle no se toca: la cancelacion solo modifica la cabecera.
+--
+-- REQUISITO DE ORDEN: la filial ya tiene que tener aplicada su migracion de la
+-- columna 'cancelado' (V86.1 en franco-system-backend-filial) antes de que esto
+-- corra en produccion. Si no, el apply worker de la suscripcion falla y la
+-- replicacion queda trabada acumulando WAL.
+UPDATE configuraciones.replication_table
+SET replicate_central_to_branch_with_filter = true
+WHERE table_name = 'financiero.gasto';

--- a/src/main/resources/graphql/financiero/gasto.graphqls
+++ b/src/main/resources/graphql/financiero/gasto.graphqls
@@ -11,6 +11,7 @@ type Gasto {
     gastoDetalleList: [GastoDetalle]
     activo: Boolean
     finalizado: Boolean
+    cancelado: Boolean
     retiroGs: Float
     retiroRs: Float
     retiroDs: Float
@@ -84,5 +85,6 @@ type GastoPorCategoria {
 extend type Mutation {
     saveGasto(entity:GastoInput!, printerName: String, local: String):Gasto!
     deleteGasto(id:ID!, sucId: ID):Boolean!
+    cancelarGasto(id:ID!, sucId: ID):Boolean!
 }
 

--- a/src/test/java/com/franco/dev/service/financiero/GastoServiceTest.java
+++ b/src/test/java/com/franco/dev/service/financiero/GastoServiceTest.java
@@ -1,0 +1,61 @@
+package com.franco.dev.service.financiero;
+
+import com.franco.dev.domain.financiero.Gasto;
+import com.franco.dev.repository.financiero.GastoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEventPublisher;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class GastoServiceTest {
+
+    private GastoRepository repository;
+    private ApplicationEventPublisher publisher;
+    private GastoService service;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(GastoRepository.class);
+        publisher = mock(ApplicationEventPublisher.class);
+        service = new GastoService(repository, publisher);
+    }
+
+    @Test
+    void cancelarGasto_gastoNuncaCanceladoQuedaCancelado() {
+        Gasto gasto = new Gasto();
+        gasto.setCancelado(null);
+
+        Boolean resultado = service.cancelarGasto(gasto);
+
+        assertTrue(resultado);
+        assertEquals(Boolean.TRUE, gasto.getCancelado());
+        verify(repository).save(gasto);
+    }
+
+    @Test
+    void cancelarGasto_gastoCanceladoSeRehabilita() {
+        Gasto gasto = new Gasto();
+        gasto.setCancelado(true);
+
+        service.cancelarGasto(gasto);
+
+        assertEquals(Boolean.FALSE, gasto.getCancelado());
+        verify(repository).save(gasto);
+    }
+
+    @Test
+    void cancelarGasto_noPublicaGastoRealizadoEvent() {
+        Gasto gasto = new Gasto();
+
+        service.cancelarGasto(gasto);
+
+        // Cancelar no es realizar un gasto: no tiene que disparar la push
+        // notification. Por eso el service persiste con repository.save() y no
+        // con this.save(), cuyo override publica GastoRealizadoEvent.
+        verify(publisher, never()).publishEvent(any());
+    }
+}


### PR DESCRIPTION
## Qué resuelve

Hasta ahora no había forma de cancelar un gasto de cajero: la única operación era `deleteGasto`, que borra la fila, no deja rastro y rompe la trazabilidad contable de la caja.

Este PR agrega la mutation `cancelarGasto`, disponible solo desde el central. Un gasto cancelado deja de descontar del balance de su caja y deja de sumar en los reportes agregados de gastos.

Replica el mecanismo de `cancelarRetiro` (#180) y `cancelarVenta`: el balance **no** se recalcula ni se persiste, sino que `generarBalance` ignora los gastos cancelados al recomputar.

## Cambios

- `V157.1__add_cancelado_gasto.sql` — `ALTER TABLE financiero.gasto ADD COLUMN IF NOT EXISTS cancelado BOOLEAN`
- `V158.1__replicar_gasto_central_a_filial.sql` — activa `replicate_central_to_branch_with_filter` para `financiero.gasto`
- `GastoService.cancelarGasto` — toggle `cancelado`. Persiste con `repository.save()` y **no** con `this.save()`: el override de `save()` publica `GastoRealizadoEvent`, que dispara la push notification de gasto realizado, y cancelar no es realizar un gasto. Hay un test que lo cubre
- `GastoGraphQL.cancelarGasto` + `cancelarGasto(id:ID!, sucId: ID):Boolean!` en el schema
- `PdvCajaService.generarBalance` — saltea los gastos cancelados
- `GastoRepository` — `AND (g.cancelado IS NOT TRUE)` en las 4 native queries agregadas
- `GastoServiceTest` — 3 tests: cancela, rehabilita, y no publica el evento

`IS NOT TRUE` y no `<> true`: con `<> true` Postgres devuelve NULL para las filas con `cancelado` nulo, el WHERE las descarta, y desaparecerían todos los gastos históricos del reporte. Por la misma razón el filtro del balance va en Java con `Boolean.TRUE.equals(...)`.

`GraficoAggregationService` no se toca: delega en `gastoService.gastosPorCategoria`/`gastosPorMes`, así que queda cubierto por el cambio del repositorio.

## Cómo probarlo

Con central + filial + desktop levantados, cancelar un gasto desde la lista de gastos con un usuario ADM y verificar que el balance de la caja sube en `retiroGs - vueltoGs`, en el central y en el POS de la filial.

Probado end-to-end el 2026-08-06: gasto 700 (sucursal 24, caja 1170, 270.000 Gs). El flag replicó del central a la filial, el `totalGastoGs` de esa caja pasó de 270.000 a 0 al cancelar y volvió a 270.000 al rehabilitar. `GastoServiceTest` 3/3 y `BUILD SUCCESS`.

## Impacto en DB

Dos migraciones, ambas aditivas: un `ADD COLUMN IF NOT EXISTS` nullable y un `UPDATE` sobre una tabla de configuración. `NULL` = no cancelado, así que los gastos históricos no necesitan backfill.

**⚠️ DEPENDENCIA DE ORDEN — leer antes de mergear.** `V158.1` activa la replicación central→filial de `financiero.gasto`. **Las filiales tienen que tener aplicada su propia migración de la columna (`V86.1` en `franco-system-backend-filial`, PR #96) ANTES de que este PR llegue a producción.** Si el central empieza a replicar una columna que la filial no tiene, el apply worker de la suscripción falla y la replicación queda trabada acumulando WAL.

Secuencia correcta: mergear el PR #96 del filial → esperar a que las filiales tomen la versión (~15 min de auto-update) y verificar que la migración se aplicó → recién ahí mergear este PR.

`gasto_detalle` no se toca: la cancelación solo modifica la cabecera.

## Impacto en rollback

Bajo del lado del código: las migraciones son aditivas y un rollback de JAR deja la DB legible por la versión anterior, que simplemente ignora la columna. Un gasto ya cancelado volvería a descontar del balance hasta que se vuelva a subir la versión.

El riesgo real no es la columna sino el orden respecto del filial (ver arriba).

## Riesgo

**Medio.** Toca el cálculo del balance de caja, que es dinero real, y activa replicación de una tabla nueva en sentido central→filial.

## Fuera de alcance

La mutation no valida el rol en el backend: el gating por ADM está solo en el frontend, igual que en `cancelarRetiro` y `cancelarVenta`. Endurecer ambos lados es un trabajo separado que aplicaría a las tres.