### PR TITLE
fix(reportes): corregir y rediseñar el reporte de inventario

### DIFF
--- a/src/main/java/com/franco/dev/graphql/operaciones/InventarioProductoItemGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/InventarioProductoItemGraphQL.java
@@ -2,6 +2,7 @@ package com.franco.dev.graphql.operaciones;
 
 import com.franco.dev.config.multitenant.MultiTenantService;
 import com.franco.dev.domain.empresarial.Sucursal;
+import com.franco.dev.domain.productos.Producto;
 import com.franco.dev.domain.operaciones.InventarioProducto;
 import com.franco.dev.domain.operaciones.InventarioProductoItem;
 import com.franco.dev.domain.operaciones.dto.ProductoSaldoDto;
@@ -16,8 +17,10 @@ import com.franco.dev.service.operaciones.ProductosVencidosService;
 import com.franco.dev.service.empresarial.SucursalService;
 import com.franco.dev.service.personas.UsuarioService;
 import com.franco.dev.service.productos.PresentacionService;
+import com.franco.dev.service.productos.ProductoService;
 import com.franco.dev.service.utils.ImageService;
 import com.franco.dev.utilitarios.DateUtils;
+import com.franco.dev.utilitarios.IdUtils;
 import graphql.kickstart.tools.GraphQLMutationResolver;
 import graphql.kickstart.tools.GraphQLQueryResolver;
 import net.sf.jasperreports.engine.*;
@@ -37,6 +40,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.LocalDateTime;
+import java.util.function.Function;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -72,6 +76,9 @@ public class InventarioProductoItemGraphQL implements GraphQLQueryResolver, Grap
 
     @Autowired
     private SucursalService sucursalService;
+
+    @Autowired
+    private ProductoService productoService;
 
     private static final int DEFAULT_PAGE_SIZE = 50;
     private static final String DEFAULT_SORT_FIELD = "vencimiento";
@@ -261,7 +268,7 @@ public class InventarioProductoItemGraphQL implements GraphQLQueryResolver, Grap
         parameters.put("filtroSucursales", nombresDeSucursales(sucursalIdList));
         parameters.put("filtroSectores", sectorIdList != null ? sectorIdList.toString() : "Todos");
         parameters.put("filtroZonas", zonaIdList != null ? zonaIdList.toString() : "Todos");
-        parameters.put("filtroProductos", productoIdList != null ? productoIdList.toString() : "Todos");
+        parameters.put("filtroProductos", nombresDeProductos(productoIdList));
         parameters.put("fechaReporte", DateUtils.toString(LocalDateTime.now()));
         parameters.put("usuario", nickname);
         parameters.put("logo", imageService.getImagePath() + File.separator + "logo.png");
@@ -273,14 +280,34 @@ public class InventarioProductoItemGraphQL implements GraphQLQueryResolver, Grap
      * Convierte los ids de sucursal del filtro en sus nombres, para que la cabecera
      * del reporte no muestre "[1, 2]". Si algun id no se encuentra, se deja el id.
      */
-    private String nombresDeSucursales(@Nullable List<Long> sucursalIdList) {
-        if (sucursalIdList == null || sucursalIdList.isEmpty()) {
+    private String nombresDeSucursales(@Nullable List<?> sucursalIdList) {
+        return nombresDeFiltro(sucursalIdList,
+                id -> sucursalService.findById(id).map(Sucursal::getNombre).orElse(null));
+    }
+
+    /**
+     * Idem para el filtro de productos, usando la descripcion del producto.
+     */
+    private String nombresDeProductos(@Nullable List<?> productoIdList) {
+        return nombresDeFiltro(productoIdList,
+                id -> productoService.findById(id).map(Producto::getDescripcion).orElse(null));
+    }
+
+    /**
+     * Resuelve los ids de un filtro a nombres legibles. Los ids llegan de GraphQL
+     * como Integer o String, asi que se normalizan con IdUtils antes de buscarlos.
+     * Si un id no resuelve a nombre, se muestra el id para no perder informacion.
+     */
+    private String nombresDeFiltro(@Nullable List<?> idList, Function<Long, String> resolverNombre) {
+        List<Long> ids = IdUtils.toLongList(idList);
+        if (ids == null) {
             return "Todos";
         }
-        return sucursalIdList.stream()
-                .map(id -> sucursalService.findById(id)
-                        .map(Sucursal::getNombre)
-                        .orElse(String.valueOf(id)))
+        return ids.stream()
+                .map(id -> {
+                    String nombre = resolverNombre.apply(id);
+                    return nombre != null && !nombre.trim().isEmpty() ? nombre : String.valueOf(id);
+                })
                 .collect(Collectors.joining(", "));
     }
 

--- a/src/main/java/com/franco/dev/graphql/operaciones/InventarioProductoItemGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/InventarioProductoItemGraphQL.java
@@ -197,7 +197,10 @@ public class InventarioProductoItemGraphQL implements GraphQLQueryResolver, Grap
             String nickname) {
 
         try {
-            Pageable pageable = PageRequest.of(page != null ? page : 0, size != null ? size : DEFAULT_PAGE_SIZE);
+            // El reporte lista todo lo que matchea los filtros: la paginacion de la
+            // pantalla (page/size) no debe recortarlo. Se reciben por compatibilidad
+            // con el schema, pero se ignoran a proposito.
+            Pageable pageable = Pageable.unpaged();
             Page<InventarioProductoItem> inventarioProductoItemPage = service.findAllWithFilters(
                     sucursalIdList, sectorIdList, zonaIdList, stringToDate(startDate), stringToDate(endDate),
                     usuarioIdList, productoIdList, null, pageable);

--- a/src/main/java/com/franco/dev/graphql/operaciones/InventarioProductoItemGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/InventarioProductoItemGraphQL.java
@@ -1,6 +1,7 @@
 package com.franco.dev.graphql.operaciones;
 
 import com.franco.dev.config.multitenant.MultiTenantService;
+import com.franco.dev.domain.empresarial.Sucursal;
 import com.franco.dev.domain.operaciones.InventarioProducto;
 import com.franco.dev.domain.operaciones.InventarioProductoItem;
 import com.franco.dev.domain.operaciones.dto.ProductoSaldoDto;
@@ -12,6 +13,7 @@ import com.franco.dev.service.operaciones.InventarioProductoItemService;
 import com.franco.dev.service.operaciones.InventarioProductoService;
 import com.franco.dev.service.operaciones.MovimientoStockService;
 import com.franco.dev.service.operaciones.ProductosVencidosService;
+import com.franco.dev.service.empresarial.SucursalService;
 import com.franco.dev.service.personas.UsuarioService;
 import com.franco.dev.service.productos.PresentacionService;
 import com.franco.dev.service.utils.ImageService;
@@ -67,6 +69,9 @@ public class InventarioProductoItemGraphQL implements GraphQLQueryResolver, Grap
 
     @Autowired
     private ProductosVencidosService productosVencidosService;
+
+    @Autowired
+    private SucursalService sucursalService;
 
     private static final int DEFAULT_PAGE_SIZE = 50;
     private static final String DEFAULT_SORT_FIELD = "vencimiento";
@@ -253,7 +258,7 @@ public class InventarioProductoItemGraphQL implements GraphQLQueryResolver, Grap
         parameters.put("filtroFechaInicio", startDate != null ? startDate : "Todos");
         parameters.put("filtroFechaFin", endDate != null ? endDate : "Todos");
         parameters.put("codigoBarra", "");
-        parameters.put("filtroSucursales", sucursalIdList != null ? sucursalIdList.toString() : "Todos");
+        parameters.put("filtroSucursales", nombresDeSucursales(sucursalIdList));
         parameters.put("filtroSectores", sectorIdList != null ? sectorIdList.toString() : "Todos");
         parameters.put("filtroZonas", zonaIdList != null ? zonaIdList.toString() : "Todos");
         parameters.put("filtroProductos", productoIdList != null ? productoIdList.toString() : "Todos");
@@ -262,6 +267,21 @@ public class InventarioProductoItemGraphQL implements GraphQLQueryResolver, Grap
         parameters.put("logo", imageService.getImagePath() + File.separator + "logo.png");
 
         return parameters;
+    }
+
+    /**
+     * Convierte los ids de sucursal del filtro en sus nombres, para que la cabecera
+     * del reporte no muestre "[1, 2]". Si algun id no se encuentra, se deja el id.
+     */
+    private String nombresDeSucursales(@Nullable List<Long> sucursalIdList) {
+        if (sucursalIdList == null || sucursalIdList.isEmpty()) {
+            return "Todos";
+        }
+        return sucursalIdList.stream()
+                .map(id -> sucursalService.findById(id)
+                        .map(Sucursal::getNombre)
+                        .orElse(String.valueOf(id)))
+                .collect(Collectors.joining(", "));
     }
 
     public Page<ProductoSaldoDto> productosConCantidadPositiva(Long sucursalId, Long productoId, Integer page, Integer size) {

--- a/src/main/java/com/franco/dev/utilitarios/IdUtils.java
+++ b/src/main/java/com/franco/dev/utilitarios/IdUtils.java
@@ -1,0 +1,58 @@
+package com.franco.dev.utilitarios;
+
+import org.springframework.lang.Nullable;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Utilidades para normalizar los ids que llegan desde GraphQL.
+ *
+ * Los campos declarados como [Int] en el schema llegan como Integer y los [ID]
+ * como String, aunque el resolver los reciba tipados como List&lt;Long&gt;: el
+ * borrado de tipos hace que nadie los convierta. Cualquier codigo que use esos
+ * ids como Long revienta con ClassCastException, asi que hay que normalizarlos
+ * antes de usarlos.
+ */
+public class IdUtils {
+
+    private IdUtils() {
+    }
+
+    /**
+     * Convierte una lista de ids de GraphQL (Integer, Long o String) en Long.
+     * Devuelve null si la lista viene vacia o nula, para no romper los filtros
+     * que interpretan null como "sin filtro".
+     */
+    @Nullable
+    public static List<Long> toLongList(@Nullable List<?> idList) {
+        if (idList == null || idList.isEmpty()) {
+            return null;
+        }
+        List<Long> converted = idList.stream()
+                .filter(Objects::nonNull)
+                .map(IdUtils::toLong)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+        return converted.isEmpty() ? null : converted;
+    }
+
+    /**
+     * Convierte un id de GraphQL en Long. Devuelve null si el valor no es numerico.
+     */
+    @Nullable
+    public static Long toLong(@Nullable Object id) {
+        if (id == null) {
+            return null;
+        }
+        if (id instanceof Number) {
+            return ((Number) id).longValue();
+        }
+        try {
+            return Long.parseLong(id.toString().trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/resources/reports/reporte-inventario.jrxml
+++ b/src/main/resources/reports/reporte-inventario.jrxml
@@ -250,7 +250,7 @@
                 </textElement>
                 <textFieldExpression><![CDATA[$F{descripcion}]]></textFieldExpression>
             </textField>
-            <textField>
+            <textField pattern="#,##0">
                 <reportElement x="180" y="0" width="50" height="12" uuid="fa6e9a7b-de74-4cca-b879-4452285fb0fd">
                     <property name="com.jaspersoft.studio.spreadsheet.connectionID" value="e74c448e-86a4-4ea0-a253-144c060ddd2c"/>
                 </reportElement>
@@ -259,7 +259,7 @@
                 </textElement>
                 <textFieldExpression><![CDATA[$F{cantidadSistema}]]></textFieldExpression>
             </textField>
-            <textField>
+            <textField pattern="#,##0">
                 <reportElement x="230" y="0" width="50" height="12" uuid="ba6ca274-d746-4bae-b288-7fda7c15d59e">
                     <property name="com.jaspersoft.studio.spreadsheet.connectionID" value="239577d0-bd84-4bb7-8dda-f598ed4e7fd0"/>
                 </reportElement>
@@ -268,7 +268,7 @@
                 </textElement>
                 <textFieldExpression><![CDATA[$F{cantidadEncontrada}]]></textFieldExpression>
             </textField>
-            <textField>
+            <textField pattern="#,##0">
                 <reportElement x="280" y="0" width="50" height="12" uuid="c5a62a97-1e0e-439e-9a38-bc2a099fd94c">
                     <property name="com.jaspersoft.studio.spreadsheet.connectionID" value="f98fc71e-6ed4-485f-8963-18c73e56e181"/>
                 </reportElement>

--- a/src/main/resources/reports/reporte-inventario.jrxml
+++ b/src/main/resources/reports/reporte-inventario.jrxml
@@ -38,7 +38,7 @@
                 <imageExpression><![CDATA[$P{logo}]]></imageExpression>
             </image>
             <staticText>
-                <reportElement x="102" y="14" width="228" height="14" uuid="b61efa33-0ea0-4fed-9d78-a768de817cb3">
+                <reportElement x="102" y="12" width="228" height="14" uuid="b61efa33-0ea0-4fed-9d78-a768de817cb3">
                     <property name="com.jaspersoft.studio.unit.height" value="px"/>
                     <property name="com.jaspersoft.studio.unit.width" value="px"/>
                 </reportElement>
@@ -49,7 +49,7 @@
                 <text><![CDATA[Filtros]]></text>
             </staticText>
             <staticText>
-                <reportElement x="80" y="-2" width="400" height="16" uuid="c0c9f5b8-f0b7-4503-9428-2d7be98aa4e6"/>
+                <reportElement x="80" y="0" width="400" height="17" uuid="c0c9f5b8-f0b7-4503-9428-2d7be98aa4e6"/>
                 <textElement textAlignment="Center">
                     <font size="12" isBold="true"/>
                 </textElement>
@@ -58,88 +58,100 @@
             <textField>
                 <reportElement x="175" y="78" width="70" height="9" uuid="7e8c778b-0e6c-4e04-a4c7-de5b9f3403f6"/>
                 <textElement>
-                    <font size="7"/>
+                    <font size="6"/>
                 </textElement>
                 <textFieldExpression><![CDATA[$P{fechaReporte}]]></textFieldExpression>
             </textField>
             <staticText>
                 <reportElement x="111" y="78" width="64" height="9" uuid="4c91f639-4e4b-4bb2-965f-156eaed3a91c"/>
                 <textElement>
-                    <font size="7"/>
+                    <font size="6"/>
                 </textElement>
                 <text><![CDATA[Reporte creado en]]></text>
             </staticText>
             <staticText>
                 <reportElement x="245" y="78" width="60" height="9" uuid="186428af-f5d4-4389-8c9b-cadb45c47034"/>
                 <textElement>
-                    <font size="7"/>
+                    <font size="6"/>
                 </textElement>
                 <text><![CDATA[por el usuario]]></text>
             </staticText>
             <textField>
                 <reportElement x="305" y="78" width="85" height="9" uuid="09ce4efd-2860-4013-b158-a83a2fdcc811"/>
                 <textElement>
-                    <font size="7"/>
+                    <font size="6"/>
                 </textElement>
                 <textFieldExpression><![CDATA[$P{usuario}]]></textFieldExpression>
             </textField>
             <staticText>
-                <reportElement x="113" y="21" width="61" height="12" uuid="952a2b7b-2b18-4daa-823e-3241f57c0708">
+                <reportElement x="113" y="27" width="61" height="12" uuid="952a2b7b-2b18-4daa-823e-3241f57c0708">
                     <property name="com.jaspersoft.studio.unit.height" value="px"/>
                     <property name="com.jaspersoft.studio.unit.width" value="px"/>
                 </reportElement>
                 <box rightPadding="4"/>
                 <textElement textAlignment="Left">
-                    <font size="9"/>
+                    <font size="8"/>
                 </textElement>
                 <text><![CDATA[Fecha inicio:]]></text>
             </staticText>
             <staticText>
-                <reportElement x="113" y="33" width="61" height="12" uuid="d6c50cb5-67d5-41eb-8304-19f12525266e">
+                <reportElement x="113" y="39" width="61" height="12" uuid="d6c50cb5-67d5-41eb-8304-19f12525266e">
                     <property name="com.jaspersoft.studio.unit.height" value="px"/>
                     <property name="com.jaspersoft.studio.unit.width" value="px"/>
                 </reportElement>
                 <box rightPadding="4"/>
                 <textElement textAlignment="Left">
-                    <font size="9"/>
+                    <font size="8"/>
                 </textElement>
                 <text><![CDATA[Fecha fin:]]></text>
             </staticText>
             <textField>
-                <reportElement x="174" y="33" width="154" height="12" uuid="de978e8e-d9c0-41b3-92c5-845bf8bbf604"/>
+                <reportElement x="174" y="39" width="154" height="12" uuid="de978e8e-d9c0-41b3-92c5-845bf8bbf604"/>
+                <textElement>
+                    <font size="8"/>
+                </textElement>
                 <textFieldExpression><![CDATA[$P{filtroFechaFin}]]></textFieldExpression>
             </textField>
             <textField>
-                <reportElement x="174" y="21" width="154" height="12" uuid="9fea43b1-2dec-48a2-907d-79ceeb4c8b82"/>
+                <reportElement x="174" y="27" width="154" height="12" uuid="9fea43b1-2dec-48a2-907d-79ceeb4c8b82"/>
+                <textElement>
+                    <font size="8"/>
+                </textElement>
                 <textFieldExpression><![CDATA[$P{filtroFechaInicio}]]></textFieldExpression>
             </textField>
             <staticText>
-                <reportElement x="114" y="46" width="61" height="12" uuid="c72b73f6-2ce5-40cd-8ef7-ba4bd75022ad">
+                <reportElement x="114" y="51" width="61" height="12" uuid="c72b73f6-2ce5-40cd-8ef7-ba4bd75022ad">
                     <property name="com.jaspersoft.studio.unit.height" value="px"/>
                     <property name="com.jaspersoft.studio.unit.width" value="px"/>
                 </reportElement>
                 <box rightPadding="4"/>
                 <textElement textAlignment="Left">
-                    <font size="9"/>
+                    <font size="8"/>
                 </textElement>
                 <text><![CDATA[Sucursal(es):]]></text>
             </staticText>
             <textField>
-                <reportElement x="175" y="45" width="154" height="30" uuid="a5e1ae18-89be-4a96-a29c-10298aca4de6"/>
+                <reportElement x="175" y="51" width="154" height="23" uuid="a5e1ae18-89be-4a96-a29c-10298aca4de6"/>
+                <textElement>
+                    <font size="8"/>
+                </textElement>
                 <textFieldExpression><![CDATA[$P{filtroSucursales}]]></textFieldExpression>
             </textField>
             <textField>
-                <reportElement x="390" y="20" width="158" height="54" uuid="d600e083-880b-48ce-bfb3-01dbb72ca132"/>
+                <reportElement x="390" y="27" width="158" height="47" uuid="d600e083-880b-48ce-bfb3-01dbb72ca132"/>
+                <textElement>
+                    <font size="8"/>
+                </textElement>
                 <textFieldExpression><![CDATA[$P{filtroProductos}]]></textFieldExpression>
             </textField>
             <staticText>
-                <reportElement x="330" y="21" width="61" height="12" uuid="60ed71d6-e25c-42ce-871c-320543ca25cd">
+                <reportElement x="330" y="27" width="61" height="12" uuid="60ed71d6-e25c-42ce-871c-320543ca25cd">
                     <property name="com.jaspersoft.studio.unit.height" value="px"/>
                     <property name="com.jaspersoft.studio.unit.width" value="px"/>
                 </reportElement>
                 <box rightPadding="4"/>
                 <textElement textAlignment="Left">
-                    <font size="9"/>
+                    <font size="8"/>
                 </textElement>
                 <text><![CDATA[Producto(s):]]></text>
             </staticText>
@@ -167,7 +179,7 @@
                     <property name="com.jaspersoft.studio.spreadsheet.connectionID" value="e74c448e-86a4-4ea0-a253-144c060ddd2c"/>
                 </reportElement>
                 <textElement textAlignment="Center" verticalAlignment="Middle">
-                    <font size="7"/>
+                    <font size="6"/>
                 </textElement>
                 <text><![CDATA[Cant. Sistema]]></text>
             </staticText>
@@ -176,7 +188,7 @@
                     <property name="com.jaspersoft.studio.spreadsheet.connectionID" value="239577d0-bd84-4bb7-8dda-f598ed4e7fd0"/>
                 </reportElement>
                 <textElement textAlignment="Center" verticalAlignment="Middle">
-                    <font size="7"/>
+                    <font size="6"/>
                 </textElement>
                 <text><![CDATA[Cant. Física]]></text>
             </staticText>

--- a/src/main/resources/reports/reporte-inventario.jrxml
+++ b/src/main/resources/reports/reporte-inventario.jrxml
@@ -165,24 +165,21 @@
             </staticText>
             <staticText>
                 <reportElement x="215" y="6" width="55" height="16" forecolor="#333333" uuid="1390f0d3-0245-44fa-b476-4e032e81147c"/>
-                <box rightPadding="6"/>
-                <textElement textAlignment="Right" verticalAlignment="Middle">
+                                <textElement textAlignment="Center" verticalAlignment="Middle">
                     <font size="8" isBold="true"/>
                 </textElement>
                 <text><![CDATA[C. Sistema]]></text>
             </staticText>
             <staticText>
                 <reportElement x="270" y="6" width="55" height="16" forecolor="#333333" uuid="32104080-de65-405b-ac44-90afcc0bd89b"/>
-                <box rightPadding="6"/>
-                <textElement textAlignment="Right" verticalAlignment="Middle">
+                                <textElement textAlignment="Center" verticalAlignment="Middle">
                     <font size="8" isBold="true"/>
                 </textElement>
                 <text><![CDATA[C. Física]]></text>
             </staticText>
             <staticText>
                 <reportElement x="325" y="6" width="50" height="16" forecolor="#333333" uuid="a56b1324-6c08-4b9d-83b0-ad22d831e02c"/>
-                <box rightPadding="6"/>
-                <textElement textAlignment="Right" verticalAlignment="Middle">
+                                <textElement textAlignment="Center" verticalAlignment="Middle">
                     <font size="8" isBold="true"/>
                 </textElement>
                 <text><![CDATA[Saldo]]></text>
@@ -229,24 +226,21 @@
             </textField>
             <textField pattern="#,##0" isBlankWhenNull="true">
                 <reportElement x="215" y="0" width="55" height="13" uuid="fa6e9a7b-de74-4cca-b879-4452285fb0fd"/>
-                <box rightPadding="6"/>
-                <textElement textAlignment="Right" verticalAlignment="Middle">
+                                <textElement textAlignment="Center" verticalAlignment="Middle">
                     <font size="8"/>
                 </textElement>
                 <textFieldExpression><![CDATA[$F{cantidadSistema}]]></textFieldExpression>
             </textField>
             <textField pattern="#,##0" isBlankWhenNull="true">
                 <reportElement x="270" y="0" width="55" height="13" uuid="ba6ca274-d746-4bae-b288-7fda7c15d59e"/>
-                <box rightPadding="6"/>
-                <textElement textAlignment="Right" verticalAlignment="Middle">
+                                <textElement textAlignment="Center" verticalAlignment="Middle">
                     <font size="8"/>
                 </textElement>
                 <textFieldExpression><![CDATA[$F{cantidadEncontrada}]]></textFieldExpression>
             </textField>
             <textField pattern="#,##0" isBlankWhenNull="true">
                 <reportElement x="325" y="0" width="50" height="13" uuid="c5a62a97-1e0e-439e-9a38-bc2a099fd94c"/>
-                <box rightPadding="6"/>
-                <textElement textAlignment="Right" verticalAlignment="Middle">
+                                <textElement textAlignment="Center" verticalAlignment="Middle">
                     <font size="8" isBold="true"/>
                 </textElement>
                 <textFieldExpression><![CDATA[$F{saldo}]]></textFieldExpression>

--- a/src/main/resources/reports/reporte-inventario.jrxml
+++ b/src/main/resources/reports/reporte-inventario.jrxml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 6.17.0.final using JasperReports Library version 6.17.0-6d93193241dd8cc42629e188b94f9e0bc5722efd  -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="transferencia" pageWidth="595" pageHeight="842" whenNoDataType="AllSectionsNoDetail" columnWidth="535" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isFloatColumnFooter="true" uuid="4eedbb89-b4f6-4469-9ab6-f642a1688cf7">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="reporte-inventario" pageWidth="595" pageHeight="842" whenNoDataType="AllSectionsNoDetail" columnWidth="555" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isFloatColumnFooter="true" uuid="4eedbb89-b4f6-4469-9ab6-f642a1688cf7">
     <property name="com.jaspersoft.studio.data.defaultdataadapter" value="One Empty Record"/>
     <parameter name="fechaReporte" class="java.lang.String"/>
     <parameter name="usuario" class="java.lang.String"/>
@@ -20,296 +20,293 @@
     <field name="cantidadEncontrada" class="java.lang.Double"/>
     <field name="saldo" class="java.lang.Double"/>
     <title>
-        <band height="96" splitType="Stretch">
-            <rectangle>
-                <reportElement x="110" y="20" width="439" height="56" uuid="e703c566-7819-4778-bdfd-f96af1fc6e09"/>
+        <band height="114" splitType="Stretch">
+            <image hAlign="Left" vAlign="Middle">
+                <reportElement x="0" y="2" width="96" height="42" uuid="94883631-a913-43e2-b182-ab8d77d0181e"/>
+                <imageExpression><![CDATA[$P{logo}]]></imageExpression>
+            </image>
+            <staticText>
+                <reportElement x="106" y="10" width="449" height="24" uuid="c0c9f5b8-f0b7-4503-9428-2d7be98aa4e6"/>
+                <textElement textAlignment="Right" verticalAlignment="Middle">
+                    <font size="15" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Reporte de inventario]]></text>
+            </staticText>
+            <line>
+                <reportElement x="0" y="50" width="555" height="1" forecolor="#BFBFBF" uuid="1f0d1b41-3a11-4c2a-9f0e-0f0b1c2d3e4f"/>
+            </line>
+            <rectangle radius="3">
+                <reportElement x="0" y="62" width="555" height="52" forecolor="#BFBFBF" uuid="e703c566-7819-4778-bdfd-f96af1fc6e09"/>
                 <graphicElement>
-                    <pen lineColor="#808080"/>
+                    <pen lineWidth="0.5" lineColor="#BFBFBF"/>
                 </graphicElement>
             </rectangle>
             <rectangle>
-                <reportElement x="194" y="13" width="39" height="12" uuid="135b7210-797e-41f2-a5fd-031e40506d08"/>
+                <reportElement x="12" y="56" width="38" height="12" forecolor="#FFFFFF" backcolor="#FFFFFF" uuid="135b7210-797e-41f2-a5fd-031e40506d08"/>
                 <graphicElement>
                     <pen lineColor="#FFFFFF"/>
                 </graphicElement>
             </rectangle>
-            <image hAlign="Center">
-                <reportElement x="0" y="0" width="102" height="61" uuid="94883631-a913-43e2-b182-ab8d77d0181e"/>
-                <imageExpression><![CDATA[$P{logo}]]></imageExpression>
-            </image>
             <staticText>
-                <reportElement x="102" y="12" width="228" height="14" uuid="b61efa33-0ea0-4fed-9d78-a768de817cb3">
-                    <property name="com.jaspersoft.studio.unit.height" value="px"/>
-                    <property name="com.jaspersoft.studio.unit.width" value="px"/>
-                </reportElement>
-                <box rightPadding="4"/>
-                <textElement textAlignment="Center">
-                    <font size="10"/>
+                <reportElement x="14" y="56" width="36" height="12" forecolor="#666666" uuid="b61efa33-0ea0-4fed-9d78-a768de817cb3"/>
+                <textElement textAlignment="Left" verticalAlignment="Middle">
+                    <font size="8" isBold="true"/>
                 </textElement>
                 <text><![CDATA[Filtros]]></text>
             </staticText>
             <staticText>
-                <reportElement x="80" y="0" width="400" height="17" uuid="c0c9f5b8-f0b7-4503-9428-2d7be98aa4e6"/>
-                <textElement textAlignment="Center">
-                    <font size="12" isBold="true"/>
-                </textElement>
-                <text><![CDATA[Reporte de inventario]]></text>
-            </staticText>
-            <textField>
-                <reportElement x="175" y="78" width="70" height="9" uuid="7e8c778b-0e6c-4e04-a4c7-de5b9f3403f6"/>
-                <textElement>
-                    <font size="6"/>
-                </textElement>
-                <textFieldExpression><![CDATA[$P{fechaReporte}]]></textFieldExpression>
-            </textField>
-            <staticText>
-                <reportElement x="111" y="78" width="64" height="9" uuid="4c91f639-4e4b-4bb2-965f-156eaed3a91c"/>
-                <textElement>
-                    <font size="6"/>
-                </textElement>
-                <text><![CDATA[Reporte creado en]]></text>
-            </staticText>
-            <staticText>
-                <reportElement x="245" y="78" width="60" height="9" uuid="186428af-f5d4-4389-8c9b-cadb45c47034"/>
-                <textElement>
-                    <font size="6"/>
-                </textElement>
-                <text><![CDATA[por el usuario]]></text>
-            </staticText>
-            <textField>
-                <reportElement x="305" y="78" width="85" height="9" uuid="09ce4efd-2860-4013-b158-a83a2fdcc811"/>
-                <textElement>
-                    <font size="6"/>
-                </textElement>
-                <textFieldExpression><![CDATA[$P{usuario}]]></textFieldExpression>
-            </textField>
-            <staticText>
-                <reportElement x="113" y="27" width="61" height="12" uuid="952a2b7b-2b18-4daa-823e-3241f57c0708">
-                    <property name="com.jaspersoft.studio.unit.height" value="px"/>
-                    <property name="com.jaspersoft.studio.unit.width" value="px"/>
-                </reportElement>
-                <box rightPadding="4"/>
-                <textElement textAlignment="Left">
+                <reportElement x="12" y="70" width="58" height="12" forecolor="#666666" uuid="952a2b7b-2b18-4daa-823e-3241f57c0708"/>
+                <textElement textAlignment="Left" verticalAlignment="Middle">
                     <font size="8"/>
                 </textElement>
-                <text><![CDATA[Fecha inicio:]]></text>
+                <text><![CDATA[Fecha inicio]]></text>
             </staticText>
-            <staticText>
-                <reportElement x="113" y="39" width="61" height="12" uuid="d6c50cb5-67d5-41eb-8304-19f12525266e">
-                    <property name="com.jaspersoft.studio.unit.height" value="px"/>
-                    <property name="com.jaspersoft.studio.unit.width" value="px"/>
-                </reportElement>
-                <box rightPadding="4"/>
-                <textElement textAlignment="Left">
-                    <font size="8"/>
-                </textElement>
-                <text><![CDATA[Fecha fin:]]></text>
-            </staticText>
-            <textField>
-                <reportElement x="174" y="39" width="154" height="12" uuid="de978e8e-d9c0-41b3-92c5-845bf8bbf604"/>
-                <textElement>
-                    <font size="8"/>
-                </textElement>
-                <textFieldExpression><![CDATA[$P{filtroFechaFin}]]></textFieldExpression>
-            </textField>
-            <textField>
-                <reportElement x="174" y="27" width="154" height="12" uuid="9fea43b1-2dec-48a2-907d-79ceeb4c8b82"/>
-                <textElement>
+            <textField isBlankWhenNull="true">
+                <reportElement x="72" y="70" width="190" height="12" uuid="9fea43b1-2dec-48a2-907d-79ceeb4c8b82"/>
+                <textElement textAlignment="Left" verticalAlignment="Middle">
                     <font size="8"/>
                 </textElement>
                 <textFieldExpression><![CDATA[$P{filtroFechaInicio}]]></textFieldExpression>
             </textField>
             <staticText>
-                <reportElement x="114" y="51" width="61" height="12" uuid="c72b73f6-2ce5-40cd-8ef7-ba4bd75022ad">
-                    <property name="com.jaspersoft.studio.unit.height" value="px"/>
-                    <property name="com.jaspersoft.studio.unit.width" value="px"/>
-                </reportElement>
-                <box rightPadding="4"/>
-                <textElement textAlignment="Left">
+                <reportElement x="12" y="83" width="58" height="12" forecolor="#666666" uuid="d6c50cb5-67d5-41eb-8304-19f12525266e"/>
+                <textElement textAlignment="Left" verticalAlignment="Middle">
                     <font size="8"/>
                 </textElement>
-                <text><![CDATA[Sucursal(es):]]></text>
+                <text><![CDATA[Fecha fin]]></text>
             </staticText>
-            <textField>
-                <reportElement x="175" y="51" width="154" height="23" uuid="a5e1ae18-89be-4a96-a29c-10298aca4de6"/>
-                <textElement>
+            <textField isBlankWhenNull="true">
+                <reportElement x="72" y="83" width="190" height="12" uuid="de978e8e-d9c0-41b3-92c5-845bf8bbf604"/>
+                <textElement textAlignment="Left" verticalAlignment="Middle">
+                    <font size="8"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$P{filtroFechaFin}]]></textFieldExpression>
+            </textField>
+            <staticText>
+                <reportElement x="12" y="96" width="58" height="12" forecolor="#666666" uuid="c72b73f6-2ce5-40cd-8ef7-ba4bd75022ad"/>
+                <textElement textAlignment="Left" verticalAlignment="Middle">
+                    <font size="8"/>
+                </textElement>
+                <text><![CDATA[Sucursal(es)]]></text>
+            </staticText>
+            <textField isBlankWhenNull="true">
+                <reportElement x="72" y="96" width="190" height="12" uuid="a5e1ae18-89be-4a96-a29c-10298aca4de6"/>
+                <textElement textAlignment="Left" verticalAlignment="Middle">
                     <font size="8"/>
                 </textElement>
                 <textFieldExpression><![CDATA[$P{filtroSucursales}]]></textFieldExpression>
             </textField>
-            <textField>
-                <reportElement x="390" y="27" width="158" height="47" uuid="d600e083-880b-48ce-bfb3-01dbb72ca132"/>
-                <textElement>
+            <staticText>
+                <reportElement x="278" y="70" width="58" height="12" forecolor="#666666" uuid="60ed71d6-e25c-42ce-871c-320543ca25cd"/>
+                <textElement textAlignment="Left" verticalAlignment="Middle">
+                    <font size="8"/>
+                </textElement>
+                <text><![CDATA[Producto(s)]]></text>
+            </staticText>
+            <textField isBlankWhenNull="true">
+                <reportElement x="338" y="70" width="205" height="25" uuid="d600e083-880b-48ce-bfb3-01dbb72ca132"/>
+                <textElement textAlignment="Left" verticalAlignment="Top">
                     <font size="8"/>
                 </textElement>
                 <textFieldExpression><![CDATA[$P{filtroProductos}]]></textFieldExpression>
             </textField>
             <staticText>
-                <reportElement x="330" y="27" width="61" height="12" uuid="60ed71d6-e25c-42ce-871c-320543ca25cd">
-                    <property name="com.jaspersoft.studio.unit.height" value="px"/>
-                    <property name="com.jaspersoft.studio.unit.width" value="px"/>
-                </reportElement>
-                <box rightPadding="4"/>
-                <textElement textAlignment="Left">
+                <reportElement x="278" y="96" width="58" height="12" forecolor="#666666" uuid="4c91f639-4e4b-4bb2-965f-156eaed3a91c"/>
+                <textElement textAlignment="Left" verticalAlignment="Middle">
                     <font size="8"/>
                 </textElement>
-                <text><![CDATA[Producto(s):]]></text>
+                <text><![CDATA[Creado]]></text>
             </staticText>
+            <textField isBlankWhenNull="true">
+                <reportElement x="338" y="96" width="96" height="12" uuid="7e8c778b-0e6c-4e04-a4c7-de5b9f3403f6"/>
+                <textElement textAlignment="Left" verticalAlignment="Middle">
+                    <font size="8"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$P{fechaReporte}]]></textFieldExpression>
+            </textField>
+            <staticText>
+                <reportElement x="440" y="96" width="38" height="12" forecolor="#666666" uuid="186428af-f5d4-4389-8c9b-cadb45c47034"/>
+                <textElement textAlignment="Left" verticalAlignment="Middle">
+                    <font size="8"/>
+                </textElement>
+                <text><![CDATA[Usuario]]></text>
+            </staticText>
+            <textField isBlankWhenNull="true">
+                <reportElement x="478" y="96" width="65" height="12" uuid="09ce4efd-2860-4013-b158-a83a2fdcc811"/>
+                <textElement textAlignment="Left" verticalAlignment="Middle">
+                    <font size="8"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$P{usuario}]]></textFieldExpression>
+            </textField>
         </band>
     </title>
     <columnHeader>
-        <band height="14">
+        <band height="24">
             <rectangle>
-                <reportElement x="0" y="0" width="555" height="12" forecolor="#D4D4D4" backcolor="#EDEDED" uuid="3006dae7-3228-4979-bda4-adc9f14e4ac7"/>
+                <reportElement x="0" y="6" width="555" height="16" forecolor="#BFBFBF" backcolor="#EDEDED" uuid="3006dae7-3228-4979-bda4-adc9f14e4ac7"/>
                 <graphicElement>
-                    <pen lineColor="#A3A3A3"/>
+                    <pen lineWidth="0.5" lineColor="#BFBFBF"/>
                 </graphicElement>
             </rectangle>
             <staticText>
-                <reportElement x="0" y="0" width="180" height="14" uuid="5173637c-cc6b-4c44-8082-94de61054a78">
-                    <property name="com.jaspersoft.studio.spreadsheet.connectionID" value="93874747-0187-4a01-9812-8c4a6be75ffa"/>
-                </reportElement>
+                <reportElement x="0" y="6" width="34" height="16" forecolor="#333333" uuid="1c9b6a2e-4d3f-4b1a-9c8e-2a5f7d1e0b31"/>
                 <textElement textAlignment="Center" verticalAlignment="Middle">
-                    <font size="8"/>
+                    <font size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[ID]]></text>
+            </staticText>
+            <staticText>
+                <reportElement x="34" y="6" width="181" height="16" forecolor="#333333" uuid="5173637c-cc6b-4c44-8082-94de61054a78"/>
+                <box leftPadding="4"/>
+                <textElement textAlignment="Left" verticalAlignment="Middle">
+                    <font size="8" isBold="true"/>
                 </textElement>
                 <text><![CDATA[Producto]]></text>
             </staticText>
             <staticText>
-                <reportElement x="180" y="0" width="50" height="14" uuid="1390f0d3-0245-44fa-b476-4e032e81147c">
-                    <property name="com.jaspersoft.studio.spreadsheet.connectionID" value="e74c448e-86a4-4ea0-a253-144c060ddd2c"/>
-                </reportElement>
-                <textElement textAlignment="Center" verticalAlignment="Middle">
-                    <font size="6"/>
+                <reportElement x="215" y="6" width="55" height="16" forecolor="#333333" uuid="1390f0d3-0245-44fa-b476-4e032e81147c"/>
+                <box rightPadding="6"/>
+                <textElement textAlignment="Right" verticalAlignment="Middle">
+                    <font size="8" isBold="true"/>
                 </textElement>
-                <text><![CDATA[Cant. Sistema]]></text>
+                <text><![CDATA[C. Sistema]]></text>
             </staticText>
             <staticText>
-                <reportElement x="230" y="0" width="50" height="14" uuid="32104080-de65-405b-ac44-90afcc0bd89b">
-                    <property name="com.jaspersoft.studio.spreadsheet.connectionID" value="239577d0-bd84-4bb7-8dda-f598ed4e7fd0"/>
-                </reportElement>
-                <textElement textAlignment="Center" verticalAlignment="Middle">
-                    <font size="6"/>
+                <reportElement x="270" y="6" width="55" height="16" forecolor="#333333" uuid="32104080-de65-405b-ac44-90afcc0bd89b"/>
+                <box rightPadding="6"/>
+                <textElement textAlignment="Right" verticalAlignment="Middle">
+                    <font size="8" isBold="true"/>
                 </textElement>
-                <text><![CDATA[Cant. Física]]></text>
+                <text><![CDATA[C. Física]]></text>
             </staticText>
             <staticText>
-                <reportElement x="280" y="0" width="50" height="14" uuid="a56b1324-6c08-4b9d-83b0-ad22d831e02c">
-                    <property name="com.jaspersoft.studio.spreadsheet.connectionID" value="f98fc71e-6ed4-485f-8963-18c73e56e181"/>
-                </reportElement>
-                <textElement textAlignment="Center" verticalAlignment="Middle">
-                    <font size="8"/>
+                <reportElement x="325" y="6" width="50" height="16" forecolor="#333333" uuid="a56b1324-6c08-4b9d-83b0-ad22d831e02c"/>
+                <box rightPadding="6"/>
+                <textElement textAlignment="Right" verticalAlignment="Middle">
+                    <font size="8" isBold="true"/>
                 </textElement>
                 <text><![CDATA[Saldo]]></text>
             </staticText>
             <staticText>
-                <reportElement x="330" y="0" width="50" height="12" uuid="caad28d3-d57f-4b8c-8ad9-2bae378b2f49">
-                    <property name="com.jaspersoft.studio.spreadsheet.connectionID" value="d0549de7-087b-42b1-98d7-99ea7d839117"/>
-                </reportElement>
+                <reportElement x="375" y="6" width="55" height="16" forecolor="#333333" uuid="caad28d3-d57f-4b8c-8ad9-2bae378b2f49"/>
                 <textElement textAlignment="Center" verticalAlignment="Middle">
-                    <font size="8"/>
+                    <font size="8" isBold="true"/>
                 </textElement>
                 <text><![CDATA[Estado]]></text>
             </staticText>
             <staticText>
-                <reportElement x="380" y="0" width="100" height="14" uuid="96373350-ee3c-4a26-aab1-f17f7e283350">
-                    <property name="com.jaspersoft.studio.spreadsheet.connectionID" value="0aa1314d-9bfd-478f-9ddf-60e93a56b975"/>
-                </reportElement>
+                <reportElement x="430" y="6" width="70" height="16" forecolor="#333333" uuid="96373350-ee3c-4a26-aab1-f17f7e283350"/>
                 <textElement textAlignment="Center" verticalAlignment="Middle">
-                    <font size="8"/>
+                    <font size="8" isBold="true"/>
                 </textElement>
                 <text><![CDATA[Responsable]]></text>
             </staticText>
             <staticText>
-                <reportElement x="480" y="0" width="74" height="14" uuid="c533521b-7fb0-4493-a32a-785e4d29ca3c">
-                    <property name="com.jaspersoft.studio.spreadsheet.connectionID" value="8cd3ce79-e926-4e95-8064-76cb2f964f5a"/>
-                </reportElement>
+                <reportElement x="500" y="6" width="55" height="16" forecolor="#333333" uuid="c533521b-7fb0-4493-a32a-785e4d29ca3c"/>
                 <textElement textAlignment="Center" verticalAlignment="Middle">
-                    <font size="8"/>
+                    <font size="8" isBold="true"/>
                 </textElement>
                 <text><![CDATA[Fecha]]></text>
             </staticText>
         </band>
     </columnHeader>
     <detail>
-        <band height="12">
-            <textField>
-                <reportElement x="0" y="0" width="20" height="12" uuid="8fdc7fa0-55f4-4eb9-9142-91736dcbd69b">
-                    <property name="com.jaspersoft.studio.spreadsheet.connectionID" value="11f543a1-fd78-44d6-80c5-680007665702"/>
-                </reportElement>
-                <textElement verticalAlignment="Middle">
+        <band height="14">
+            <textField isBlankWhenNull="true">
+                <reportElement x="0" y="0" width="34" height="13" forecolor="#666666" uuid="8fdc7fa0-55f4-4eb9-9142-91736dcbd69b"/>
+                <textElement textAlignment="Center" verticalAlignment="Middle">
                     <font size="8"/>
                 </textElement>
                 <textFieldExpression><![CDATA[$F{productoId}]]></textFieldExpression>
             </textField>
-            <textField>
-                <reportElement x="20" y="0" width="160" height="12" uuid="8b7fd0b4-bcf9-4fab-abd0-307abe33ab11">
-                    <property name="com.jaspersoft.studio.spreadsheet.connectionID" value="93874747-0187-4a01-9812-8c4a6be75ffa"/>
-                </reportElement>
-                <textElement verticalAlignment="Middle">
+            <textField isBlankWhenNull="true">
+                <reportElement x="34" y="0" width="181" height="13" uuid="8b7fd0b4-bcf9-4fab-abd0-307abe33ab11"/>
+                <box leftPadding="4"/>
+                <textElement textAlignment="Left" verticalAlignment="Middle">
                     <font size="8"/>
                 </textElement>
                 <textFieldExpression><![CDATA[$F{descripcion}]]></textFieldExpression>
             </textField>
-            <textField pattern="#,##0">
-                <reportElement x="180" y="0" width="50" height="12" uuid="fa6e9a7b-de74-4cca-b879-4452285fb0fd">
-                    <property name="com.jaspersoft.studio.spreadsheet.connectionID" value="e74c448e-86a4-4ea0-a253-144c060ddd2c"/>
-                </reportElement>
-                <textElement textAlignment="Center" verticalAlignment="Middle">
+            <textField pattern="#,##0" isBlankWhenNull="true">
+                <reportElement x="215" y="0" width="55" height="13" uuid="fa6e9a7b-de74-4cca-b879-4452285fb0fd"/>
+                <box rightPadding="6"/>
+                <textElement textAlignment="Right" verticalAlignment="Middle">
                     <font size="8"/>
                 </textElement>
                 <textFieldExpression><![CDATA[$F{cantidadSistema}]]></textFieldExpression>
             </textField>
-            <textField pattern="#,##0">
-                <reportElement x="230" y="0" width="50" height="12" uuid="ba6ca274-d746-4bae-b288-7fda7c15d59e">
-                    <property name="com.jaspersoft.studio.spreadsheet.connectionID" value="239577d0-bd84-4bb7-8dda-f598ed4e7fd0"/>
-                </reportElement>
-                <textElement textAlignment="Center" verticalAlignment="Middle">
+            <textField pattern="#,##0" isBlankWhenNull="true">
+                <reportElement x="270" y="0" width="55" height="13" uuid="ba6ca274-d746-4bae-b288-7fda7c15d59e"/>
+                <box rightPadding="6"/>
+                <textElement textAlignment="Right" verticalAlignment="Middle">
                     <font size="8"/>
                 </textElement>
                 <textFieldExpression><![CDATA[$F{cantidadEncontrada}]]></textFieldExpression>
             </textField>
-            <textField pattern="#,##0">
-                <reportElement x="280" y="0" width="50" height="12" uuid="c5a62a97-1e0e-439e-9a38-bc2a099fd94c">
-                    <property name="com.jaspersoft.studio.spreadsheet.connectionID" value="f98fc71e-6ed4-485f-8963-18c73e56e181"/>
-                </reportElement>
-                <textElement textAlignment="Center" verticalAlignment="Middle">
-                    <font size="8"/>
+            <textField pattern="#,##0" isBlankWhenNull="true">
+                <reportElement x="325" y="0" width="50" height="13" uuid="c5a62a97-1e0e-439e-9a38-bc2a099fd94c"/>
+                <box rightPadding="6"/>
+                <textElement textAlignment="Right" verticalAlignment="Middle">
+                    <font size="8" isBold="true"/>
                 </textElement>
                 <textFieldExpression><![CDATA[$F{saldo}]]></textFieldExpression>
             </textField>
-            <textField>
-                <reportElement x="330" y="0" width="50" height="12" uuid="9725eae3-f6d0-4462-934c-5f910bdd1004">
-                    <property name="com.jaspersoft.studio.spreadsheet.connectionID" value="d0549de7-087b-42b1-98d7-99ea7d839117"/>
-                </reportElement>
+            <textField isBlankWhenNull="true">
+                <reportElement x="375" y="0" width="55" height="13" uuid="9725eae3-f6d0-4462-934c-5f910bdd1004"/>
                 <textElement textAlignment="Center" verticalAlignment="Middle">
                     <font size="8"/>
                 </textElement>
                 <textFieldExpression><![CDATA[$F{estado}]]></textFieldExpression>
             </textField>
-            <textField>
-                <reportElement x="380" y="-2" width="100" height="14" uuid="86c506cb-5eff-4ad6-b0cd-749ee663cf60">
-                    <property name="com.jaspersoft.studio.spreadsheet.connectionID" value="0aa1314d-9bfd-478f-9ddf-60e93a56b975"/>
-                </reportElement>
+            <textField isBlankWhenNull="true">
+                <reportElement x="430" y="0" width="70" height="13" uuid="86c506cb-5eff-4ad6-b0cd-749ee663cf60"/>
                 <textElement textAlignment="Center" verticalAlignment="Middle">
                     <font size="8"/>
                 </textElement>
                 <textFieldExpression><![CDATA[$F{responsable}]]></textFieldExpression>
             </textField>
-            <textField>
-                <reportElement x="480" y="-2" width="74" height="14" uuid="9edec707-0070-4470-aae6-fcb22738d392">
-                    <property name="com.jaspersoft.studio.spreadsheet.connectionID" value="8cd3ce79-e926-4e95-8064-76cb2f964f5a"/>
-                </reportElement>
+            <textField isBlankWhenNull="true">
+                <reportElement x="500" y="0" width="55" height="13" uuid="9edec707-0070-4470-aae6-fcb22738d392"/>
                 <textElement textAlignment="Center" verticalAlignment="Middle">
                     <font size="8"/>
                 </textElement>
                 <textFieldExpression><![CDATA[$F{fecha}]]></textFieldExpression>
             </textField>
+            <line>
+                <reportElement x="0" y="13" width="555" height="1" forecolor="#E4E4E4" uuid="2b8c4d5e-6f70-4a81-9b2c-3d4e5f607182"/>
+            </line>
         </band>
     </detail>
     <columnFooter>
         <band height="15"/>
     </columnFooter>
-    <lastPageFooter>
-        <band height="17"/>
-    </lastPageFooter>
+    <pageFooter>
+        <band height="20">
+            <line>
+                <reportElement x="0" y="2" width="555" height="1" forecolor="#D9D9D9" uuid="3c9d5e6f-7081-4b92-8c3d-4e5f60718293"/>
+            </line>
+            <textField isBlankWhenNull="true" evaluationTime="Report">
+                <reportElement x="0" y="6" width="300" height="12" forecolor="#808080" uuid="4da6f708-8192-4ca3-9d4e-5f6071829304"/>
+                <textElement textAlignment="Left" verticalAlignment="Middle">
+                    <font size="7"/>
+                </textElement>
+                <textFieldExpression><![CDATA["Total de items: " + $V{REPORT_COUNT}]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement x="380" y="6" width="130" height="12" forecolor="#808080" uuid="5eb70819-92a3-4db4-ae5f-60718293a415"/>
+                <textElement textAlignment="Right" verticalAlignment="Middle">
+                    <font size="7"/>
+                </textElement>
+                <textFieldExpression><![CDATA["Página " + $V{PAGE_NUMBER} + " de "]]></textFieldExpression>
+            </textField>
+            <textField evaluationTime="Report">
+                <reportElement x="510" y="6" width="45" height="12" forecolor="#808080" uuid="6fc81920-a3b4-4ec5-bf60-718293a41526"/>
+                <box leftPadding="3"/>
+                <textElement textAlignment="Left" verticalAlignment="Middle">
+                    <font size="7"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$V{PAGE_NUMBER}]]></textFieldExpression>
+            </textField>
+        </band>
+    </pageFooter>
 </jasperReport>

--- a/src/test/java/com/franco/dev/utilitarios/IdUtilsTest.java
+++ b/src/test/java/com/franco/dev/utilitarios/IdUtilsTest.java
@@ -1,0 +1,59 @@
+package com.franco.dev.utilitarios;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class IdUtilsTest {
+
+    @Test
+    void convierteIntegerALong() {
+        // Los campos [Int] del schema llegan como Integer aunque el resolver
+        // los reciba tipados como List<Long>: usarlos como Long tira ClassCastException.
+        List<?> desdeGraphQL = Arrays.asList(1, 2, 3);
+
+        List<Long> ids = IdUtils.toLongList(desdeGraphQL);
+
+        assertEquals(Arrays.asList(1L, 2L, 3L), ids);
+    }
+
+    @Test
+    void convierteStringALong() {
+        assertEquals(Arrays.asList(10L, 20L), IdUtils.toLongList(Arrays.asList("10", " 20 ")));
+    }
+
+    @Test
+    void mantieneLosLong() {
+        assertEquals(Collections.singletonList(7L), IdUtils.toLongList(Collections.singletonList(7L)));
+    }
+
+    @Test
+    void devuelveNullSiNoHayFiltro() {
+        assertNull(IdUtils.toLongList(null));
+        assertNull(IdUtils.toLongList(Collections.emptyList()));
+    }
+
+    @Test
+    void ignoraNullsYValoresNoNumericos() {
+        assertEquals(Collections.singletonList(5L), IdUtils.toLongList(Arrays.asList(null, "abc", 5)));
+    }
+
+    @Test
+    void devuelveNullSiNingunIdEsValido() {
+        assertNull(IdUtils.toLongList(Arrays.asList("abc", "-")));
+    }
+
+    @Test
+    void toLongAceptaDistintosTipos() {
+        assertEquals(4L, IdUtils.toLong(4));
+        assertEquals(4L, IdUtils.toLong(4L));
+        assertEquals(4L, IdUtils.toLong("4"));
+        assertNull(IdUtils.toLong("x"));
+        assertNull(IdUtils.toLong(null));
+    }
+}


### PR DESCRIPTION
## Qué resuelve

Correcciones y rediseño del reporte de inventario en PDF. Sale de `develop` con el fix de carga del `.jrxml` desde el JAR (PR #195) ya integrado.

### 1. La cabecera de filtros salía vacía

Varios elementos tenían una altura menor a la que necesita su fuente para dibujar una línea, y en ese caso JasperReports **no dibuja nada** (no trunca: desaparece). Quedaban invisibles el título, las cuatro etiquetas de filtro, ambas fechas y la línea de "Reporte creado en … por el usuario …". Además el título estaba en `y="-2"`, fuera de la banda.

### 2. ClassCastException al resolver los nombres de sucursal

```
class java.lang.Integer cannot be cast to class java.lang.Long
```

El schema declara `sucursalIdList: [Int]`, así que GraphQL entrega `Integer` aunque el resolver reciba `List<Long>`; el borrado de tipos hace que nadie convierta. `InventarioProductoItemService` ya tenía un `toLongList` privado para este mismo problema, así que en vez de duplicarlo se extrajo **`IdUtils.toLongList/toLong`** (normaliza Integer, Long y String — los campos `[ID]` llegan como String), con tests.

### 3. El reporte listaba solo la página actual

Armaba el `Pageable` con el `page`/`size` de la pantalla: si la grilla estaba en 15 por página, el PDF salía con 15 items en vez de con todos los que matchean los filtros. Ahora usa `Pageable.unpaged()`; `page`/`size` se siguen recibiendo por compatibilidad con el schema pero se ignoran a propósito.

### 4. Presentación de los datos

- Cant. Sistema, Cant. Física y Saldo son conteos: se muestran con `pattern="#,##0"` (el que usa el resto de los reportes) en vez de decimales.
- Los filtros de sucursal y de producto mostraban los ids crudos (`[1, 2]`); ahora resuelven nombres. Si un id no resuelve, se muestra el id para no perder información.

### 5. Rediseño del template

- Se agrega la cabecera **ID** a la columna de ids, que no tenía encabezado.
- "Cant. Sistema" / "Cant. Física" pasan a **C. Sistema** / **C. Física**, en 8pt como el resto (iban en 6pt), y las tres columnas numéricas quedan centradas.
- "Creado" y "Usuario" se mueven adentro del cuadro de filtros.
- Título alineado a la derecha del logo, separador bajo el encabezado, cuadro de filtros con borde redondeado, línea sutil entre filas, anchos repartidos sobre el ancho útil real (555px; `columnWidth` declaraba 535).
- Pie de página con total de items y numeración. Se elimina el `lastPageFooter` vacío, que **reemplazaba** al `pageFooter` en la última página y por eso el pie nunca aparecía.
- El template se llamaba internamente `transferencia` (venía copiado de otro reporte); ahora `reporte-inventario`.

## Cómo probarlo

Con `spring-boot:run` alcanza para esta parte (el fix del JAR ya está en develop):

```bash
./mvnw -o spring-boot:run -DskipFlyway=true
```

Desde el desktop, módulo de inventario → generar el reporte en PDF:

- Filtrando por sucursal y por productos: la cabecera debe mostrar **nombres**, no ids.
- Con la paginación de la grilla en cualquier valor: el PDF debe traer **todos** los items del filtro. Verificado contra la DB `bodega`: el 02/03/2023 sin otros filtros da 1448 items.
- Las cantidades salen sin decimales y centradas.

## Verificación realizada

- PDF generado con 0, 3 y 120 filas: cabecera repetida por página, numeración correcta, total real en todas las páginas, ningún elemento recortado.
- `./mvnw clean verify -B -DskipFlyway=true` → BUILD SUCCESS, 89 tests (7 nuevos en `IdUtilsTest`).
- Probado en la UI contra el JAR empaquetado en 8081 con la DB `bodega`.

## Impacto en DB

Ninguno. No hay migraciones.

## Impacto en rollback

Ninguno. Solo cambia un template y un resolver; revertir el JAR restaura el comportamiento anterior.

## Riesgo

Bajo. Sin cambios en la API GraphQL: `page`/`size` se siguen aceptando en `reporteInventario`, solo dejan de recortar el resultado.
