### PR TITLE
feat(personas): cascadear el estado inactivo del funcionario a su usuario y cliente

### DIFF
--- a/src/main/java/com/franco/dev/domain/personas/Cliente.java
+++ b/src/main/java/com/franco/dev/domain/personas/Cliente.java
@@ -65,6 +65,7 @@ public class Cliente implements Identifiable<Long> {
 
     private Boolean tributa;
     private Boolean verificadoSet;
+    private Boolean activo;
 }
 
 

--- a/src/main/java/com/franco/dev/graphql/personas/ClienteGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/personas/ClienteGraphQL.java
@@ -96,6 +96,12 @@ public class ClienteGraphQL implements GraphQLQueryResolver, GraphQLMutationReso
         Boolean modifPersona = false;
         ModelMapper m = new ModelMapper();
         Cliente e = m.map(input, Cliente.class);
+        if (input.getActivo() == null) {
+            // caller no envió 'activo': preservar el valor actual (o true si es nuevo)
+            e.setActivo(input.getId() != null
+                    ? service.findById(input.getId()).map(Cliente::getActivo).orElse(true)
+                    : true);
+        }
         if (input.getUsuarioId() != null)
             e.setUsuario(usuarioService.findById(input.getUsuarioId()).orElse(null));
         if (input.getSucursalId() != null)

--- a/src/main/java/com/franco/dev/graphql/personas/FuncionarioGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/personas/FuncionarioGraphQL.java
@@ -101,9 +101,18 @@ public class FuncionarioGraphQL implements GraphQLQueryResolver, GraphQLMutation
             e.setSucursal(null);
             e.setUsuario(null);
             e.setSupervisadoPor(null);
+            Boolean activoPrevio = e.getActivo();
             m.map(input, e);
+            if (input.getActivo() == null) {
+                // caller no envió 'activo': preservar el valor actual. 'activo' dispara la
+                // cascada de estado, un null accidental inactivaría usuario y cliente.
+                e.setActivo(activoPrevio != null ? activoPrevio : true);
+            }
         } else {
             e = m.map(input, Funcionario.class);
+            if (input.getActivo() == null) {
+                e.setActivo(true);
+            }
         }
         if (input.getFechaIngreso() != null)
             e.setFechaIngreso(stringToDate(input.getFechaIngreso()));
@@ -131,7 +140,11 @@ public class FuncionarioGraphQL implements GraphQLQueryResolver, GraphQLMutation
         } else {
             cliente = new Cliente();
             cliente.setPersona(e.getPersona());
-            cliente.setTipo(TipoCliente.FUNCIONARIO);
+            // Un funcionario inactivo no puede estrenar un cliente activo de tipo
+            // FUNCIONARIO: sin esto la desactivación terminaba creando justo eso.
+            boolean activo = Boolean.TRUE.equals(e.getActivo());
+            cliente.setActivo(activo);
+            cliente.setTipo(activo ? TipoCliente.FUNCIONARIO : TipoCliente.NORMAL);
             cliente.setUsuario(e.getUsuario());
             cliente.setCredito(e.getCredito());
             cliente.setSucursal(e.getSucursal());

--- a/src/main/java/com/franco/dev/graphql/personas/FuncionarioGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/personas/FuncionarioGraphQL.java
@@ -166,7 +166,9 @@ public class FuncionarioGraphQL implements GraphQLQueryResolver, GraphQLMutation
                     usuario.setNickname(palabras.get(0) + " " + palabras.get(2));
                     break;
             }
-            usuario.setActivo(true);
+            // Mismo criterio que el cliente: un funcionario inactivo no puede estrenar
+            // un usuario habilitado (y encima con la password por defecto).
+            usuario.setActivo(Boolean.TRUE.equals(e.getActivo()));
             usuario = usuarioService.save(usuario);
 
         }

--- a/src/main/java/com/franco/dev/graphql/personas/input/ClienteInput.java
+++ b/src/main/java/com/franco/dev/graphql/personas/input/ClienteInput.java
@@ -17,4 +17,5 @@ public class ClienteInput {
     private Boolean tributa;
     private Boolean verificadoSet;
     private String documento;
+    private Boolean activo;
 }

--- a/src/main/java/com/franco/dev/repository/personas/FuncionarioRepository.java
+++ b/src/main/java/com/franco/dev/repository/personas/FuncionarioRepository.java
@@ -7,8 +7,10 @@ import com.franco.dev.repository.HelperRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 
+import javax.persistence.QueryHint;
 import java.util.List;
 
 public interface FuncionarioRepository extends HelperRepository<Funcionario, Long> {
@@ -29,6 +31,11 @@ public interface FuncionarioRepository extends HelperRepository<Funcionario, Lon
 
         public Funcionario findByUsuarioId(Long id);
 
+        // FlushMode COMMIT: en el path de update la entity está managed y sucia con el
+        // nuevo 'activo'. Sin este hint Hibernate auto-flushea antes de la consulta (el
+        // query space coincide con personas.funcionario) y devolvería el valor nuevo,
+        // dejando sin efecto la comparación previa que dispara la cascada de estado.
+        @QueryHints(@QueryHint(name = "org.hibernate.flushMode", value = "COMMIT"))
         @Query("select f.activo from Funcionario f where f.id = :id")
         Boolean findActivoById(@Param("id") Long id);
 

--- a/src/main/java/com/franco/dev/repository/personas/FuncionarioRepository.java
+++ b/src/main/java/com/franco/dev/repository/personas/FuncionarioRepository.java
@@ -29,6 +29,9 @@ public interface FuncionarioRepository extends HelperRepository<Funcionario, Lon
 
         public Funcionario findByUsuarioId(Long id);
 
+        @Query("select f.activo from Funcionario f where f.id = :id")
+        Boolean findActivoById(@Param("id") Long id);
+
         @Query("select u from Funcionario u " +
                         "join u.persona p " +
                         "left join u.sucursal s where " +

--- a/src/main/java/com/franco/dev/security/TokenController.java
+++ b/src/main/java/com/franco/dev/security/TokenController.java
@@ -64,6 +64,9 @@ public class TokenController {
         if(usuario!=null){
             Boolean matches = jwtUser.getPassword().toUpperCase().equals(usuario.getPassword().toUpperCase());
             if(matches){
+                if(Boolean.FALSE.equals(usuario.getActivo())){
+                    throw new GraphQLException("Usuario inactivo, contacte al administrador");
+                }
                 jwtUser.setRoles(service.getRoles(usuario.getId()));
             } else {
                 throw new GraphQLException("Ups!! Contraseña inválida.");
@@ -102,6 +105,9 @@ public class TokenController {
         Usuario usuarioToken = service.findByNickname(tokenPayload.getNickname()).orElse(null);
         if (usuarioToken == null || !usuarioToken.getId().equals(biometricOwnerId)) {
             throw new GraphQLException("El token biométrico no corresponde al usuario.");
+        }
+        if (Boolean.FALSE.equals(usuarioToken.getActivo())) {
+            throw new GraphQLException("Usuario inactivo, contacte al administrador");
         }
 
         boolean existeSesionDelOwnerEnDispositivo = inicioSesionRepository

--- a/src/main/java/com/franco/dev/security/TokenController.java
+++ b/src/main/java/com/franco/dev/security/TokenController.java
@@ -8,8 +8,12 @@ import com.franco.dev.service.empresarial.SucursalService;
 import com.franco.dev.service.personas.UsuarioService;
 import graphql.GraphQLException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Collections;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/login")
@@ -140,6 +144,20 @@ public class TokenController {
                 .map(inicioSesion -> inicioSesion.getUsuario() != null ? inicioSesion.getUsuario().getId() : null)
                 .orElse(null);
         return ResponseEntity.ok(biometricOwnerId);
+    }
+
+    /**
+     * Sin este handler el GraphQLException lanzado desde este @RestController termina
+     * en el error page por defecto: HTTP 500 y, con server.error.include-message=never
+     * (default en Boot 2.7), sin el texto del motivo. El desktop mostraba entonces un
+     * error generico de servidor en vez de "Usuario inactivo, contacte al administrador".
+     * Se limita a este controller a proposito: no se agrega un @ControllerAdvice global.
+     */
+    @ExceptionHandler(GraphQLException.class)
+    public ResponseEntity<Map<String, String>> handleLoginError(GraphQLException ex) {
+        String mensaje = ex.getMessage() != null ? ex.getMessage() : "No se pudo iniciar sesión.";
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(Collections.singletonMap("message", mensaje));
     }
 
     private boolean isBlank(String value) {

--- a/src/main/java/com/franco/dev/service/personas/FuncionarioService.java
+++ b/src/main/java/com/franco/dev/service/personas/FuncionarioService.java
@@ -1,21 +1,31 @@
 package com.franco.dev.service.personas;
 
+import com.franco.dev.domain.personas.Cliente;
 import com.franco.dev.domain.personas.Funcionario;
+import com.franco.dev.domain.personas.Persona;
+import com.franco.dev.domain.personas.Usuario;
+import com.franco.dev.domain.personas.enums.TipoCliente;
 import com.franco.dev.repository.personas.FuncionarioRepository;
 import com.franco.dev.service.CrudService;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 
+@Slf4j
 @Service
 @AllArgsConstructor
 public class FuncionarioService extends CrudService<Funcionario, FuncionarioRepository, Long> {
 
     private final FuncionarioRepository repository;
+    private final UsuarioService usuarioService;
+    private final ClienteService clienteService;
 
     @Override
     public FuncionarioRepository getRepository() {
@@ -39,12 +49,58 @@ public class FuncionarioService extends CrudService<Funcionario, FuncionarioRepo
     }
 
     @Override
+    @Transactional
     public Funcionario save(Funcionario entity) {
-        if (entity.getId() == null) {
+        boolean esNuevo = entity.getId() == null;
+
+        // Se lee ANTES de persistir. La entity viene detached del resolver (ModelMapper),
+        // así que no hay estado sucio que Hibernate pueda flushear antes de esta consulta.
+        Boolean activoAnterior = esNuevo ? null : repository.findActivoById(entity.getId());
+
+        if (esNuevo) {
             entity.setCreadoEn(LocalDateTime.now());
             entity.setActivo(true);
         }
+        if (Boolean.FALSE.equals(entity.getActivo())) {
+            // El resolver re-sincroniza cliente.credito desde funcionario.credito después
+            // de este save; sin esto el cliente recuperaría el crédito que la cascada borró.
+            entity.setCredito(0f);
+        }
+
         Funcionario e = repository.save(entity);
+
+        if (!esNuevo && !Objects.equals(activoAnterior, e.getActivo())) {
+            aplicarCascadaEstado(e);
+        }
         return e;
+    }
+
+    /**
+     * Propaga el estado activo/inactivo del funcionario a su usuario y a su cliente.
+     * Al inactivar, el cliente pierde el beneficio de funcionario: pasa a NORMAL con crédito 0.
+     * Al reactivar vuelve a FUNCIONARIO, pero el crédito NO se restaura: se carga a mano.
+     */
+    private void aplicarCascadaEstado(Funcionario f) {
+        Persona persona = f.getPersona();
+        if (persona == null || persona.getId() == null) {
+            log.warn("Funcionario {} sin persona: no se cascadea el estado activo", f.getId());
+            return;
+        }
+        boolean activo = Boolean.TRUE.equals(f.getActivo());
+
+        Usuario usuario = usuarioService.findByPersonaId(persona.getId());
+        if (usuario == null) usuario = f.getUsuario();
+        if (usuario != null) {
+            usuario.setActivo(activo);
+            usuarioService.save(usuario);
+        }
+
+        Cliente cliente = clienteService.findByPersonaId(persona.getId());
+        if (cliente != null) {
+            cliente.setActivo(activo);
+            cliente.setTipo(activo ? TipoCliente.FUNCIONARIO : TipoCliente.NORMAL);
+            cliente.setCredito(0f);
+            clienteService.save(cliente);
+        }
     }
 }

--- a/src/main/java/com/franco/dev/service/personas/FuncionarioService.java
+++ b/src/main/java/com/franco/dev/service/personas/FuncionarioService.java
@@ -53,8 +53,12 @@ public class FuncionarioService extends CrudService<Funcionario, FuncionarioRepo
     public Funcionario save(Funcionario entity) {
         boolean esNuevo = entity.getId() == null;
 
-        // Se lee ANTES de persistir. La entity viene detached del resolver (ModelMapper),
-        // así que no hay estado sucio que Hibernate pueda flushear antes de esta consulta.
+        // Se lee ANTES de persistir. En el path de update la entity NO viene detached:
+        // el resolver la obtiene con findById y la muta, así que está managed y sucia
+        // dentro del EntityManager de la request (OpenEntityManagerInViewFilter).
+        // Por eso findActivoById lleva el hint flushMode=COMMIT: sin él Hibernate
+        // auto-flushea el UPDATE antes del SELECT y activoAnterior vendría ya con el
+        // valor nuevo, salteando la cascada en ambos sentidos.
         Boolean activoAnterior = esNuevo ? null : repository.findActivoById(entity.getId());
 
         if (esNuevo) {

--- a/src/main/resources/graphql/personas/cliente.graphqls
+++ b/src/main/resources/graphql/personas/cliente.graphqls
@@ -12,6 +12,7 @@ type Cliente {
     sucursal: Sucursal
     tributa: Boolean
     verificadoSet: Boolean
+    activo: Boolean
 }
 
 input ClienteInput {
@@ -29,6 +30,7 @@ input ClienteInput {
     sucursalId: Int
     tributa: Boolean
     verificadoSet: Boolean
+    activo: Boolean
 }
 
 type ClientePage {

--- a/src/test/java/com/franco/dev/service/personas/FuncionarioServiceCascadaEstadoTest.java
+++ b/src/test/java/com/franco/dev/service/personas/FuncionarioServiceCascadaEstadoTest.java
@@ -1,0 +1,143 @@
+package com.franco.dev.service.personas;
+
+import com.franco.dev.domain.personas.Cliente;
+import com.franco.dev.domain.personas.Funcionario;
+import com.franco.dev.domain.personas.Persona;
+import com.franco.dev.domain.personas.Usuario;
+import com.franco.dev.domain.personas.enums.TipoCliente;
+import com.franco.dev.repository.personas.FuncionarioRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class FuncionarioServiceCascadaEstadoTest {
+
+    private FuncionarioRepository repository;
+    private UsuarioService usuarioService;
+    private ClienteService clienteService;
+    private FuncionarioService service;
+
+    private Persona persona;
+    private Usuario usuario;
+    private Cliente cliente;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(FuncionarioRepository.class);
+        usuarioService = mock(UsuarioService.class);
+        clienteService = mock(ClienteService.class);
+        service = new FuncionarioService(repository, usuarioService, clienteService);
+
+        persona = new Persona();
+        persona.setId(7L);
+
+        usuario = new Usuario();
+        usuario.setId(70L);
+        usuario.setActivo(true);
+
+        cliente = new Cliente();
+        cliente.setId(700L);
+        cliente.setActivo(true);
+        cliente.setTipo(TipoCliente.FUNCIONARIO);
+        cliente.setCredito(50000f);
+
+        when(usuarioService.findByPersonaId(7L)).thenReturn(usuario);
+        when(clienteService.findByPersonaId(7L)).thenReturn(cliente);
+        when(repository.save(any(Funcionario.class))).thenAnswer(i -> i.getArgument(0));
+    }
+
+    private Funcionario funcionario(Boolean activo) {
+        Funcionario f = new Funcionario();
+        f.setId(1L);
+        f.setPersona(persona);
+        f.setCredito(50000f);
+        f.setActivo(activo);
+        return f;
+    }
+
+    @Test
+    void alInactivar_desactivaUsuarioYDejaClienteNormalSinCredito() {
+        when(repository.findActivoById(1L)).thenReturn(true);
+
+        Funcionario guardado = service.save(funcionario(false));
+
+        assertFalse(usuario.getActivo());
+        assertFalse(cliente.getActivo());
+        assertEquals(TipoCliente.NORMAL, cliente.getTipo());
+        assertEquals(0f, cliente.getCredito());
+        assertEquals(0f, guardado.getCredito());
+        verify(usuarioService).save(usuario);
+        verify(clienteService).save(cliente);
+    }
+
+    @Test
+    void alReactivar_reactivaUsuarioYClienteFuncionarioPeroDejaElCreditoEnCero() {
+        when(repository.findActivoById(1L)).thenReturn(false);
+        usuario.setActivo(false);
+        cliente.setActivo(false);
+        cliente.setTipo(TipoCliente.NORMAL);
+        cliente.setCredito(0f);
+
+        service.save(funcionario(true));
+
+        assertTrue(usuario.getActivo());
+        assertTrue(cliente.getActivo());
+        assertEquals(TipoCliente.FUNCIONARIO, cliente.getTipo());
+        assertEquals(0f, cliente.getCredito());
+    }
+
+    @Test
+    void siElEstadoNoCambia_noTocaUsuarioNiCliente() {
+        when(repository.findActivoById(1L)).thenReturn(true);
+
+        service.save(funcionario(true));
+
+        verify(usuarioService, never()).save(any(Usuario.class));
+        verify(clienteService, never()).save(any(Cliente.class));
+    }
+
+    @Test
+    void activoNuloEnLaBaseSeTrataComoActivo_yPasarloAFalseCascadea() {
+        when(repository.findActivoById(1L)).thenReturn(null);
+
+        service.save(funcionario(false));
+
+        assertFalse(usuario.getActivo());
+        assertFalse(cliente.getActivo());
+    }
+
+    @Test
+    void funcionarioSinPersona_noRompeElGuardado() {
+        when(repository.findActivoById(1L)).thenReturn(true);
+        Funcionario f = funcionario(false);
+        f.setPersona(null);
+
+        Funcionario guardado = service.save(f);
+
+        assertEquals(0f, guardado.getCredito());
+        verify(usuarioService, never()).save(any(Usuario.class));
+        verify(clienteService, never()).save(any(Cliente.class));
+    }
+
+    @Test
+    void funcionarioNuevo_noCascadeaNiConsultaElEstadoAnterior() {
+        Funcionario f = new Funcionario();
+        f.setPersona(persona);
+        f.setCredito(50000f);
+
+        Funcionario guardado = service.save(f);
+
+        assertTrue(guardado.getActivo());
+        verify(repository, never()).findActivoById(any());
+        verify(usuarioService, never()).save(any(Usuario.class));
+        verify(clienteService, never()).save(any(Cliente.class));
+    }
+}

--- a/src/test/java/com/franco/dev/service/personas/FuncionarioServiceCascadaEstadoTest.java
+++ b/src/test/java/com/franco/dev/service/personas/FuncionarioServiceCascadaEstadoTest.java
@@ -8,8 +8,14 @@ import com.franco.dev.domain.personas.enums.TipoCliente;
 import com.franco.dev.repository.personas.FuncionarioRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.jpa.repository.QueryHints;
+
+import javax.persistence.QueryHint;
+import java.lang.reflect.Method;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -139,5 +145,25 @@ class FuncionarioServiceCascadaEstadoTest {
         verify(repository, never()).findActivoById(any());
         verify(usuarioService, never()).save(any(Usuario.class));
         verify(clienteService, never()).save(any(Cliente.class));
+    }
+
+    /**
+     * Regresion del bug de auto-flush: en el path real de update la entity está managed
+     * y sucia con el nuevo 'activo'. Sin flushMode=COMMIT, Hibernate flushea el UPDATE
+     * antes de este SELECT y activoAnterior vuelve igual al nuevo valor, salteando la
+     * cascada. Los tests de arriba mockean el repository y no pueden verlo, por eso acá
+     * se verifica el contrato de la consulta: debe declarar el hint que evita el flush.
+     */
+    @Test
+    void findActivoById_debeDeclararFlushModeCommitParaNoAutoFlushear() throws Exception {
+        Method metodo = FuncionarioRepository.class.getMethod("findActivoById", Long.class);
+        QueryHints hints = metodo.getAnnotation(QueryHints.class);
+        assertNotNull(hints, "findActivoById debe declarar @QueryHints");
+        QueryHint flushMode = Arrays.stream(hints.value())
+                .filter(h -> "org.hibernate.flushMode".equals(h.name()))
+                .findFirst()
+                .orElse(null);
+        assertNotNull(flushMode, "falta el hint org.hibernate.flushMode");
+        assertEquals("COMMIT", flushMode.value());
     }
 }


### PR DESCRIPTION
## Qué resuelve

Marcar `personas.funcionario.activo = false` no tenía ningún efecto sobre las otras dos identidades de la misma persona: su usuario seguía pudiendo loguearse y su cliente conservaba `tipo = FUNCIONARIO` con su crédito. Ahora la desactivación cascadea y excluye a la persona de todo acceso y beneficio.

Las tres identidades se enlazan por `personas.persona.id`.

- `usuario.activo = false` → el login lo rechaza
- `cliente.activo = false`, `tipo = NORMAL`, `credito = 0`
- `funcionario.credito = 0`

Reactivar revierte todo **salvo el crédito**, que queda en 0 y se recarga a mano, para no revivir por accidente el crédito de alguien que reingresó.

## Decisiones de diseño

- **La cascada vive solo en el central**, en `FuncionarioService.save`. El filial no la lleva: su `ClienteService.save` hace un HTTP al central en vez de escribir local, y el desktop guarda funcionarios contra el central (`servidor = true`). El filial solo lee el flag replicado y bloquea el login (PR aparte).
- **Sin migración Flyway.** `personas.cliente.activo` ya existía en `V0__initial_schema.sql` con `DEFAULT true`; solo faltaba mapearlo en la entity y el schema GraphQL.
- **`funcionario.credito = 0` es load-bearing, no cosmético.** El resolver `saveFuncionario` re-sincroniza `cliente.credito` desde `funcionario.credito` justo después de `service.save`; sin poner el funcionario en 0, el cliente recuperaría el crédito que la cascada acaba de borrar.
- **La cascada dispara solo cuando `activo` cambia de valor**, comparando contra una lectura previa a la persistencia. Sin eso, cualquier guardado de un funcionario activo reactivaría un usuario que un administrador desactivó a mano por otro motivo.
- **`Boolean.FALSE.equals(x)` en todos lados**, nunca `!x`: hay filas con `activo` en NULL que deben seguir contando como activas.

## Bug crítico encontrado en review y corregido

La primera versión leía el estado anterior con JPQL asumiendo que la entity venía *detached*. Es falso: `saveFuncionario` la carga con `service.findById` y la muta, así que Hibernate la tiene **managed** y sucia, y el auto-flush emitía el `UPDATE` **antes** del `SELECT` — la comparación daba igual y la cascada nunca corría. Se corrigió con `@QueryHints(flushMode = COMMIT)` en `findActivoById`.

Verificado en runtime con `logging.level.org.hibernate.SQL=DEBUG` sobre datos reales: el `select ... activo` ahora precede al `update personas.funcionario`, seguido de los updates de usuario y cliente.

Otros dos hallazgos del mismo review, también corregidos: desactivar un funcionario sin cliente le creaba un cliente **activo** de tipo FUNCIONARIO, y sin usuario le creaba un usuario **habilitado**. Ambos derivan ahora del estado del funcionario. Se agregó además el preserve-guard de `funcionario.activo`, para que un caller que omita el campo no dispare la cascada destructiva.

## Cómo probarlo

Funcionario con usuario y cliente con crédito > 0:

1. Desmarcar "activo" y guardar → aparece el aviso de confirmación.
2. En la base: `usuario.activo = f`, `cliente.activo = f`, `tipo = NORMAL`, `cli_credito = 0`, `func_credito = 0`.
3. Intentar loguearse con ese usuario → "Usuario inactivo, contacte al administrador".
4. Reactivar → login OK, cliente vuelve a FUNCIONARIO, crédito sigue en 0.
5. Regresión: editar un cliente cualquiera → su `activo` no se pone en NULL.
6. Regresión: guardar el funcionario reactivado sin tocar el checkbox → no cambia nada.

Los 6 pasos se probaron end-to-end contra la base real.

## Impacto en DB

Ninguno en el esquema: no hay migración. Solo se escribe en columnas existentes.

## Impacto en rollback

Seguro. Revertir el JAR deja los datos como estén; no hay migración que deshacer. Los funcionarios ya desactivados conservan su estado y sus créditos en 0 (se recargan a mano si hiciera falta).

## Riesgo

**Medio.** El bloqueo de login toca un camino crítico. El `@ExceptionHandler(GraphQLException.class)` nuevo convierte 500 → 401 para **todos** los errores de `/login`, `/login/new` y `/login/biometric*` de este controlador — es lo que hace que el mensaje llegue al cliente, y de paso arregla el de contraseña inválida. **frc-mobile usa estos mismos endpoints**: si en algún lado ramifica según el status, ese cambio le llega.

## PRs relacionados

Va junto con el del filial y el del desktop, misma rama `feat/funcionario-inactivo-cascada` en los tres repos.

Spec y plan: `docs/superpowers/specs/2026-08-06-funcionario-inactivo-cascada-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)