### PR TITLE
fix(funcionarios): corregir filtro por sucursal en listado paginado

### DIFF
--- a/src/main/java/com/franco/dev/graphql/personas/FuncionarioGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/personas/FuncionarioGraphQL.java
@@ -18,7 +18,9 @@ import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.franco.dev.utilitarios.DateUtils.stringToDate;
 
@@ -59,12 +61,26 @@ public class FuncionarioGraphQL implements GraphQLQueryResolver, GraphQLMutation
         return service.findAll(pageable);
     }
 
-    public Page<Funcionario> funcionariosWithPage(int page, int size, Long id, String nombre, List<Long> sucursalList) {
+    // sucursalIdList se declara como [Int] en el schema, por lo que graphql-java-tools
+    // entrega la lista con Integer sin convertirla al tipo generico del parametro. Se
+    // recibe como List<Integer> y se convierte a Long, que es lo que espera la consulta.
+    public Page<Funcionario> funcionariosWithPage(int page, int size, Long id, String nombre,
+            List<Integer> sucursalList) {
         Pageable pageable = PageRequest.of(page, size);
         if (nombre != null) {
             nombre = nombre.replace(" ", "%");
         }
-        Page<Funcionario> result = service.findAllWithPage(id, nombre, sucursalList, pageable);
+        List<Long> sucursalIdList = null;
+        if (sucursalList != null && !sucursalList.isEmpty()) {
+            sucursalIdList = sucursalList.stream()
+                    .filter(Objects::nonNull)
+                    .map(Number::longValue)
+                    .collect(Collectors.toList());
+            if (sucursalIdList.isEmpty()) {
+                sucursalIdList = null;
+            }
+        }
+        Page<Funcionario> result = service.findAllWithPage(id, nombre, sucursalIdList, pageable);
         return result;
     }
 


### PR DESCRIPTION
## Problema

Al filtrar el listado de funcionarios por sucursal, la query fallaba con:

> Exception while fetching data (/data) : Parameter value element [3] did not match expected type [java.lang.Long (n/a)]

El `[3]` es el **valor** del elemento (el id de sucursal), no un índice.

## Causa raíz

En `funcionario.graphqls` el argumento se declara `sucursalIdList: [Int]`, mientras que el resolver lo recibía como `List<Long>`.

graphql-java-tools 11.1.0 **no convierte** ese argumento: en `MethodFieldResolver.shouldValueBeConverted` la conversión con Jackson se saltea cuando el tipo GraphQL es un escalar concreto (`Int`) y la clase cruda ya es asignable (`List`). La lista llega entonces con `Integer` adentro; por borrado de genéricos Java no se queja, y el error aparece recién en Hibernate al bindear `s.id in :sucursalList`, que espera `Long`.

Contraprueba en el mismo repo: las queries que usan `[ID]` (`lucroPorFuncionario`, `lucroPorProducto`) funcionan porque `isConcreteScalarType` excluye explícitamente `ID` y ahí sí corre la conversión. El `id: Int` escalar también funciona porque `Integer` no es asignable a `Long` y se convierte. Solo rompe el caso lista.

## Solución

El resolver `funcionariosWithPage` recibe `List<Integer>` — el tipo real que entrega GraphQL — y convierte a `List<Long>` antes de consultar, normalizando a `null` si queda vacía para no generar un `in ()` inválido.

Es un cambio **backend-only** a propósito: cambiar el schema a `[ID]` rompería a los desktops ya desplegados, que mandan `$sucursalIdList: [Int]`.

## Verificación

- `./mvnw compile` OK; el central arranca sin errores de schema/resolver.
- Probado en la UI (Personas → Funcionarios) filtrando por sucursal: el listado se carga correctamente.

## Nota aparte

Las queries de `inventario-producto-item.graphqls` tienen el mismo defecto (`sucursalIdList`, `sectorIdList`, `zonaIdList`, `usuarioIdList`, `productoIdList` declarados `[Int]` con `List<Long>` en el resolver). Se dejan fuera de este PR a pedido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)