### PR TITLE
fix(replicacion): movimiento_stock baja del central a la filial

### DIFF
--- a/src/main/resources/db/migration/V161.3__replicar_movimiento_stock_central_a_filial.sql
+++ b/src/main/resources/db/migration/V161.3__replicar_movimiento_stock_central_a_filial.sql
@@ -1,0 +1,75 @@
+-- operaciones.movimiento_stock pasa a bajar del central a la filial, igual que ya lo hace su tabla
+-- hija operaciones.movimiento_stock_lote.
+--
+-- ============================================================================
+-- QUE ESTABA MAL
+-- ============================================================================
+-- V113 activo replicate_central_to_branch_with_filter para una lista explicita de 5 tablas
+-- (factura_legal, factura_legal_item, venta, venta_item, stock_por_producto_sucursal).
+-- operaciones.movimiento_stock quedo afuera de esa lista.
+--
+-- V154.3 registro la tabla hija movimiento_stock_lote con el flag en true, afirmando en su
+-- comentario que copiaba "exactamente la misma configuracion que operaciones.movimiento_stock".
+-- Esa premisa era falsa: el padre tiene el flag en false. Quedaron en regimenes distintos.
+--
+-- Consecuencia: el desglose por lote baja a la filial pero el movimiento agregado que lo origino
+-- no. Como los apply workers de replicacion logica corren con session_replication_role = 'replica',
+-- la FK fk_msl_movimiento no se dispara y las filas hijas entran igual, sin padre.
+--
+-- Medido en el par bodega3 (central) / general6 (filial 24) al 2026-08-12:
+--   - 7 filas de movimiento_stock_lote huerfanas en la filial.
+--   - existencia divergente: HALLS CEREZA suc 24 = 113 en el central y 14 en la filial.
+--   - "sin trazar" negativo en la filial (existencia - suma de lotes), o sea el ledger por lote
+--     afirmando mas mercaderia de la que el agregado reconoce.
+--   - 43 filas de desglose de origen central repartidas en 9 sucursales, con el mismo problema.
+--
+-- ============================================================================
+-- POR QUE SE ARREGLA DEL LADO DEL PADRE Y NO DEL HIJO
+-- ============================================================================
+-- La tentacion es la inversa: apagar el flag del hijo para que siga al padre. Rompe la filial.
+--
+-- El ledger por lote de la filial se compone SOLO de dos cosas: las entradas que bajan del central
+-- (compras y transferencias) y las salidas de sus propias ventas. No existe una sola entrada de
+-- origen local. En general6 al 2026-08-12: 7 filas positivas, todas bajadas del central, contra 26
+-- filas negativas de venta.
+--
+-- LoteFefoService lee esa tabla en el momento de la venta. Sin las entradas del central no encuentra
+-- lotes y todas las ventas caen al bucket SIN LOTE: hoy 24 de las 26 ventas de la filial estan
+-- atribuidas a un lote real, y pasarian a cero. Se perderia la trazabilidad en el punto de venta,
+-- que es para lo que existe el control de lote.
+--
+-- Padre e hijo se consumen distinto: la filial no calcula el agregado localmente, pero si resuelve
+-- FEFO localmente. Por eso el hijo tiene que bajar, y por eso el padre tiene que acompanarlo.
+--
+-- ============================================================================
+-- QUE PASA AL APLICARLA
+-- ============================================================================
+-- ReplicationPublicationSyncScheduler (cada hora, replication.sync.enabled=true en produccion)
+-- llama a LogicalReplicationService.syncPublicationsWithReplicationTable, que:
+--   - paso 2: agrega operaciones.movimiento_stock a cada central_<db>_filialN_pub con
+--     WHERE (sucursal_id = N).
+--   - paso 4: refresca las suscripciones para que la filial recoja la tabla nueva.
+-- No hay que tocar publicaciones a mano.
+--
+-- Riesgos evaluados, todos descartados:
+--   - REPLICA IDENTITY: movimiento_stock ya esta en 'f'. ensureReplicaIdentityFull no cambia nada y
+--     no hay costo nuevo de escritura.
+--   - Eco entre las dos direcciones: PostgreSQL 18.4 con origin = 'none' en las suscripciones. El
+--     mismo patron bidireccional ya corre para operaciones.venta, con 6,3 M de filas.
+--   - Volumen: el filtro WHERE sucursal_id = N acota cada filial a su propia sucursal.
+--
+-- Orden de despliegue: a diferencia de V154.3, no hay riesgo de romper un subscriber por tabla
+-- inexistente. movimiento_stock es tabla core y existe en todas las filiales desde siempre.
+--
+-- ============================================================================
+-- LO QUE ESTA MIGRACION NO HACE
+-- ============================================================================
+-- El REFRESH PUBLICATION usa copy_data = false, asi que nada historico baja. Las filas que ya
+-- faltan en cada filial siguen faltando (6.245 en la sucursal 24 al momento de escribir esto) y las
+-- huerfanas ya bajadas siguen sin padre. Corregir solo de aca en adelante fue una decision
+-- explicita: lo que importa es que el desvio deje de crecer. Un backfill, si se decide, va como
+-- script aparte contra cada base de filial, no como migracion de este repo.
+
+UPDATE configuraciones.replication_table
+SET replicate_central_to_branch_with_filter = true
+WHERE table_name = 'operaciones.movimiento_stock';


### PR DESCRIPTION
## Qué resuelve

`operaciones.movimiento_stock` pasa a bajar del central a la filial, igual que ya lo hace su tabla hija `operaciones.movimiento_stock_lote`.

V113 activó `replicate_central_to_branch_with_filter` para una lista explícita de 5 tablas y `operaciones.movimiento_stock` quedó afuera. V154.3 registró la tabla hija `movimiento_stock_lote` con el flag en true, afirmando en su comentario que copiaba "exactamente la misma configuración que `operaciones.movimiento_stock`". La premisa era falsa: el padre tenía el flag en false. Quedaron en regímenes distintos — el desglose por lote baja a la filial y el movimiento agregado que lo originó no.

Los apply workers de replicación lógica corren con `session_replication_role = 'replica'`, así que la FK `fk_msl_movimiento` no se dispara y las filas hijas entran igual, sin padre.

Medido en el par bodega3 / general6 (filial 24) al 2026-08-12:

- 7 filas de `movimiento_stock_lote` huérfanas en la filial.
- Existencia divergente: HALLS CEREZA suc 24 = 113 en el central y 14 en la filial.
- "Sin trazar" negativo en la filial: el ledger por lote afirmando más mercadería de la que el agregado reconoce.
- 43 filas de desglose de origen central repartidas en 9 sucursales, con el mismo problema.

### Por qué del lado del padre y no apagando el flag del hijo

La tentación es la inversa, y rompe la filial. El ledger por lote de la filial se compone solo de entradas que bajan del central y salidas de sus propias ventas: no existe una sola entrada de origen local. `LoteFefoService` lee esa tabla al vender, así que cortar la bajada mandaría todas las ventas al bucket SIN LOTE — hoy 24 de 26 están atribuidas a un lote real. Padre e hijo se consumen distinto: la filial no calcula el agregado localmente, pero sí resuelve FEFO localmente.

## Cómo probarlo

```bash
./mvnw clean verify -B -DskipFlyway=true
```

En un par central/filial de prueba:

1. Aplicar la migración en el central.
2. Esperar a `ReplicationPublicationSyncScheduler` (corre cada hora con `replication.sync.enabled=true`) o invocar `LogicalReplicationService.syncPublicationsWithReplicationTable` a mano.
3. Verificar que `operaciones.movimiento_stock` aparece en cada `central_<db>_filialN_pub` con `WHERE (sucursal_id = N)`.
4. Generar un movimiento en el central para esa sucursal y verificar que baja con su desglose por lote, ahora con padre.

No hay que tocar publicaciones a mano.

## Impacto en DB

Migración `V161.3__replicar_movimiento_stock_central_a_filial.sql`. Es un solo `UPDATE` sobre `configuraciones.replication_table`: no crea, altera ni borra ninguna tabla. Idempotente.

Riesgos evaluados y descartados, documentados en el encabezado del propio SQL:

- **REPLICA IDENTITY:** `movimiento_stock` ya está en `'f'`. No hay costo nuevo de escritura.
- **Eco entre las dos direcciones:** PostgreSQL 18.4 con `origin = 'none'` en las suscripciones, el mismo patrón bidireccional que ya corre para `operaciones.venta` con 6,3 M de filas.
- **Volumen:** el filtro `WHERE sucursal_id = N` acota cada filial a su propia sucursal.
- **Orden de despliegue:** a diferencia de V154.3, no hay riesgo de romper un subscriber por tabla inexistente — `movimiento_stock` es tabla core y existe en todas las filiales desde siempre.

**Lo que NO hace:** el `REFRESH PUBLICATION` usa `copy_data = false`, así que nada histórico baja. Las filas que ya faltan en cada filial siguen faltando (6.245 en la sucursal 24) y las huérfanas ya bajadas siguen sin padre. Corregir solo de acá en adelante fue una decisión explícita: lo que importa es que el desvío deje de crecer. Un backfill, si se decide, va como script aparte contra cada base de filial, no como migración de este repo.

### Nota sobre la numeración

El commit original creaba `V160.3`. Ese número ya está tomado en `develop` por `V160.3__add_intentos_a_notificacion_envio_log.sql`: la rama salió de un `develop` anterior a ese merge y dos migraciones con la misma versión hacen fallar a Flyway al arrancar. Se renumeró a `V161.3`, el siguiente libre del carril, verificado contra `develop` y contra todas las ramas remotas abiertas. El contenido del SQL no cambió.

## Impacto en rollback

Volver a la versión anterior del JAR **no revierte la migración** (Flyway no hace down migrations). El efecto persistente es que la tabla queda marcada para replicar. Para revertir hace falta el `UPDATE` inverso a `false` más un refresh de las publicaciones.

Dicho eso, el estado "revertido" es justamente el que produce las filas huérfanas descritas arriba, así que revertir reintroduce el bug en vez de arreglar algo.

## Riesgo

**Medio.** El cambio en sí es un `UPDATE` de una fila de configuración y no toca código de aplicación, pero modifica la topología de replicación en producción, que es infraestructura compartida. Los tres riesgos habituales (replica identity, eco, volumen) están evaluados arriba con el estado real medido. Conviene desplegarlo cuando se pueda observar el primer ciclo del scheduler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
