### PR TITLE
fix(devolucion): costo declarado en la nota de credito y remito sin "null"

### DIFF
--- a/src/main/java/com/franco/dev/service/impresion/RemitoRetiroService.java
+++ b/src/main/java/com/franco/dev/service/impresion/RemitoRetiroService.java
@@ -82,10 +82,12 @@ public class RemitoRetiroService {
             List<DevolucionItem> items = devolucionItemService.findByDevolucionId(id);
             for (DevolucionItem item : items) {
                 Presentacion pres = item.getPresentacion();
-                String codigo = null;
+                // Vacio (no "null") cuando la presentacion no tiene codigo principal:
+                // el remito lo firma el proveedor.
+                String codigo = "";
                 if (pres != null && pres.getId() != null) {
                     Codigo cod = codigoService.findPrincipalByPresentacionId(pres.getId());
-                    if (cod != null) codigo = cod.getCodigo();
+                    if (cod != null && cod.getCodigo() != null) codigo = cod.getCodigo();
                 }
                 RemitoRetiroFilaDto fila = new RemitoRetiroFilaDto();
                 fila.setSucursal(sucNombre);

--- a/src/main/java/com/franco/dev/service/operaciones/NotaCreditoDevolucionService.java
+++ b/src/main/java/com/franco/dev/service/operaciones/NotaCreditoDevolucionService.java
@@ -81,6 +81,15 @@ public class NotaCreditoDevolucionService {
         return 0.0;
     }
 
+    /**
+     * Costo por unidad base a partir del valor declarado en los items de la
+     * devolucion. Fallback para productos sin CostoPorProducto.
+     */
+    private double costoDeclaradoBase(Double valorDeclarado, double cantidadBase) {
+        if (valorDeclarado == null || valorDeclarado <= 0.0 || cantidadBase <= 0.0) return 0.0;
+        return valorDeclarado / cantidadBase;
+    }
+
     private double factor(DevolucionItem item) {
         if (item.getPresentacion() != null && item.getPresentacion().getCantidad() != null) {
             return item.getPresentacion().getCantidad();
@@ -103,12 +112,18 @@ public class NotaCreditoDevolucionService {
         List<Devolucion> devoluciones = devolucionService.findByRetiroId(retiroId);
         // productoId -> cantidad base acumulada
         Map<Long, Double> cantidadPorProducto = new LinkedHashMap<>();
+        // productoId -> valor declarado acumulado (cantidad * costo cargado en el item)
+        Map<Long, Double> valorDeclaradoPorProducto = new LinkedHashMap<>();
         for (Devolucion d : devoluciones) {
             for (DevolucionItem item : devolucionItemService.findByDevolucionId(d.getId())) {
                 Long prodId = item.getProducto() != null ? item.getProducto().getId() : null;
                 if (prodId == null) continue;
-                double cantidadBase = (item.getCantidad() != null ? item.getCantidad() : 0.0) * factor(item);
+                double cantidad = item.getCantidad() != null ? item.getCantidad() : 0.0;
+                double cantidadBase = cantidad * factor(item);
                 cantidadPorProducto.merge(prodId, cantidadBase, Double::sum);
+                if (item.getCostoUnitario() != null && item.getCostoUnitario() > 0.0) {
+                    valorDeclaradoPorProducto.merge(prodId, cantidad * item.getCostoUnitario(), Double::sum);
+                }
             }
         }
 
@@ -117,7 +132,12 @@ public class NotaCreditoDevolucionService {
         for (Map.Entry<Long, Double> e : cantidadPorProducto.entrySet()) {
             Long prodId = e.getKey();
             double cantidadBase = e.getValue();
+            // Sin CostoPorProducto la linea salia en 0 y el operador tenia que
+            // retipear el costo: se usa entonces el declarado en los items.
             double costoMedio = costoMedioBase(prodId);
+            if (costoMedio <= 0.0) {
+                costoMedio = costoDeclaradoBase(valorDeclaradoPorProducto.get(prodId), cantidadBase);
+            }
             double total = cantidadBase * costoMedio;
             montoTotal += total;
 


### PR DESCRIPTION
Dos fixes al modulo de Devoluciones salidos del testing del MVP contra
`central-alpha`.

## Que resuelve

**1. La nota de credito ignoraba el costo cargado en el item** (`NotaCreditoDevolucionService`)

El preview de acreditacion valorizaba unicamente con `CostoPorProducto`. Los
productos sin ese registro salian con costo `0`, y el operador tenia que
retipear el costo linea por linea — con el riesgo de confirmar la NC en 0 si no
lo notaba. Verificado en alpha: cargue costo 500 y 1000 en los items y el
dialogo mostro 0 en ambas lineas.

Ahora, cuando no hay costo medio, se usa el costo unitario declarado en los
items de la devolucion, ponderado por cantidad y llevado a unidad base.
`CostoPorProducto` sigue teniendo prioridad cuando existe.

**2. El remito imprimia el literal `null`** (`RemitoRetiroService`)

Las presentaciones sin codigo principal salian con `null` en la columna Codigo
del comprobante de retiro — el papel que firma el proveedor. Es el mismo
tratamiento que ya tenia el vencimiento en ese servicio: cadena vacia.

## Como probarlo

1. Devolucion CON_PROVEEDOR con un producto **sin** `CostoPorProducto`, cargando
   costo unitario a mano en el item.
2. Separar -> retirar -> `Registrar credito` en el historico de retiros.
3. La linea debe traer el costo cargado, no 0.
4. Imprimir el `Remito` del retiro con un producto sin codigo principal: la
   columna Codigo debe quedar vacia, no decir `null`.

## Impacto en DB

Ninguno. Sin migraciones, sin cambios de schema.

## Riesgo

**Bajo.** Los dos cambios son de presentacion/calculo dentro del modulo de
devoluciones, no tocan stock ni estados. El fallback de costo solo actua cuando
hoy el valor seria `0`, asi que no puede empeorar un caso que hoy funciona.

## Rollback

Revertir el merge. No deja datos que haya que limpiar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
