### PR TITLE
fix(replicacion): agregar las tablas de lote a las publicaciones del central

### DIFF
--- a/src/main/resources/db/migration/V159.3__sincronizar_publicaciones_lote.sql
+++ b/src/main/resources/db/migration/V159.3__sincronizar_publicaciones_lote.sql
@@ -1,0 +1,105 @@
+-- Control de lotes - sincroniza las publicaciones del central con lo que ya esta registrado
+-- en configuraciones.replication_table.
+--
+-- V154.3 registro operaciones.movimiento_stock_lote (BRANCH_TO_MAIN + bajada filtrada) y
+-- V156.3 registro operaciones.lote (MAIN_TO_ALL). Pero registrar no mueve datos: quien traduce
+-- replication_table a ALTER PUBLICATION es ReplicationPublicationSyncScheduler, que arranca
+-- recien 2 minutos despues del boot y despues corre cada hora.
+--
+-- Verificado en alpha el 2026-08-07: las dos filas estaban en replication_table, y sin embargo
+-- operaciones.lote NO estaba en central_pub y operaciones.movimiento_stock_lote NO estaba en
+-- central_alpha_filial2_pub. O sea que el canal de lotes central -> filial nunca transporto
+-- nada, aunque toda la configuracion "se veia" correcta.
+--
+-- Esta migracion cierra ese hueco de forma deterministica, sin depender de que el scheduler
+-- haya corrido alguna vez. Es idempotente: si el scheduler ya lo hizo, no hace nada.
+--
+-- LO QUE ESTA MIGRACION NO HACE, a proposito:
+-- el ALTER SUBSCRIPTION ... REFRESH PUBLICATION que cada suscriptor necesita para tomar las
+-- tablas nuevas. No puede hacerlo por dos razones independientes:
+--   1) REFRESH PUBLICATION no corre dentro de una transaccion, y Flyway envuelve cada migracion
+--      en una.
+--   2) Dos de los tres refresh se ejecutan en la base de la FILIAL (alpha_filial2_central_sub
+--      contra central_pub, y central_alpha_filial2_sub contra central_alpha_filial2_pub), que
+--      esta fuera del alcance de una migracion del central.
+-- De eso se encarga ReplicationRefreshScheduler (copy_data = false) o la mutation
+-- refreshSubscription. Ojo con copy_data = false: engancha lo que venga de ahi en adelante, asi
+-- que los lotes ya cargados antes del refresh necesitan un backfill aparte.
+
+-- 1) Re-asegurar el registro. En alpha ya estaban, pero la migracion tiene que ser
+--    autosuficiente para beta y produccion, donde el estado no esta verificado.
+INSERT INTO configuraciones.replication_table
+    (table_name, direction, description, enabled, replicate_central_to_branch_with_filter, creado_en)
+VALUES
+    ('operaciones.lote', 'MAIN_TO_ALL', 'Maestro de lotes de producto', true, false, NOW()),
+    ('operaciones.movimiento_stock_lote', 'BRANCH_TO_MAIN', 'Movimiento stock por lote', true, true, NOW())
+ON CONFLICT (table_name) DO NOTHING;
+
+
+-- 2) operaciones.lote -> central_pub (bajada a todas las filiales).
+--    Sin filtro: es un maestro global y la tabla no tiene columna sucursal_id.
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_publication WHERE pubname = 'central_pub') THEN
+        RAISE NOTICE 'No existe central_pub - se omite (replicacion no configurada todavia)';
+    ELSIF EXISTS (
+        SELECT 1 FROM pg_publication_tables
+        WHERE pubname = 'central_pub'
+          AND schemaname = 'operaciones'
+          AND tablename = 'lote'
+    ) THEN
+        RAISE NOTICE 'operaciones.lote ya esta en central_pub';
+    ELSE
+        ALTER PUBLICATION central_pub ADD TABLE operaciones.lote;
+        RAISE NOTICE 'Agregada operaciones.lote a central_pub';
+    END IF;
+END $$;
+
+
+-- 3) operaciones.movimiento_stock_lote -> cada central_%_filial%_pub, filtrado por sucursal.
+--
+--    Se recorren TODAS las publicaciones que matcheen, no una sola: el central tiene una por
+--    filial (central_alpha_filial2_pub, central_beta_filial2_pub, ...). Es la diferencia con la
+--    V84.3 de la filial, donde el LIMIT 1 alcanzaba porque una filial publica una sola vez.
+--
+--    El nombre lleva el entorno adentro, por eso se descubren en vez de nombrarlas literal: un
+--    ALTER PUBLICATION con nombre fijo solo funcionaria en una de las bases.
+--
+--    El numero de sucursal sale del propio nombre. Si algun nombre no matchea el patron se avisa
+--    y se sigue, en vez de abortar toda la migracion por una publicacion mal nombrada.
+DO $$
+DECLARE
+    pub        RECORD;
+    sucursal   BIGINT;
+BEGIN
+    FOR pub IN
+        SELECT pubname
+        FROM pg_publication
+        WHERE pubname LIKE 'central\_%\_filial%\_pub'
+        ORDER BY pubname
+    LOOP
+        sucursal := NULLIF(substring(pub.pubname FROM 'filial([0-9]+)'), '')::BIGINT;
+
+        IF sucursal IS NULL THEN
+            RAISE NOTICE 'No se pudo deducir la sucursal de %, se omite', pub.pubname;
+            CONTINUE;
+        END IF;
+
+        IF EXISTS (
+            SELECT 1 FROM pg_publication_tables
+            WHERE pubname = pub.pubname
+              AND schemaname = 'operaciones'
+              AND tablename = 'movimiento_stock_lote'
+        ) THEN
+            RAISE NOTICE 'operaciones.movimiento_stock_lote ya esta en %', pub.pubname;
+            CONTINUE;
+        END IF;
+
+        EXECUTE format(
+            'ALTER PUBLICATION %I ADD TABLE operaciones.movimiento_stock_lote WHERE (sucursal_id = %L)',
+            pub.pubname, sucursal
+        );
+        RAISE NOTICE 'Agregada operaciones.movimiento_stock_lote a % con filtro sucursal_id = %',
+            pub.pubname, sucursal;
+    END LOOP;
+END $$;


### PR DESCRIPTION
## Problema

Registrar una tabla en `configuraciones.replication_table` **no mueve datos por sí solo**. Quien traduce ese registro a `ALTER PUBLICATION` es `ReplicationPublicationSyncScheduler`, que arranca 2 minutos después del boot y después corre cada hora.

Verificado en alpha: `V154.3` y `V156.3` habían dejado las dos filas correctas en `replication_table`, y sin embargo:

| Objeto | Estado encontrado |
|---|---|
| `operaciones.lote` en `central_pub` | ❌ faltaba |
| `operaciones.movimiento_stock_lote` en `central_alpha_filial2_pub` | ❌ faltaba |
| sub del central `alpha_filial2_sub` | ❌ sin la tabla (faltaba REFRESH) |
| sub de la filial `central_alpha_filial2_sub` | ❌ sin la tabla |
| sub de la filial `alpha_filial2_central_sub` | ❌ sin la tabla |

El canal de lotes entre el central y la filial **nunca transportó nada**, aunque desde `replication_table` la configuración "se veía" bien.

## Solución

Migración `V159.3` que cierra el hueco de forma determinística, sin depender de que el scheduler haya corrido, e idempotente para cuando ya lo hizo:

1. Re-asegura las dos filas en `replication_table` (`ON CONFLICT DO NOTHING`) — en alpha ya estaban, pero la migración tiene que ser autosuficiente para beta y producción.
2. `operaciones.lote` → `central_pub`, sin filtro (es maestro global, la tabla no tiene `sucursal_id`).
3. `operaciones.movimiento_stock_lote` → **cada** `central_%_filial%_pub`, con `WHERE (sucursal_id = N)`.

Las publicaciones se descubren en vez de nombrarse literal, porque el nombre lleva el entorno adentro (`alpha`, `beta`, …). Y se recorren todas: el central tiene una por filial, a diferencia de la filial que publica una sola vez — por eso la `V84.3` pudo usar `LIMIT 1` y acá no corresponde.

## Lo que queda deliberadamente afuera

**Los `ALTER SUBSCRIPTION ... REFRESH PUBLICATION`.** Por dos razones independientes: no corren dentro de una transacción y Flyway envuelve cada migración en una; y dos de los tres se ejecutan en la base de la *filial*, fuera del alcance de una migración del central. De eso se encarga `ReplicationRefreshScheduler` (`copy_data = false`) o la mutation `refreshSubscription`.

**`transferencia_item_lote`.** Su padre `operaciones.transferencia_item` tampoco se replica: llega a la filial por la capa de aplicación (534 filas ahí, sin estar en ninguna publicación). Replicar solo a la hija generaría conflictos que el esquema actual saltea en silencio.

## Verificación

Aplicada a mano en alpha (`172.25.0.172:5553`) junto con los tres refresh, y probada end-to-end:

- `operaciones.lote` creado en el central → aparece en la filial con el mismo id ✅
- `operaciones.movimiento_stock_lote` creado en la filial (`sucursal_id = 2`) → sube al central ✅
- los `DELETE` de ambos también replican ✅
- las tres suscripciones quedan en estado `r` con workers vivos ✅
- datos de prueba eliminados, cero residuos en las cuatro tablas ✅

No se insertó fila en `flyway_schema_history`: el central no tiene `validate-on-migrate=false`, así que valida checksums y una fila con checksum `NULL` rompería el próximo `migrate`. Como la migración es idempotente, Flyway la registra sola en el próximo deploy.

## Pendiente para beta y producción

Con `copy_data = false` el refresh solo engancha lo que venga de ahí en adelante. Los lotes ya cargados antes del refresh necesitan un **backfill aparte** (en alpha es 1 fila, irrelevante).

🤖 Generated with [Claude Code](https://claude.com/claude-code)