### PR TITLE
fix(reportes): cargar plantillas jrxml como stream para que funcionen desde el jar

### DIFF
--- a/src/main/java/com/franco/dev/graphql/financiero/FacturaLegalGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/FacturaLegalGraphQL.java
@@ -82,7 +82,7 @@ import static com.franco.dev.utilitarios.CalcularVerificadorRuc.getDigitoVerific
 
 import net.sf.jasperreports.engine.*;
 import net.sf.jasperreports.engine.data.JRBeanCollectionDataSource;
-import org.springframework.util.ResourceUtils;
+import org.springframework.core.io.ClassPathResource;
 import com.franco.dev.utilitarios.DateUtils;
 
 @Component
@@ -1535,11 +1535,14 @@ public class FacturaLegalGraphQL implements GraphQLQueryResolver, GraphQLMutatio
             Double tipoCambio = factura.getTipoCambio() != null ? factura.getTipoCambio() : 1.0;
 
             // Cargar y compilar el template Jasper (KUDE electrónico o réplica legal sin SIFEN)
-            String reportClasspath = facturaElectronica
-                    ? "classpath:reports/factura-electronica-kude.jrxml"
-                    : "classpath:reports/factura-legal.jrxml";
-            File file = ResourceUtils.getFile(reportClasspath);
-            JasperReport jasperReport = JasperCompileManager.compileReport(file.getAbsolutePath());
+            // Se lee como stream: dentro del JAR empaquetado el .jrxml no tiene ruta de filesystem
+            String reportResourcePath = facturaElectronica
+                    ? "reports/factura-electronica-kude.jrxml"
+                    : "reports/factura-legal.jrxml";
+            JasperReport jasperReport;
+            try (InputStream jrxmlStream = new ClassPathResource(reportResourcePath).getInputStream()) {
+                jasperReport = JasperCompileManager.compileReport(jrxmlStream);
+            }
 
             // Preparar datasource con items
             List<FacturaItemDto> itemDtoList = new ArrayList<>();

--- a/src/main/java/com/franco/dev/graphql/operaciones/InventarioProductoItemGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/InventarioProductoItemGraphQL.java
@@ -29,10 +29,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
-import org.springframework.util.ResourceUtils;
+import org.springframework.core.io.ClassPathResource;
 
 import java.io.File;
-import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.InputStream;
 import java.time.LocalDateTime;
 import java.util.*;
@@ -220,8 +220,11 @@ public class InventarioProductoItemGraphQL implements GraphQLQueryResolver, Grap
                 reporteInventarioDtoList.add(dto);
             }
 
-            File file = ResourceUtils.getFile("classpath:reports/reporte-inventario.jrxml");
-            JasperReport jasperReport = JasperCompileManager.compileReport(file.getAbsolutePath());
+            // Se lee como stream: dentro del JAR empaquetado el .jrxml no tiene ruta de filesystem
+            JasperReport jasperReport;
+            try (InputStream jrxmlStream = new ClassPathResource("reports/reporte-inventario.jrxml").getInputStream()) {
+                jasperReport = JasperCompileManager.compileReport(jrxmlStream);
+            }
             JRBeanCollectionDataSource dataSource = new JRBeanCollectionDataSource(reporteInventarioDtoList);
 
             Map<String, Object> parameters = createReportParameters(
@@ -231,7 +234,7 @@ public class InventarioProductoItemGraphQL implements GraphQLQueryResolver, Grap
             byte[] pdfBytes = JasperExportManager.exportReportToPdf(jasperPrint);
             return Base64.getEncoder().encodeToString(pdfBytes);
 
-        } catch (FileNotFoundException | JRException e) {
+        } catch (IOException | JRException e) {
             e.printStackTrace();
             return null;
         }


### PR DESCRIPTION
## Qué resuelve

En producción, descargar/abrir el PDF de una factura legal falla con:

```
Error al generar PDF: class path resource [reports/factura-electronica-kude.jrxml]
cannot be resolved to absolute file path because it does not reside in the file system:
jar:file:/opt/frc-backend-central/releases/4.7.0/frc-central-server.jar!/BOOT-INF/classes!/reports/factura-electronica-kude.jrxml
```

`ResourceUtils.getFile("classpath:reports/...")` exige que el recurso tenga ruta de filesystem. En desarrollo funciona porque el `.jrxml` queda suelto en `target/classes`, pero en producción la app corre desde el fat JAR y el recurso vive dentro del zip. El `.jrxml` **sí está** en el JAR; el problema es pedirlo como `File`.

Se reemplaza por `ClassPathResource(...).getInputStream()` + `JasperCompileManager.compileReport(InputStream)`, el mismo patrón que ya usan `ImpresionService`, `ProductoService` y `ConstanciaRecepcionPrintService` (que por eso nunca fallaron en producción).

Afecta:
- `FacturaLegalGraphQL:1537` — factura electrónica (KUDE) **y** factura legal no electrónica (misma línea para ambos templates)
- `InventarioProductoItemGraphQL:223` — reporte de inventario, mismo bug

No es exclusivo de bodega: fallaba en cualquier instancia desplegada como JAR (alpha y farmacia incluidas).

## Cómo probarlo

Importante: **con `spring-boot:run` el bug no se reproduce**, porque el `.jrxml` queda como archivo suelto. Hay que correr el JAR empaquetado:

```bash
./mvnw clean package -DskipFlyway=true
java -jar target/frc-central-server.jar --spring.flyway.enabled=false
```

Desde el desktop, descargar el PDF de:
- una factura **con** documento electrónico (KUDE) → probado con nro. 111981
- una factura **sin** documento electrónico (`factura-legal.jrxml`) → nro. 31239
- exportar el reporte de inventario a PDF

## Verificación realizada

- Reproducción del caso real: se empaquetaron los `.jrxml` en un JAR y se comprobó que `getFile()` lanza `FileNotFoundException` en los tres templates, mientras que `getInputStream()` los compila correctamente.
- `./mvnw clean verify -B -DskipFlyway=true` → BUILD SUCCESS, 82 tests, 0 fallas.
- JAR empaquetado levantado en 8081 contra la DB `bodega`, descarga de la factura 111981 verificada en la UI.

## Impacto en DB

Ninguno. No hay migraciones ni cambios de schema.

## Impacto en rollback

Ninguno. Solo cambia cómo se lee un recurso del classpath; revertir el JAR restaura el comportamiento anterior (con el bug).

## Riesgo

Bajo. Cambio acotado a dos métodos, sin cambios en la API GraphQL ni en los templates `.jrxml`.
