### PR TITLE
feat(transferencia): filtrar la lista por ultimo responsable

### DIFF
--- a/src/main/java/com/franco/dev/graphql/operaciones/TransferenciaGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/TransferenciaGraphQL.java
@@ -357,7 +357,7 @@ public class TransferenciaGraphQL implements GraphQLQueryResolver, GraphQLMutati
 
     public Page<Transferencia> transferenciasWithFilters(Long sucursalOrigenId, Long sucursalDestinoId,
             TransferenciaEstado estado, List<TransferenciaEstado> estados, TipoTransferencia tipo,
-            EtapaTransferencia etapa, Boolean isOrigen, Boolean isDestino,
+            EtapaTransferencia etapa, Boolean isOrigen, Boolean isDestino, Long ultimoResponsableId,
             String creadoDesde, String creadoHasta, Integer page, Integer size) {
         if (page == null)
             page = 0;
@@ -372,7 +372,7 @@ public class TransferenciaGraphQL implements GraphQLQueryResolver, GraphQLMutati
         if (estado != null && !estadoList.contains(estado))
             estadoList.add(estado);
         return service.findByFilter(sucursalOrigenId, sucursalDestinoId, estadoList, tipo, etapa, isOrigen, isDestino,
-                stringToDate(creadoDesde), stringToDate(creadoHasta), pageable);
+                ultimoResponsableId, stringToDate(creadoDesde), stringToDate(creadoHasta), pageable);
     }
 
     public String imprimirTransferencia(Long id, Boolean ticket, String printerName) {

--- a/src/main/java/com/franco/dev/repository/operaciones/TransferenciaRepository.java
+++ b/src/main/java/com/franco/dev/repository/operaciones/TransferenciaRepository.java
@@ -16,6 +16,15 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public interface TransferenciaRepository extends HelperRepository<Transferencia, Long> {
+        /**
+         * El "ultimo responsable" es el usuario de la etapa mas avanzada que ya tiene
+         * responsable asignado, por eso el COALESCE va en orden inverso al flujo:
+         * recepcion -> transporte -> preparacion -> pre transferencia.
+         */
+        String ULTIMO_RESPONSABLE_FILTER = "(:ultimoResponsableId IS NULL OR COALESCE("
+                        + "t.usuarioRecepcion.id, t.usuarioTransporte.id, t.usuarioPreparacion.id, t.usuarioPreTransferencia.id"
+                        + ") = :ultimoResponsableId) AND ";
+
         default Class<Transferencia> getEntityClass() {
                 return Transferencia.class;
         }
@@ -50,6 +59,7 @@ public interface TransferenciaRepository extends HelperRepository<Transferencia,
                         + "(t.etapa = :etapa OR cast(:etapa as com.franco.dev.domain.operaciones.enums.EtapaTransferencia) IS NULL) AND "
                         + "(:isOrigen IS NULL OR t.isOrigen = :isOrigen) AND "
                         + "(:isDestino IS NULL OR t.isDestino = :isDestino) AND "
+                        + ULTIMO_RESPONSABLE_FILTER
                         + "(t.creadoEn >= :creadoEnDesde or cast(:creadoEnDesde as timestamp) IS NULL) AND "
                         + "(t.creadoEn <= :creadoEnHasta or cast(:creadoEnHasta as timestamp) IS NULL ) order by t.id desc")
         Page<Transferencia> findByFilter(
@@ -60,6 +70,7 @@ public interface TransferenciaRepository extends HelperRepository<Transferencia,
                         EtapaTransferencia etapa,
                         Boolean isOrigen,
                         Boolean isDestino,
+                        Long ultimoResponsableId,
                         LocalDateTime creadoEnDesde,
                         LocalDateTime creadoEnHasta,
                         Pageable pageable);
@@ -72,6 +83,7 @@ public interface TransferenciaRepository extends HelperRepository<Transferencia,
                         + "(t.etapa = :etapa OR cast(:etapa as com.franco.dev.domain.operaciones.enums.EtapaTransferencia) IS NULL) AND "
                         + "(:isOrigen IS NULL OR t.isOrigen = :isOrigen) AND "
                         + "(:isDestino IS NULL OR t.isDestino = :isDestino) AND "
+                        + ULTIMO_RESPONSABLE_FILTER
                         + "(t.creadoEn >= :creadoEnDesde or cast(:creadoEnDesde as timestamp) IS NULL) AND "
                         + "(t.creadoEn <= :creadoEnHasta or cast(:creadoEnHasta as timestamp) IS NULL ) order by t.id desc")
         Page<Transferencia> findByFilterEstadoIn(
@@ -82,6 +94,7 @@ public interface TransferenciaRepository extends HelperRepository<Transferencia,
                         @Param("etapa") EtapaTransferencia etapa,
                         @Param("isOrigen") Boolean isOrigen,
                         @Param("isDestino") Boolean isDestino,
+                        @Param("ultimoResponsableId") Long ultimoResponsableId,
                         @Param("creadoEnDesde") LocalDateTime creadoEnDesde,
                         @Param("creadoEnHasta") LocalDateTime creadoEnHasta,
                         Pageable pageable);

--- a/src/main/java/com/franco/dev/service/operaciones/TransferenciaService.java
+++ b/src/main/java/com/franco/dev/service/operaciones/TransferenciaService.java
@@ -52,23 +52,25 @@ public class TransferenciaService extends CrudService<Transferencia, Transferenc
 
     public Page<Transferencia> findByFilter(Long sucursalOrigenId, Long sucursalDestinoId, TransferenciaEstado estado,
             TipoTransferencia tipo, EtapaTransferencia etapa, Boolean isOrigen, Boolean isDestino,
+            Long ultimoResponsableId,
             LocalDateTime creadoDesde,
             LocalDateTime creadoHasta, Pageable pageable) {
         return repository.findByFilter(sucursalOrigenId, sucursalDestinoId, estado, tipo, etapa, isOrigen, isDestino,
-                creadoDesde, creadoHasta, pageable);
+                ultimoResponsableId, creadoDesde, creadoHasta, pageable);
     }
 
     public Page<Transferencia> findByFilter(Long sucursalOrigenId, Long sucursalDestinoId,
             List<TransferenciaEstado> estados,
             TipoTransferencia tipo, EtapaTransferencia etapa, Boolean isOrigen, Boolean isDestino,
+            Long ultimoResponsableId,
             LocalDateTime creadoDesde,
             LocalDateTime creadoHasta, Pageable pageable) {
         if (estados == null || estados.isEmpty()) {
             return repository.findByFilter(sucursalOrigenId, sucursalDestinoId, null, tipo, etapa, isOrigen, isDestino,
-                    creadoDesde, creadoHasta, pageable);
+                    ultimoResponsableId, creadoDesde, creadoHasta, pageable);
         }
         return repository.findByFilterEstadoIn(sucursalOrigenId, sucursalDestinoId, estados, tipo, etapa, isOrigen,
-                isDestino, creadoDesde, creadoHasta, pageable);
+                isDestino, ultimoResponsableId, creadoDesde, creadoHasta, pageable);
     }
 
     public List<VencimientoProductoDto> findProductosVencidos(Long sucId, LocalDateTime fechaInicio,

--- a/src/main/resources/graphql/operaciones/transferencia.graphqls
+++ b/src/main/resources/graphql/operaciones/transferencia.graphqls
@@ -62,7 +62,7 @@ extend type Query {
     transferenciaPorFecha(inicio:String, fin:String):[Transferencia]!
     transferenciasPorUsuario(id: ID!):[Transferencia]!
     countTransferencia: Int
-    transferenciasWithFilters(sucursalOrigenId: Int, sucursalDestinoId: Int, estado: TransferenciaEstado, estados: [TransferenciaEstado], tipo: TipoTransferencia, etapa: EtapaTransferencia, isOrigen: Boolean, isDestino: Boolean, creadoDesde: String, creadoHasta: String, page: Int, size: Int): TransferenciaPage
+    transferenciasWithFilters(sucursalOrigenId: Int, sucursalDestinoId: Int, estado: TransferenciaEstado, estados: [TransferenciaEstado], tipo: TipoTransferencia, etapa: EtapaTransferencia, isOrigen: Boolean, isDestino: Boolean, ultimoResponsableId: Int, creadoDesde: String, creadoHasta: String, page: Int, size: Int): TransferenciaPage
     imprimirTransferencia(id:ID!, ticket: Boolean, printerName:String!):String
     findProductoVencido(sucId: Int!, fechaInicio: String!, fechaFin: String!):[VencimientoProductoDto]
 }


### PR DESCRIPTION
## Qué resuelve

Permite filtrar `transferenciasWithFilters` por el **último responsable** de la transferencia: el usuario de la etapa más avanzada que ya tiene uno asignado (recepción → transporte → preparación → pre transferencia, primer no-nulo).

Va acompañado del PR del desktop en `frc-sistemas-integrados-angular`, misma rama `feature/transferencia-filtro-responsables`, que consume este argumento y además muestra los 4 responsables en el desplegable de cada fila.

## Cambios

- `transferencia.graphqls`: nuevo argumento opcional `ultimoResponsableId: Int`.
- `TransferenciaRepository`: constante `ULTIMO_RESPONSABLE_FILTER` con el `COALESCE`, aplicada a `findByFilter` y `findByFilterEstadoIn`.
- `TransferenciaService` y `TransferenciaGraphQL`: propagan el parámetro.

## Cómo probarlo

Módulo Operaciones → Transferencias en el desktop, o directo por GraphQL:

```graphql
transferenciasWithFilters(ultimoResponsableId: 341, creadoDesde: "...", creadoHasta: "...", page: 0, size: 20)
```

Sin el argumento (o en `null`) el resultado tiene que ser idéntico al de antes.

## Impacto en DB

Ninguno: sin migración, sin cambio de esquema. Solo lectura.

## Riesgo

**Bajo.** El argumento es opcional y aditivo, así que los clientes viejos siguen funcionando sin cambios.

Un punto que verifiqué explícitamente: el `COALESCE` se resuelve sobre las columnas FK y **no** genera joins a `usuario`, o sea que no esconde las transferencias sin responsable asignado. SQL generado por Hibernate:

```
from operaciones.transferencia transferen0_ where ... and (? is null or coalesce(
  transferen0_.usuario_recepcion_id, transferen0_.usuario_transporte_id,
  transferen0_.usuario_preparacion_id, transferen0_.usuario_pre_transferencia_id) = ?) ...
```

Rollback: revertir el commit, sin pasos manuales.

## Verificación

- `./mvnw clean verify -B -DskipFlyway=true` → BUILD SUCCESS, 89 tests OK.
- Probado por el usuario en la UI con datos reales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)