### PR TITLE
fix(rrhh): leer plantillas jasper como stream del classpath

### DIFF
--- a/src/main/java/com/franco/dev/service/rrhh/ReciboLiquidacionService.java
+++ b/src/main/java/com/franco/dev/service/rrhh/ReciboLiquidacionService.java
@@ -19,11 +19,11 @@ import net.sf.jasperreports.engine.JasperFillManager;
 import net.sf.jasperreports.engine.JasperPrint;
 import net.sf.jasperreports.engine.JasperReport;
 import net.sf.jasperreports.engine.data.JRBeanCollectionDataSource;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.ResourceUtils;
 
-import java.io.File;
+import java.io.InputStream;
 import java.math.BigDecimal;
 import java.text.DecimalFormat;
 import java.time.LocalDate;
@@ -115,9 +115,8 @@ public class ReciboLiquidacionService {
         params.put("totalNeto", formatear(liq.getTotalNeto()));
         params.put("montoEnLetras", enLetras(liq.getTotalNeto()));
 
-        try {
-            File file = ResourceUtils.getFile("classpath:reports/recibo-liquidacion.jrxml");
-            JasperReport jasperReport = JasperCompileManager.compileReport(file.getAbsolutePath());
+        try (InputStream jrxmlStream = new ClassPathResource("reports/recibo-liquidacion.jrxml").getInputStream()) {
+            JasperReport jasperReport = JasperCompileManager.compileReport(jrxmlStream);
             JRBeanCollectionDataSource dataSource = new JRBeanCollectionDataSource(filas);
             JasperPrint jasperPrint = JasperFillManager.fillReport(jasperReport, params, dataSource);
             byte[] pdfBytes = JasperExportManager.exportReportToPdf(jasperPrint);
@@ -167,9 +166,8 @@ public class ReciboLiquidacionService {
         params.put("totalEnLetras", enLetras(neto));
 
         String tpl = anchoMm >= 80 ? "reports/recibo-ticket-80.jrxml" : "reports/recibo-ticket-58.jrxml";
-        try {
-            File file = ResourceUtils.getFile("classpath:" + tpl);
-            JasperReport jasperReport = JasperCompileManager.compileReport(file.getAbsolutePath());
+        try (InputStream jrxmlStream = new ClassPathResource(tpl).getInputStream()) {
+            JasperReport jasperReport = JasperCompileManager.compileReport(jrxmlStream);
             JRBeanCollectionDataSource dataSource = new JRBeanCollectionDataSource(filas);
             JasperPrint jasperPrint = JasperFillManager.fillReport(jasperReport, params, dataSource);
             byte[] pdfBytes = JasperExportManager.exportReportToPdf(jasperPrint);

--- a/src/main/java/com/franco/dev/service/rrhh/ReporteRrhhService.java
+++ b/src/main/java/com/franco/dev/service/rrhh/ReporteRrhhService.java
@@ -13,11 +13,11 @@ import net.sf.jasperreports.engine.JasperFillManager;
 import net.sf.jasperreports.engine.JasperPrint;
 import net.sf.jasperreports.engine.JasperReport;
 import net.sf.jasperreports.engine.data.JRBeanCollectionDataSource;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.ResourceUtils;
 
-import java.io.File;
+import java.io.InputStream;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
@@ -416,9 +416,8 @@ public class ReporteRrhhService {
     }
 
     private String generar(String classpathReport, Map<String, Object> params, List<?> filas) {
-        try {
-            File file = ResourceUtils.getFile("classpath:" + classpathReport);
-            JasperReport jasperReport = JasperCompileManager.compileReport(file.getAbsolutePath());
+        try (InputStream jrxmlStream = new ClassPathResource(classpathReport).getInputStream()) {
+            JasperReport jasperReport = JasperCompileManager.compileReport(jrxmlStream);
             JRBeanCollectionDataSource dataSource = new JRBeanCollectionDataSource(filas);
             JasperPrint jasperPrint = JasperFillManager.fillReport(jasperReport, params, dataSource);
             byte[] pdfBytes = JasperExportManager.exportReportToPdf(jasperPrint);


### PR DESCRIPTION
## Que resuelve

Todos los reportes de RRHH fallaban en cualquier instancia empaquetada (alpha, farmacia y bodega por igual) con:

```
Error generando el reporte: class path resource [reports/recibo-rrhh.jrxml] cannot be resolved
to absolute file path because it does not reside in the file system:
jar:file:/opt/frc-backend-central/releases/4.7.0-alpha.40/frc-central-server.jar!/BOOT-INF/classes!/reports/recibo-rrhh.jrxml
```

**No faltaban los `.jrxml`** — se verifico el JAR y estan los 30. El bug era el modo de lectura: `ResourceUtils.getFile("classpath:...")` + `compileReport(file.getAbsolutePath())` solo resuelve con clases explotadas en disco (dev con `spring-boot:run`). Dentro de un JAR no hay ruta de filesystem, y `ResourceUtils` tira `FileNotFoundException`. Por eso nunca se vio en desarrollo.

El resto del repo ya habia migrado a este patron (`ImpresionService.compileReportFromClasspath`, `FacturaLegalGraphQL`, `ConstanciaRecepcionPrintService`, `InventarioProductoItemGraphQL`); RRHH quedo afuera.

## Cambios

3 call sites, todos en `service/rrhh`, pasados a `ClassPathResource().getInputStream()` + `compileReport(InputStream)` con try-with-resources:

| Archivo | Plantillas que destraba |
|---|---|
| `ReporteRrhhService.generar()` | `recibo-rrhh`, `recibo-ticket-58/80`, `nomina-mes`, `resumen-ips`, `recibo-finiquito`, `reporte-rrhh-generico` |
| `ReciboLiquidacionService.generarBase64()` | `recibo-liquidacion` |
| `ReciboLiquidacionService.generarTicket()` | `recibo-ticket-58/80` |

Ninguna de esas plantillas usa subreportes ni `imageExpression` con ruta, asi que perder el directorio base del template no tiene efecto.

Barrido del repo completo (`ResourceUtils.getFile`, `.getFile()` sobre recursos, `getResource().getPath()/.toURI()`, `new File("classpath...")`, `compileReport`/`fillReport`/`JRLoader` por ruta, `SUBREPORT_DIR`, imagenes por ruta en `.jrxml`): **central queda sin ocurrencias vivas**. Las 2 que quedan en `ImpresionService` estan comentadas.

## Como probarlo

Requiere JAR empaquetado — con `spring-boot:run` el bug no se reproduce (clases explotadas):

```bash
./mvnw clean package -DskipTests
java -jar target/frc-central-server.jar
```

Luego, desde el desktop: RRHH > Liquidaciones > imprimir recibo (A4 y ticket 58/80), y RRHH > Reportes > nomina del mes / resumen IPS / finiquito. Antes del fix todos devuelven el `GraphQLException`; despues bajan el PDF.

## Impacto en DB

Ninguno. Sin migraciones.

## Impacto en rollback

Ninguno. Cambio puramente de codigo, sin estado persistido ni contrato GraphQL modificado. Rollback a la version anterior simplemente reintroduce el bug.

## Riesgo

**Bajo.** 10 lineas netas, sin cambio de comportamiento en dev, y el patron destino ya esta probado en produccion en los otros servicios de impresion.

## Nota aparte (fuera de este PR)

`frc-comercial/filial` tiene el mismo bug vivo en 4 lugares: `FacturaLegalGraphQL:567` (`factura.jrxml`), `FacturaLegalGraphQL:586` (`factura2.jrxml`), `ProductoService:158` (`productos.jrxml`) y `TicketReportService:52` (`reports/ticket-58mm.jrxml`). Se deja para un PR propio en ese repo, dado que filial se auto-propaga cada 15 minutos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)