### PR TITLE
feat(reportes): sucursal del cliente en cobro de venta a credito

### DIFF
--- a/src/main/java/com/franco/dev/service/impresion/ImpresionService.java
+++ b/src/main/java/com/franco/dev/service/impresion/ImpresionService.java
@@ -17,6 +17,7 @@ import com.franco.dev.domain.operaciones.dto.LucroPorProductosDto;
 import com.franco.dev.domain.operaciones.dto.ReporteVentaItemDto;
 import com.franco.dev.domain.operaciones.dto.ReporteVentaDetalladoDto;
 import com.franco.dev.domain.personas.Cliente;
+import com.franco.dev.domain.personas.Funcionario;
 import com.franco.dev.domain.personas.Usuario;
 import com.franco.dev.domain.productos.Codigo;
 import com.franco.dev.domain.productos.PrecioPorSucursal;
@@ -97,6 +98,8 @@ public class ImpresionService {
     private PrecioPorSucursalService precioPorSucursalService;
     @Autowired
     private SucursalService sucursalService;
+    @Autowired
+    private com.franco.dev.service.personas.FuncionarioService funcionarioService;
     @Autowired
     private PreGastoDetalleFinanzasService preGastoDetalleFinanzasService;
 
@@ -968,6 +971,7 @@ public class ImpresionService {
         } else {
             try {
                 List<VentaCreditoItemDto> ventaCreditoItemDtoList = new ArrayList<>();
+                String sucursalCliente = getSucursalDelCliente(cliente);
                 for (VentaCredito ti : ventaCreditoList) {
                     VentaCreditoItemDto tiDto = new VentaCreditoItemDto();
                     Sucursal sucursal = sucursalService.findById(ti.getSucursalId()).orElse(null);
@@ -979,6 +983,7 @@ public class ImpresionService {
                     tiDto.setNombreCliente(cliente.getPersona().getNombre().toUpperCase());
                     tiDto.setDocumentoCliente(cliente.getPersona().getDocumento());
                     tiDto.setDireccionCliente(cliente.getPersona().getDireccion());
+                    tiDto.setSucursalCliente(sucursalCliente);
                     ventaCreditoItemDtoList.add(tiDto);
                 }
                 // file =
@@ -1136,6 +1141,7 @@ public class ImpresionService {
                 List<VentaCredito> ventaCreditoList = ventaCreditoMap.get(cliente.getId());
                 if (ventaCreditoList != null && !ventaCreditoList.isEmpty()) {
                     Double totalCliente = 0.0;
+                    String sucursalCliente = getSucursalDelCliente(cliente);
                     for (VentaCredito ti : ventaCreditoList) {
                         VentaCreditoItemDto tiDto = new VentaCreditoItemDto();
                         Sucursal sucursal = sucursalService.findById(ti.getSucursalId()).orElse(null);
@@ -1147,6 +1153,7 @@ public class ImpresionService {
                         tiDto.setNombreCliente(cliente.getPersona().getNombre().toUpperCase());
                         tiDto.setDocumentoCliente(cliente.getPersona().getDocumento());
                         tiDto.setDireccionCliente(cliente.getPersona().getDireccion());
+                        tiDto.setSucursalCliente(sucursalCliente);
                         ventaCreditoItemDtoList.add(tiDto);
                         totalCliente += ti.getValorTotal();
                         totalGeneral += ti.getValorTotal();
@@ -1345,6 +1352,21 @@ public class ImpresionService {
         private Double precio;
     }
 
+    /**
+     * Nombre de la sucursal a la que pertenece el cliente. La mayoria de las
+     * ventas a credito son de funcionarios, asi que la sucursal se toma de su
+     * ficha en personas.funcionario (sucursal_id), buscada por la persona del
+     * cliente. Un cliente que no es funcionario no tiene sucursal: devuelve "".
+     */
+    private String getSucursalDelCliente(Cliente cliente) {
+        if (cliente == null || cliente.getPersona() == null || cliente.getPersona().getId() == null)
+            return "";
+        Funcionario funcionario = funcionarioService.findByPersonaId(cliente.getPersona().getId());
+        if (funcionario == null || funcionario.getSucursal() == null)
+            return "";
+        return sucursalService.findById(funcionario.getSucursal().getId()).map(Sucursal::getNombre).orElse("");
+    }
+
     @Data
     @AllArgsConstructor
     @NoArgsConstructor
@@ -1357,6 +1379,7 @@ public class ImpresionService {
         private String nombreCliente;
         private String documentoCliente;
         private String direccionCliente;
+        private String sucursalCliente;
     }
 
     @Data

--- a/src/main/resources/reports/reporte-cobro-venta-credito.jrxml
+++ b/src/main/resources/reports/reporte-cobro-venta-credito.jrxml
@@ -16,6 +16,7 @@
     <field name="nombreCliente" class="java.lang.String"/>
     <field name="documentoCliente" class="java.lang.String"/>
     <field name="direccionCliente" class="java.lang.String"/>
+    <field name="sucursalCliente" class="java.lang.String"/>
     <variable name="TotalCliente" class="java.lang.Double" resetType="Group" resetGroup="GrupoCliente" calculation="Sum">
         <variableExpression><![CDATA[$F{totalGs}]]></variableExpression>
         <initialValueExpression><![CDATA[0.0]]></initialValueExpression>
@@ -88,28 +89,47 @@
                     <textFieldExpression><![CDATA[$F{direccionCliente}]]></textFieldExpression>
                 </textField>
                 <staticText>
-                    <reportElement x="136" y="67" width="64" height="12" uuid="4c91f639-4e4b-4bb2-965f-156eaed3a91c"/>
+                    <reportElement x="136" y="64" width="54" height="14" uuid="e3f4a5b6-c7d8-4901-e2f3-a4b5c6d7e8f9">
+                        <property name="com.jaspersoft.studio.unit.height" value="px"/>
+                        <property name="com.jaspersoft.studio.unit.width" value="px"/>
+                        <printWhenExpression><![CDATA[$F{sucursalCliente} != null && !$F{sucursalCliente}.trim().isEmpty()]]></printWhenExpression>
+                    </reportElement>
+                    <box rightPadding="4"/>
+                    <textElement textAlignment="Left">
+                        <font size="10"/>
+                    </textElement>
+                    <text><![CDATA[Sucursal:]]></text>
+                </staticText>
+                <textField isBlankWhenNull="true">
+                    <reportElement x="190" y="64" width="365" height="14" uuid="f4a5b6c7-d8e9-4012-f3a4-b5c6d7e8f9a0"/>
+                    <textElement textAlignment="Left">
+                        <font size="10"/>
+                    </textElement>
+                    <textFieldExpression><![CDATA[$F{sucursalCliente}]]></textFieldExpression>
+                </textField>
+                <staticText>
+                    <reportElement x="136" y="82" width="64" height="12" uuid="4c91f639-4e4b-4bb2-965f-156eaed3a91c"/>
                     <textElement>
                         <font size="7"/>
                     </textElement>
                     <text><![CDATA[Reporte creado en]]></text>
                 </staticText>
                 <textField>
-                    <reportElement x="200" y="67" width="70" height="12" uuid="7e8c778b-0e6c-4e04-a4c7-de5b9f3403f6"/>
+                    <reportElement x="200" y="82" width="70" height="12" uuid="7e8c778b-0e6c-4e04-a4c7-de5b9f3403f6"/>
                     <textElement>
                         <font size="7"/>
                     </textElement>
                     <textFieldExpression><![CDATA[$P{fechaReporte}]]></textFieldExpression>
                 </textField>
                 <staticText>
-                    <reportElement x="270" y="67" width="60" height="12" uuid="186428af-f5d4-4389-8c9b-cadb45c47034"/>
+                    <reportElement x="270" y="82" width="60" height="12" uuid="186428af-f5d4-4389-8c9b-cadb45c47034"/>
                     <textElement>
                         <font size="7"/>
                     </textElement>
                     <text><![CDATA[por el usuario]]></text>
                 </staticText>
                 <textField>
-                    <reportElement x="330" y="67" width="85" height="12" uuid="09ce4efd-2860-4013-b158-a83a2fdcc811"/>
+                    <reportElement x="330" y="82" width="85" height="12" uuid="09ce4efd-2860-4013-b158-a83a2fdcc811"/>
                     <textElement>
                         <font size="7"/>
                     </textElement>


### PR DESCRIPTION
## Qué resuelve

En el reporte de cobro de venta a crédito (`reporte-cobro-venta-credito.jrxml`) la mayoría de los clientes son funcionarios. Faltaba saber a qué sucursal pertenece cada uno. Ahora el encabezado de cada cliente muestra `Sucursal: <nombre>`, tomada de `personas.funcionario.sucursal_id` buscando por la persona del cliente.

Ejemplo: `Cliente: MAURO ARIEL RUIZ GONZÁLEZ` → `Sucursal: DEPOSITO AQUARIO SDG` (funcionario 203, sucursal_id 13).

## Cambios

- `ImpresionService`: inyecta `FuncionarioService` y agrega el helper `getSucursalDelCliente(Cliente)`.
- `VentaCreditoItemDto`: nuevo campo `sucursalCliente`, llenado en los dos métodos que usan el reporte (`imprimirReporteCobroVentaCredito` e `imprimirReporteCobroVentaCreditoMultiplesClientes`).
- `reporte-cobro-venta-credito.jrxml`: nuevo campo + fila "Sucursal:" bajo Dirección; la fila de "Reporte creado en" baja de y=67 a y=82 (la banda mantiene su altura).

El cliente que no es funcionario no tiene sucursal: el campo queda vacío y la fila no se imprime (`printWhenExpression`), sin etiqueta huérfana.

## Cómo probarlo

Financiero → Venta crédito → lista (un cliente), y Personas → Clientes → lista (múltiples clientes).

- Cliente 825 MAURO ARIEL RUIZ GONZÁLEZ → `Sucursal: DEPOSITO AQUARIO SDG`
- Cliente 4205 EFREN EUDELIO MORAN CONTRERA → `Sucursal: SUC. CENTRAL`
- Cliente 798 FARMACIA FRANCO AREVALOS S.A (no funcionario) → la fila "Sucursal:" no aparece

Probado en local por el usuario con el central en 8081 + filial 8082 + desktop.

## Impacto en DB

Ninguno. No hay migración; solo lectura de `personas.funcionario`.

## Impacto en rollback

Ninguno. El DTO es interno del servicio de impresión, no se expone en el schema GraphQL, así que desktop y mobile no requieren cambios ni quedan desalineados con una versión anterior.

## Riesgo

Bajo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)