### PR TITLE
fix(reportes): excluir canceladas y descontar descuentos del total de ventas

### DIFF
--- a/src/main/java/com/franco/dev/graphql/operaciones/VentaGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/VentaGraphQL.java
@@ -493,6 +493,136 @@ public class VentaGraphQL implements GraphQLQueryResolver, GraphQLMutationResolv
                 fechaInicio, fechaFin);
     }
 
+    /**
+     * Acumulador de totales por forma de pago para los reportes de ventas.
+     * Cada venta reparte su neto entre las formas de pago que realmente se
+     * usaron, de modo que una venta mixta (parte efectivo, parte tarjeta) no
+     * se imputa entera a la forma de pago del primer movimiento de cobro.
+     */
+    static class TotalesPorFormaPago {
+        double general       = 0.0;
+        double efectivo      = 0.0;
+        double tarjeta       = 0.0;
+        double convenio      = 0.0;
+        double transferencia = 0.0;
+        double otros         = 0.0;
+
+        void acumular(String claveFormaPago, double valorGs) {
+            general += valorGs;
+            String desc = claveFormaPago != null ? claveFormaPago : "";
+            if (desc.contains("EFECTIVO")) {
+                efectivo += valorGs;
+            } else if (desc.contains("TARJETA")) {
+                tarjeta += valorGs;
+            } else if (desc.contains("CONVENIO")) {
+                convenio += valorGs;
+            } else if (desc.contains("TRANSFERENCIA")) {
+                transferencia += valorGs;
+            } else {
+                otros += valorGs;
+            }
+        }
+    }
+
+    /** Descuento y aumento (en Gs.) registrados en los movimientos de un cobro. */
+    static class AjustesCobro {
+        double descuento = 0.0;
+        double aumento   = 0.0;
+    }
+
+    private static boolean esVerdadero(Boolean valor) {
+        return valor != null && valor;
+    }
+
+    private static double valorEnGs(CobroDetalle cd) {
+        double valor = cd.getValor() != null ? cd.getValor() : 0.0;
+        double cambio = cd.getCambio() != null ? cd.getCambio() : 1.0;
+        return valor * cambio;
+    }
+
+    private static String claveFormaPago(FormaPago fp) {
+        return fp != null && fp.getDescripcion() != null
+                ? fp.getDescripcion().toUpperCase() : "";
+    }
+
+    /**
+     * Suma los descuentos y aumentos aplicados a una venta.
+     *
+     * No se usan los movimientos de PAGO para reconstruir el neto: hay cobros
+     * que quedaron con dos juegos de movimientos (un recobro posterior sobre
+     * el mismo cobro_id), asi que sumarlos duplica lo cobrado en alrededor del
+     * 5% de las ventas. El descuento y el aumento, en cambio, son un unico
+     * movimiento por cobro en mas del 99,8% de los casos.
+     */
+    static AjustesCobro ajustesDe(List<CobroDetalle> cobroDetalleList) {
+        AjustesCobro ajustes = new AjustesCobro();
+        if (cobroDetalleList == null) {
+            return ajustes;
+        }
+        for (CobroDetalle cd : cobroDetalleList) {
+            if (esVerdadero(cd.getPago()) || esVerdadero(cd.getVuelto())) {
+                continue;
+            }
+            if (esVerdadero(cd.getDescuento())) {
+                ajustes.descuento += valorEnGs(cd);
+            } else if (esVerdadero(cd.getAumento())) {
+                ajustes.aumento += valorEnGs(cd);
+            }
+        }
+        return ajustes;
+    }
+
+    /**
+     * Reparte el neto de una venta entre las formas de pago efectivamente
+     * usadas, en proporcion a lo pagado con cada una. Las proporciones salen
+     * de los movimientos de cobro, pero el monto repartido es siempre el neto
+     * de la venta, de modo que un cobro con movimientos duplicados desvia el
+     * reparto entre columnas pero nunca el total.
+     */
+    static void repartirPorFormaPago(List<CobroDetalle> cobroDetalleList,
+                                      FormaPago formaPagoVenta,
+                                      double netoVenta,
+                                      TotalesPorFormaPago totales) {
+        Map<String, Double> pagadoPorFormaPago = new LinkedHashMap<>();
+        double totalPagos = 0.0;
+        if (cobroDetalleList != null) {
+            for (CobroDetalle cd : cobroDetalleList) {
+                if (!esVerdadero(cd.getPago()) && !esVerdadero(cd.getVuelto())) {
+                    continue;
+                }
+                double valorGs = valorEnGs(cd);
+                String clave = cd.getFormaPago() != null
+                        ? claveFormaPago(cd.getFormaPago())
+                        : claveFormaPago(formaPagoVenta);
+                pagadoPorFormaPago.merge(clave, valorGs, Double::sum);
+                totalPagos += valorGs;
+            }
+        }
+
+        // Sin movimientos de pago utilizables, todo va a la forma de pago de la venta.
+        if (pagadoPorFormaPago.size() <= 1 || totalPagos == 0.0) {
+            String clave = pagadoPorFormaPago.isEmpty()
+                    ? claveFormaPago(formaPagoVenta)
+                    : pagadoPorFormaPago.keySet().iterator().next();
+            totales.acumular(clave, netoVenta);
+            return;
+        }
+
+        List<String> claves = new ArrayList<>(pagadoPorFormaPago.keySet());
+        String ultima = claves.get(claves.size() - 1);
+        double asignado = 0.0;
+        for (String clave : claves) {
+            if (clave.equals(ultima)) {
+                continue;
+            }
+            double parte = netoVenta * (pagadoPorFormaPago.get(clave) / totalPagos);
+            totales.acumular(clave, parte);
+            asignado += parte;
+        }
+        // La ultima forma de pago absorbe el redondeo para que el reparto cierre.
+        totales.acumular(ultima, netoVenta - asignado);
+    }
+
     public String reporteGenericVentas(
             Long idVenta,
             Long idCaja,
@@ -520,28 +650,26 @@ public class VentaGraphQL implements GraphQLQueryResolver, GraphQLMutationResolv
         List<Venta> ventas = ventaPage.getContent();
 
         // Acumuladores de totales por forma de pago (en Gs.)
-        double totalGeneral       = 0.0;
-        double totalEfectivo      = 0.0;
-        double totalTarjeta       = 0.0;
-        double totalConvenio      = 0.0;
-        double totalTransferencia = 0.0;
-        double totalOtros         = 0.0;
+        TotalesPorFormaPago totales = new TotalesPorFormaPago();
+        double totalDescuentos = 0.0;
+        double totalCanceladas = 0.0;
 
         List<ReporteVentaItemDto> itemList = new ArrayList<>();
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
 
         for (Venta v : ventas) {
             double ventaTotalGs = v.getTotalGs() != null ? v.getTotalGs() : 0.0;
-            totalGeneral += ventaTotalGs;
 
             // Resolver forma de pago y moneda usando la lógica del VentaResolver:
             // si la venta no tiene formaPago directo, buscar en el cobro
             FormaPago fp = v.getFormaPago();
             Moneda moneda = null;
+            List<CobroDetalle> cobroDetalleList = new ArrayList<>();
             if (v.getCobro() != null) {
                 List<CobroDetalle> detalles = cobroDetalleService.findByCobroId(
                         v.getCobro().getId(), v.getSucursalId());
                 if (detalles != null && !detalles.isEmpty()) {
+                    cobroDetalleList = detalles;
                     CobroDetalle primerDetalle = detalles.get(0);
                     if (fp == null) {
                         fp = primerDetalle.getFormaPago();
@@ -550,19 +678,15 @@ public class VentaGraphQL implements GraphQLQueryResolver, GraphQLMutationResolv
                 }
             }
 
-            String fpDesc = fp != null && fp.getDescripcion() != null
-                    ? fp.getDescripcion().toUpperCase() : "";
-
-            if (fpDesc.contains("EFECTIVO")) {
-                totalEfectivo += ventaTotalGs;
-            } else if (fpDesc.contains("TARJETA")) {
-                totalTarjeta += ventaTotalGs;
-            } else if (fpDesc.contains("CONVENIO")) {
-                totalConvenio += ventaTotalGs;
-            } else if (fpDesc.contains("TRANSFERENCIA")) {
-                totalTransferencia += ventaTotalGs;
+            // Las ventas canceladas se siguen listando, pero no suman al total:
+            // se acumulan aparte para mostrarlas como línea propia del resumen.
+            if (v.getEstado() == VentaEstado.CANCELADA) {
+                totalCanceladas += ventaTotalGs;
             } else {
-                totalOtros += ventaTotalGs;
+                AjustesCobro ajustes = ajustesDe(cobroDetalleList);
+                totalDescuentos += ajustes.descuento;
+                repartirPorFormaPago(cobroDetalleList, fp,
+                        ventaTotalGs - ajustes.descuento + ajustes.aumento, totales);
             }
 
             // Construir fila para el reporte
@@ -639,8 +763,9 @@ public class VentaGraphQL implements GraphQLQueryResolver, GraphQLMutationResolv
                 filtroSucursalStr, filtroFpStr, filtroMonedaStr,
                 filtroEstadoStr, filtroClienteStr,
                 filtroModoStr, filtroConObsStr, filtroConDescStr, filtroConAumStr,
-                totalGeneral, totalEfectivo, totalTarjeta,
-                totalConvenio, totalTransferencia, totalOtros,
+                totales.general, totales.efectivo, totales.tarjeta,
+                totales.convenio, totales.transferencia, totales.otros,
+                totalDescuentos, totalCanceladas,
                 usuario);
     }
 
@@ -671,19 +796,15 @@ public class VentaGraphQL implements GraphQLQueryResolver, GraphQLMutationResolv
         List<Venta> ventas = ventaPage.getContent();
 
         // Acumuladores de totales por forma de pago (en Gs.)
-        double totalGeneral       = 0.0;
-        double totalEfectivo      = 0.0;
-        double totalTarjeta       = 0.0;
-        double totalConvenio      = 0.0;
-        double totalTransferencia = 0.0;
-        double totalOtros         = 0.0;
+        TotalesPorFormaPago totales = new TotalesPorFormaPago();
+        double totalDescuentos = 0.0;
+        double totalCanceladas = 0.0;
 
         List<ReporteVentaDetalladoDto> itemList = new ArrayList<>();
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
 
         for (Venta v : ventas) {
             double ventaTotalGs = v.getTotalGs() != null ? v.getTotalGs() : 0.0;
-            totalGeneral += ventaTotalGs;
 
             // Resolver forma de pago y moneda usando la lógica del VentaResolver:
             // si la venta no tiene formaPago directo, buscar en el cobro
@@ -702,19 +823,15 @@ public class VentaGraphQL implements GraphQLQueryResolver, GraphQLMutationResolv
                 }
             }
 
-            String fpDesc = fp != null && fp.getDescripcion() != null
-                    ? fp.getDescripcion().toUpperCase() : "";
-
-            if (fpDesc.contains("EFECTIVO")) {
-                totalEfectivo += ventaTotalGs;
-            } else if (fpDesc.contains("TARJETA")) {
-                totalTarjeta += ventaTotalGs;
-            } else if (fpDesc.contains("CONVENIO")) {
-                totalConvenio += ventaTotalGs;
-            } else if (fpDesc.contains("TRANSFERENCIA")) {
-                totalTransferencia += ventaTotalGs;
+            // Las ventas canceladas se siguen listando, pero no suman al total:
+            // se acumulan aparte para mostrarlas como línea propia del resumen.
+            if (v.getEstado() == VentaEstado.CANCELADA) {
+                totalCanceladas += ventaTotalGs;
             } else {
-                totalOtros += ventaTotalGs;
+                AjustesCobro ajustes = ajustesDe(cobroDetalleList);
+                totalDescuentos += ajustes.descuento;
+                repartirPorFormaPago(cobroDetalleList, fp,
+                        ventaTotalGs - ajustes.descuento + ajustes.aumento, totales);
             }
 
             // Items de la venta (producto, presentación, cantidad, precio, costo unitario/total)
@@ -904,8 +1021,9 @@ public class VentaGraphQL implements GraphQLQueryResolver, GraphQLMutationResolv
                 filtroSucursalStr, filtroFpStr, filtroMonedaStr,
                 filtroEstadoStr, filtroClienteStr,
                 filtroModoStr, filtroConObsStr, filtroConDescStr, filtroConAumStr,
-                totalGeneral, totalEfectivo, totalTarjeta,
-                totalConvenio, totalTransferencia, totalOtros,
+                totales.general, totales.efectivo, totales.tarjeta,
+                totales.convenio, totales.transferencia, totales.otros,
+                totalDescuentos, totalCanceladas,
                 usuario);
     }
 

--- a/src/main/java/com/franco/dev/service/impresion/ImpresionService.java
+++ b/src/main/java/com/franco/dev/service/impresion/ImpresionService.java
@@ -1613,6 +1613,8 @@ public class ImpresionService {
             Double totalConvenio,
             Double totalTransferencia,
             Double totalOtros,
+            Double totalDescuentos,
+            Double totalCanceladas,
             Usuario usuario) {
         try {
             ClassPathResource resource = new ClassPathResource("reports/reporte-ventas.jrxml");
@@ -1637,6 +1639,8 @@ public class ImpresionService {
             parameters.put("filtroConDescuento", filtroConDescuento != null ? filtroConDescuento : "");
             parameters.put("filtroConAumento", filtroConAumento != null ? filtroConAumento : "");
             parameters.put("totalGeneral", totalGeneral != null ? totalGeneral : 0.0);
+            parameters.put("totalDescuentos", totalDescuentos != null ? totalDescuentos : 0.0);
+            parameters.put("totalCanceladas", totalCanceladas != null ? totalCanceladas : 0.0);
             parameters.put("totalEfectivo", totalEfectivo != null ? totalEfectivo : 0.0);
             parameters.put("totalTarjeta", totalTarjeta != null ? totalTarjeta : 0.0);
             parameters.put("totalConvenio", totalConvenio != null ? totalConvenio : 0.0);
@@ -1675,6 +1679,8 @@ public class ImpresionService {
             Double totalConvenio,
             Double totalTransferencia,
             Double totalOtros,
+            Double totalDescuentos,
+            Double totalCanceladas,
             Usuario usuario) {
         try {
             JasperReport jasperReport = compileReportFromClasspath("reports/reporte-ventas-detallado.jrxml");
@@ -1697,6 +1703,8 @@ public class ImpresionService {
             parameters.put("filtroConDescuento", filtroConDescuento != null ? filtroConDescuento : "");
             parameters.put("filtroConAumento", filtroConAumento != null ? filtroConAumento : "");
             parameters.put("totalGeneral", totalGeneral != null ? totalGeneral : 0.0);
+            parameters.put("totalDescuentos", totalDescuentos != null ? totalDescuentos : 0.0);
+            parameters.put("totalCanceladas", totalCanceladas != null ? totalCanceladas : 0.0);
             parameters.put("totalEfectivo", totalEfectivo != null ? totalEfectivo : 0.0);
             parameters.put("totalTarjeta", totalTarjeta != null ? totalTarjeta : 0.0);
             parameters.put("totalConvenio", totalConvenio != null ? totalConvenio : 0.0);

--- a/src/main/resources/reports/reporte-ventas-detallado.jrxml
+++ b/src/main/resources/reports/reporte-ventas-detallado.jrxml
@@ -42,6 +42,8 @@
 	<parameter name="totalConvenio" class="java.lang.Double"/>
 	<parameter name="totalTransferencia" class="java.lang.Double"/>
 	<parameter name="totalOtros" class="java.lang.Double"/>
+	<parameter name="totalDescuentos" class="java.lang.Double"/>
+	<parameter name="totalCanceladas" class="java.lang.Double"/>
 	<parameter name="cantidadVentas" class="java.lang.Long"/>
 	<parameter name="filtroIdVenta" class="java.lang.String"/>
 	<queryString>
@@ -340,14 +342,42 @@
 				<textFieldExpression><![CDATA[$P{totalTransferencia}]]></textFieldExpression>
 			</textField>
 			<staticText>
-				<reportElement x="590" y="113" width="110" height="12" uuid="11111111-1111-1111-1111-111111111143"/>
+				<reportElement x="590" y="101" width="110" height="12" uuid="11111111-1111-1111-1111-111111111145"/>
+				<textElement>
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Descuentos (Gs.):]]></text>
+			</staticText>
+			<textField pattern="#,###">
+				<reportElement x="704" y="101" width="86" height="12" uuid="11111111-1111-1111-1111-111111111146"/>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{totalDescuentos}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="590" y="113" width="110" height="12" uuid="11111111-1111-1111-1111-111111111147"/>
+				<textElement>
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Canceladas (Gs.):]]></text>
+			</staticText>
+			<textField pattern="#,###">
+				<reportElement x="704" y="113" width="86" height="12" uuid="11111111-1111-1111-1111-111111111148"/>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{totalCanceladas}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="590" y="129" width="110" height="12" uuid="11111111-1111-1111-1111-111111111143"/>
 				<textElement>
 					<font fontName="Verdana" size="9" isBold="true"/>
 				</textElement>
 				<text><![CDATA[TOTAL (Gs.):]]></text>
 			</staticText>
 			<textField pattern="#,###">
-				<reportElement x="704" y="113" width="86" height="12" uuid="11111111-1111-1111-1111-111111111144"/>
+				<reportElement x="704" y="129" width="86" height="12" uuid="11111111-1111-1111-1111-111111111144"/>
 				<textElement textAlignment="Right">
 					<font fontName="Verdana" size="9" isBold="true"/>
 				</textElement>

--- a/src/main/resources/reports/reporte-ventas-detallado.jrxml
+++ b/src/main/resources/reports/reporte-ventas-detallado.jrxml
@@ -70,7 +70,7 @@
 	<field name="movimientosDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
 	<field name="observacionesDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
 	<title>
-		<band height="148" splitType="Stretch">
+		<band height="158" splitType="Stretch">
 			<image hAlign="Center">
 				<reportElement x="10" y="51" width="100" height="76" uuid="11111111-1111-1111-1111-111111111101"/>
 				<imageExpression><![CDATA[$P{logo}]]></imageExpression>
@@ -83,7 +83,7 @@
 				<text><![CDATA[Reporte Detallado de Ventas]]></text>
 			</staticText>
 			<rectangle>
-				<reportElement x="120" y="32" width="449" height="100" uuid="11111111-1111-1111-1111-111111111107"/>
+				<reportElement x="120" y="32" width="449" height="114" uuid="11111111-1111-1111-1111-111111111107"/>
 				<graphicElement>
 					<pen lineColor="#808080"/>
 				</graphicElement>
@@ -257,7 +257,7 @@
 				<textFieldExpression><![CDATA[$P{filtroConAumento}]]></textFieldExpression>
 			</textField>
 			<rectangle>
-				<reportElement x="580" y="32" width="222" height="100" uuid="11111111-1111-1111-1111-111111111121"/>
+				<reportElement x="580" y="32" width="222" height="114" uuid="11111111-1111-1111-1111-111111111121"/>
 				<graphicElement>
 					<pen lineColor="#808080"/>
 				</graphicElement>

--- a/src/main/resources/reports/reporte-ventas.jrxml
+++ b/src/main/resources/reports/reporte-ventas.jrxml
@@ -37,7 +37,7 @@
 	<field name="estado" class="java.lang.String"/>
 	<field name="totalGs" class="java.lang.Double"/>
 	<title>
-		<band height="148" splitType="Stretch">
+		<band height="158" splitType="Stretch">
 			<image hAlign="Center">
 				<reportElement x="10" y="51" width="100" height="76" uuid="11111111-1111-1111-1111-111111111101"/>
 				<imageExpression><![CDATA[$P{logo}]]></imageExpression>
@@ -50,7 +50,7 @@
 				<text><![CDATA[Reporte de Ventas]]></text>
 			</staticText>
 			<rectangle>
-				<reportElement x="120" y="32" width="449" height="100" uuid="11111111-1111-1111-1111-111111111107">
+				<reportElement x="120" y="32" width="449" height="114" uuid="11111111-1111-1111-1111-111111111107">
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 				</reportElement>
@@ -269,7 +269,7 @@
 				<textFieldExpression><![CDATA[$P{filtroConAumento}]]></textFieldExpression>
 			</textField>
 			<rectangle>
-				<reportElement x="580" y="32" width="222" height="100" uuid="11111111-1111-1111-1111-111111111121"/>
+				<reportElement x="580" y="32" width="222" height="114" uuid="11111111-1111-1111-1111-111111111121"/>
 				<graphicElement>
 					<pen lineColor="#808080"/>
 				</graphicElement>

--- a/src/main/resources/reports/reporte-ventas.jrxml
+++ b/src/main/resources/reports/reporte-ventas.jrxml
@@ -21,6 +21,8 @@
 	<parameter name="totalConvenio" class="java.lang.Double"/>
 	<parameter name="totalTransferencia" class="java.lang.Double"/>
 	<parameter name="totalOtros" class="java.lang.Double"/>
+	<parameter name="totalDescuentos" class="java.lang.Double"/>
+	<parameter name="totalCanceladas" class="java.lang.Double"/>
 	<parameter name="cantidadVentas" class="java.lang.Long"/>
 	<parameter name="filtroIdVenta" class="java.lang.String"/>
 	<queryString>
@@ -377,7 +379,35 @@
 				<textFieldExpression><![CDATA[$P{totalTransferencia}]]></textFieldExpression>
 			</textField>
 			<staticText>
-				<reportElement x="590" y="113" width="110" height="12" uuid="11111111-1111-1111-1111-111111111143">
+				<reportElement x="590" y="101" width="110" height="12" uuid="11111111-1111-1111-1111-111111111145"/>
+				<textElement>
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Descuentos (Gs.):]]></text>
+			</staticText>
+			<textField pattern="#,###">
+				<reportElement x="704" y="101" width="86" height="12" uuid="11111111-1111-1111-1111-111111111146"/>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{totalDescuentos}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="590" y="113" width="110" height="12" uuid="11111111-1111-1111-1111-111111111147"/>
+				<textElement>
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<text><![CDATA[Canceladas (Gs.):]]></text>
+			</staticText>
+			<textField pattern="#,###">
+				<reportElement x="704" y="113" width="86" height="12" uuid="11111111-1111-1111-1111-111111111148"/>
+				<textElement textAlignment="Right">
+					<font fontName="Verdana" size="9"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{totalCanceladas}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="590" y="129" width="110" height="12" uuid="11111111-1111-1111-1111-111111111143">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 				</reportElement>
@@ -387,7 +417,7 @@
 				<text><![CDATA[TOTAL (Gs.):]]></text>
 			</staticText>
 			<textField pattern="#,###">
-				<reportElement x="704" y="113" width="86" height="12" uuid="11111111-1111-1111-1111-111111111144">
+				<reportElement x="704" y="129" width="86" height="12" uuid="11111111-1111-1111-1111-111111111144">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 				</reportElement>

--- a/src/test/java/com/franco/dev/graphql/operaciones/VentaGraphQLTotalesTest.java
+++ b/src/test/java/com/franco/dev/graphql/operaciones/VentaGraphQLTotalesTest.java
@@ -1,0 +1,150 @@
+package com.franco.dev.graphql.operaciones;
+
+import com.franco.dev.domain.financiero.FormaPago;
+import com.franco.dev.domain.operaciones.CobroDetalle;
+import com.franco.dev.graphql.operaciones.VentaGraphQL.AjustesCobro;
+import com.franco.dev.graphql.operaciones.VentaGraphQL.TotalesPorFormaPago;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Cubre el calculo de totales del resumen de los reportes de ventas
+ * (generic-list-venta, normal y detallado).
+ */
+class VentaGraphQLTotalesTest {
+
+    private static final double DELTA = 0.001;
+
+    private static FormaPago formaPago(String descripcion) {
+        FormaPago fp = new FormaPago();
+        fp.setDescripcion(descripcion);
+        return fp;
+    }
+
+    private static CobroDetalle detalle(String tipo, String formaPago, Double valor, Double cambio) {
+        CobroDetalle cd = new CobroDetalle();
+        cd.setPago("PAGO".equals(tipo));
+        cd.setVuelto("VUELTO".equals(tipo));
+        cd.setDescuento("DESCUENTO".equals(tipo));
+        cd.setAumento("AUMENTO".equals(tipo));
+        cd.setFormaPago(formaPago(formaPago));
+        cd.setValor(valor);
+        cd.setCambio(cambio);
+        return cd;
+    }
+
+    @Test
+    @DisplayName("El descuento se toma del movimiento de cobro, no del total de la venta")
+    void descuentoSaleDeLosMovimientos() {
+        // Venta real 48479: total_gs 5500, descuento 500, cobrado 5000.
+        List<CobroDetalle> detalles = Arrays.asList(
+                detalle("PAGO", "EFECTIVO", 5000.0, 1.0),
+                detalle("DESCUENTO", "EFECTIVO", 500.0, 1.0));
+
+        AjustesCobro ajustes = VentaGraphQL.ajustesDe(detalles);
+
+        assertEquals(500.0, ajustes.descuento, DELTA);
+        assertEquals(0.0, ajustes.aumento, DELTA);
+
+        TotalesPorFormaPago totales = new TotalesPorFormaPago();
+        VentaGraphQL.repartirPorFormaPago(detalles, formaPago("EFECTIVO"),
+                5500.0 - ajustes.descuento + ajustes.aumento, totales);
+
+        assertEquals(5000.0, totales.general, DELTA);
+        assertEquals(5000.0, totales.efectivo, DELTA);
+    }
+
+    @Test
+    @DisplayName("El aumento suma al neto de la venta")
+    void aumentoSumaAlNeto() {
+        // Venta real 60247: total_gs 6000, aumento 250, cobrado 6250.
+        List<CobroDetalle> detalles = Arrays.asList(
+                detalle("PAGO", "EFECTIVO", 6250.0, 1.0),
+                detalle("AUMENTO", "EFECTIVO", 250.0, 1.0));
+
+        AjustesCobro ajustes = VentaGraphQL.ajustesDe(detalles);
+        assertEquals(250.0, ajustes.aumento, DELTA);
+
+        TotalesPorFormaPago totales = new TotalesPorFormaPago();
+        VentaGraphQL.repartirPorFormaPago(detalles, formaPago("EFECTIVO"),
+                6000.0 - ajustes.descuento + ajustes.aumento, totales);
+
+        assertEquals(6250.0, totales.general, DELTA);
+    }
+
+    @Test
+    @DisplayName("Un cobro con movimientos duplicados no infla el total")
+    void movimientosDuplicadosNoInflanElTotal() {
+        // Venta real 262022/sucursal 8: total_gs 83000 con dos juegos de
+        // movimientos sobre el mismo cobro. Sumar los pagos daria 161000.
+        List<CobroDetalle> detalles = Arrays.asList(
+                detalle("PAGO", "EFECTIVO", 100000.0, 1.0),
+                detalle("VUELTO", "EFECTIVO", -7000.0, 1.0),
+                detalle("PAGO", "EFECTIVO", 100000.0, null),
+                detalle("VUELTO", "EFECTIVO", -32000.0, null));
+
+        AjustesCobro ajustes = VentaGraphQL.ajustesDe(detalles);
+        TotalesPorFormaPago totales = new TotalesPorFormaPago();
+        VentaGraphQL.repartirPorFormaPago(detalles, formaPago("EFECTIVO"),
+                83000.0 - ajustes.descuento + ajustes.aumento, totales);
+
+        assertEquals(83000.0, totales.general, DELTA);
+        assertEquals(83000.0, totales.efectivo, DELTA);
+    }
+
+    @Test
+    @DisplayName("Una venta mixta reparte el neto entre cada forma de pago")
+    void ventaMixtaSeReparte() {
+        List<CobroDetalle> detalles = Arrays.asList(
+                detalle("PAGO", "EFECTIVO", 30000.0, 1.0),
+                detalle("PAGO", "TARJETA", 70000.0, 1.0));
+
+        TotalesPorFormaPago totales = new TotalesPorFormaPago();
+        VentaGraphQL.repartirPorFormaPago(detalles, formaPago("EFECTIVO"), 100000.0, totales);
+
+        assertEquals(100000.0, totales.general, DELTA);
+        assertEquals(30000.0, totales.efectivo, DELTA);
+        assertEquals(70000.0, totales.tarjeta, DELTA);
+        // El reparto tiene que cerrar exactamente contra el total.
+        assertEquals(totales.general,
+                totales.efectivo + totales.tarjeta + totales.convenio
+                        + totales.transferencia + totales.otros, DELTA);
+    }
+
+    @Test
+    @DisplayName("El valor en moneda extranjera se convierte con su cambio")
+    void monedaExtranjeraUsaElCambio() {
+        List<CobroDetalle> detalles = Collections.singletonList(
+                detalle("DESCUENTO", "EFECTIVO", 10.0, 7500.0));
+
+        assertEquals(75000.0, VentaGraphQL.ajustesDe(detalles).descuento, DELTA);
+    }
+
+    @Test
+    @DisplayName("Sin movimientos de cobro el neto va a la forma de pago de la venta")
+    void sinMovimientosUsaLaFormaPagoDeLaVenta() {
+        TotalesPorFormaPago totales = new TotalesPorFormaPago();
+        VentaGraphQL.repartirPorFormaPago(null, formaPago("CONVENIO"), 12000.0, totales);
+
+        assertEquals(12000.0, totales.general, DELTA);
+        assertEquals(12000.0, totales.convenio, DELTA);
+    }
+
+    @Test
+    @DisplayName("Una forma de pago desconocida cae en Otros")
+    void formaPagoDesconocidaVaAOtros() {
+        TotalesPorFormaPago totales = new TotalesPorFormaPago();
+        VentaGraphQL.repartirPorFormaPago(
+                Collections.singletonList(detalle("PAGO", "CHEQUE", 5000.0, 1.0)),
+                formaPago("CHEQUE"), 5000.0, totales);
+
+        assertEquals(5000.0, totales.general, DELTA);
+        assertEquals(5000.0, totales.otros, DELTA);
+    }
+}


### PR DESCRIPTION
## Qué resuelve

El `TOTAL (Gs.)` del resumen general de los reportes de `generic-list-venta` (normal y detallado) venía inflado respecto de lo realmente cobrado, por dos motivos:

1. **Incluía las ventas canceladas.** El acumulador recorría todas las ventas devueltas por el filtro sin mirar `estado`, así que una venta listada como `CANCELADA` igual sumaba al total y a los subtotales por forma de pago.
2. **No descontaba los descuentos.** `venta.totalGs` se guarda bruto (suma de `cantidad * precio` de los ítems); el descuento se aplica solo en `cobro.totalGs`, nunca en `venta.totalGs`.

Medido sobre `bodega`, el total quedaba inflado ~0,8% mensual:

| Mes | TOTAL viejo | TOTAL nuevo | Descuentos | Canceladas |
|---|---|---|---|---|
| ene 2026 | 6.224.028.808 | 6.177.927.787 | 23.114.875 | 24.468.621 |
| feb 2026 | 5.554.967.395 | 5.507.683.049 | 25.787.039 | 23.028.915 |
| mar 2026 | 6.184.846.949 | 6.132.707.812 | 27.427.591 | 26.519.940 |
| abr 2026 | 4.472.241.834 | 4.429.694.061 | 20.136.589 | 23.417.506 |

De paso se corrigió un tercer problema del mismo bloque: los subtotales por forma de pago imputaban el total **entero** de la venta a la forma de pago del *primer* movimiento de cobro, así que una venta mixta (parte efectivo, parte tarjeta) caía completa en una sola columna.

## Qué cambia

- Las ventas `CANCELADA` **se siguen listando** con su estado, pero ya no suman al total ni a los subtotales. Se acumulan aparte.
- El total pasa a ser el neto: `totalGs − descuentos + aumentos`, tomados de los movimientos de cobro.
- Cada movimiento de cobro suma a su propia forma de pago, en proporción a lo pagado con cada una.
- El resumen suma dos líneas nuevas: **Descuentos (Gs.)** y **Canceladas (Gs.)**.
- Los recuadros del encabezado y la banda del título crecen para que el `TOTAL (Gs.)` quede dentro del cuadro del resumen.

## Decisión de diseño: por qué el neto no se calcula sumando los PAGOS

La primera implementación reconstruía el neto sumando los movimientos `PAGO`/`VUELTO`, que es lo intuitivo. **No cierra contra los datos reales.**

Hay cobros que quedaron con **dos juegos completos de movimientos sobre el mismo `cobro_id`**, como si se hubiera recobrado encima. Ejemplo, venta 262022 / sucursal 8, `total_gs = 83.000`:

| detalle | tipo | valor | cambio | creado |
|---|---|---|---|---|
| 327156 | pago | 100.000 | *(nulo)* | 21:15:03 |
| 327157 | vuelto | −32.000 | *(nulo)* | 21:15:03 |
| 327154 | pago | 100.000 | 1 | 22:08:46 |
| 327155 | vuelto | −7.000 | 1 | 22:08:46 |

Sumar los pagos daría **161.000** para una venta de 83.000. No es un artefacto de la consulta (el join va por `cobro_id` **y** `sucursal_id`) ni es histórico: afecta al **5-6% de las ventas, todos los meses, de forma sostenida**.

Por eso el neto se ancla en `venta.totalGs` —un único valor por venta, inmune a movimientos duplicados— y solo se usa `cobro_detalle` para el ajuste de descuento y aumento, que son un único movimiento por cobro en más del **99,8%** de los casos. Sobre el 94% de ventas limpias ambas fórmulas dan idéntico; en el 6% problemático solo esta da bien.

El reparto por forma de pago sí usa las proporciones de los movimientos, pero el monto repartido es siempre el neto de la venta: un cobro duplicado puede desviar el reparto entre columnas, nunca el total.

## Cómo probarlo

1. Levantar el central: `./mvnw -o spring-boot:run -DskipFlyway=true` (8081).
2. En el desktop, **Operaciones → Ventas**, filtrar un rango con canceladas y descuentos (ej. sucursal 8, 2026-04-01 a 2026-04-30).
3. Generar los dos reportes, normal y detallado.

Esperado: dos líneas nuevas **Descuentos (Gs.)** y **Canceladas (Gs.)** entre "Transferencia" y el TOTAL; el TOTAL más bajo que antes; las canceladas siguen apareciendo en el listado; en ventas mixtas el importe repartido entre columnas.

## Verificación

- `./mvnw clean verify -B -DskipFlyway=true` → **96/96 tests, BUILD SUCCESS**.
- Test nuevo `VentaGraphQLTotalesTest` (7 casos), incluido el de movimientos duplicados con los valores reales de la venta 262022.
- Ambos `.jrxml` compilan y llenan con JasperReports (24 parámetros, antes 22); se renderizaron a PDF y se revisó visualmente el cuadro del resumen.

## Impacto

- **DB:** ninguno. Sin migraciones.
- **Schema GraphQL:** sin cambios. La firma de `reporteGenericVentas` / `reporteGenericVentasDetallado` no se toca, así que el desktop y el mobile no requieren coordinación.
- **Filial:** no aplica, estos reportes solo existen en el central.
- **Rollback:** trivial, revertir el merge. No hay estado persistido que deshacer.
- **Riesgo:** bajo en lo técnico. Lo que sí conviene comunicar es que **el TOTAL de los reportes va a bajar ~0,8%** respecto de lo que venía saliendo, porque el número anterior estaba inflado.

## Fuera de alcance (para seguir aparte)

Los cobros con movimientos duplicados son un problema de datos **activo**. Este PR hace que los reportes sean inmunes, pero cualquier otra pantalla o consulta que sume `cobro_detalle` está contando de más.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
