### PR TITLE
feat(financiero): pagar vales de RRHH con el motor de pago de CPP

### DIFF
--- a/docs/manuales-implementacion/financiero/PAGAR-VALES.md
+++ b/docs/manuales-implementacion/financiero/PAGAR-VALES.md
@@ -1,0 +1,119 @@
+# Pagar Vale — vales de RRHH pagados con el motor de CPP
+
+Estado: implementado (2026-08-15). Reemplaza en el hub de egresos de la Caja Mayor la opción
+**"Registrar Vale"** por **"Pagar Vale"**.
+
+## El problema
+
+`Registrar Vale` era un atajo: creaba el vale y lo confirmaba en una sola transacción
+(`ValeService.crearValeConfirmado`), posteando un egreso directo de caja. Eso dejaba dos huecos:
+
+1. **No se podía pagar un vale ya registrado.** El mobile crea vales en estado `SOLICITADO`
+   (`RrhhMobileService`), y no había forma de entregarles la plata desde tesorería.
+2. **Solo efectivo de caja mayor.** Sin cuenta bancaria, sin cheque, sin multi-moneda —
+   a diferencia de "Pagar Gasto", que ya tenía todo eso.
+
+## El diseño: puente `Vale ↔ SolicitudPago(tipo = RRHH)`
+
+Un gasto pagable es una `SolicitudPago` de `tipo = GASTO`, y el motor de CPP
+(`PagoProveedorService.procesarEvento`) sabe pagarla con cualquier combinación de formas de pago.
+El vale reusa exactamente ese motor: su **obligación de pago** se representa con una
+`SolicitudPago` de `tipo = RRHH` — un valor que ya existía en el enum y estaba sin usar.
+
+```
+rrhh.vale (SOLICITADO)  ──solicitud_pago_id──▶  SolicitudPago(RRHH, SOLICITADO)
+                                                          │
+                                          pagarValesMixto │ (motor CPP)
+                                                          ▼
+                                                SolicitudPago CONCLUIDO
+                                                          │ hook de sincronización
+                                                          ▼
+                                                rrhh.vale CONFIRMADO
+```
+
+- **El vale sigue siendo la verdad de RRHH.** La liquidación descuenta leyendo `rrhh.vale`
+  (estado `CONFIRMADO`); la solicitud es solo el documento pagable.
+- **Cero lógica de pago nueva.** Cheques, banco, ajuste FX, reparto FIFO y anulación por evento
+  vienen gratis del motor existente.
+- `ValeService.sincronizarDesdeSolicitudPago` es el espejo de
+  `PreGastoService.sincronizarDesdeSolicitudPago`, y lo llama el motor en los mismos dos puntos
+  (al pagar y al anular).
+
+### Consecuencia asumida sobre el ledger
+
+El movimiento de caja de un vale pagado por este flujo queda **`PAGO_PROVEEDOR` / `origenTipo = PAGO_CPP`**,
+no `EGRESO` / `RRHH_VALE` como el atajo viejo. Es el precio de reusar el motor. Se preserva
+`vale.movimiento_caja_virtual_id` (el FK inverso que usa la trazabilidad) apuntando al movimiento
+consolidado, y la descripción del movimiento es `VALE #id - FUNCIONARIO - MOTIVO`.
+
+**La anulación va por `anularPagoCpp`**, no por `anularVale`: `TesoreriaService.anular` bloquea
+todo origen que no sea `MANUAL`. En la UI es ⋮ → Anular sobre la fila de caja del pago.
+
+## Reglas propias (dónde se aparta de "Pagar Gasto")
+
+| Regla | Por qué |
+|---|---|
+| **Un vale se paga entero o no se paga.** El backend rechaza el pago parcial y la columna "Monto a pagar" es de solo lectura. | La liquidación descuenta `vale.monto` **completo**. Entregar 400.000 de un vale de 1.000.000 sacaría plata de la caja que nunca se recupera del sueldo. |
+| **`ValeService.anular` rechaza un vale con `solicitud_pago_id` y estado `CONFIRMADO`.** | `revertirEgresoCaja` hace `return` si no hay `cajaVirtualId`: anularía el vale **sin devolver la plata**, en silencio. La reversión correcta es anular el pago. |
+| **Un vale sin moneda no es pagable.** Fila no seleccionable con chip `sin moneda`, más guard en el backend. | Hay vales viejos con `moneda_id NULL` (verificado en la base de desarrollo). Sin moneda no se puede armar la obligación ni saber en qué moneda sale la plata. |
+| Selección multi-vale: solo exige **misma moneda** (el funcionario puede variar). | Mismo criterio que gastos. Con varios vales la etiqueta del movimiento pasa a `Pago de vales (N)`. |
+
+## Qué se tocó
+
+**Backend (`central`)**
+
+| Archivo | Cambio |
+|---|---|
+| `V198.5__rrhh_vale_solicitud_pago.sql` | Columna `rrhh.vale.solicitud_pago_id` + índice único parcial. Aditiva. |
+| `domain/rrhh/Vale.java` | Campo `solicitudPagoId` (FK plana). |
+| `repository/rrhh/ValeRepository.java` | `findBySolicitudPagoId`, `findByEstadoOrderByFechaDescIdDesc`. |
+| `service/operaciones/SolicitudPagoService.java` | `crearSolicitudVale(...)` (`tipo = RRHH`, estado `SOLICITADO`). |
+| `service/rrhh/ValeService.java` | `sincronizarDesdeSolicitudPago(...)` + guard en `anular`. |
+| `service/financiero/ValeTesoreriaService.java` (nuevo) | `listarValesPendientes`, `crearValeParaPago`, `pagarValesMixto`. |
+| `service/financiero/PagoProveedorService.java` | 2 hooks de sincronización + etiqueta del movimiento para vales. |
+| `graphql/rrhh/ValeTesoreriaGraphQL.java` + `vale-tesoreria.graphqls` | `valesPendientes`, `crearValeParaPago`, `pagarValesMixto`, type `ValePendiente`. |
+
+**Sin ciclo de beans:** `PagoProveedorService → ValeService`, y `ValeService` no conoce el motor de
+pago (el que lo usa es `ValeTesoreriaService`). Por eso el hook vive en `ValeService`.
+
+**Seguridad:** `RrhhSecurityService` — `requireVer()` para listar, `APROBAR` para crear y pagar.
+Es **paridad exacta** con `crearValeConfirmado`, que es lo que el hub hacía antes: no amplía ni
+restringe privilegios.
+
+**Desktop**
+
+"Pagar Gasto" no es un diálogo aparte: es `PagarComprasDialogComponent` con `modo: 'GASTOS'`.
+Se agregó un tercer modo **`VALES`** al mismo componente (título, columnas, filtros, fuente de datos
+y vista de alta ya eran condicionales por modo). Se eliminó `registrar-vale-dialog/`, que quedó sin
+referencias.
+
+Columnas: `N° · Funcionario · Motivo · Descripción · Saldo pendiente · Monto a pagar`.
+Filtros: `N° · Funcionario · Motivo`, más el botón **+ Nuevo Vale** (funcionario, motivo, moneda,
+monto, es adelanto, observación) que crea el vale **pendiente de pago**, sin mover plata.
+
+## Cómo probarlo
+
+Entorno local según `ENTORNO_LOCAL.md` (central contra `bodega_producto_devoluciones` en 5551).
+
+1. Caja Mayor → **Egreso** → **Pagar Vale**.
+2. **+ Nuevo Vale** → funcionario, monto, guardar. Aparece en la lista con saldo, **sin** movimiento de caja.
+3. Seleccionar el vale → Siguiente → forma de pago (caja mayor, banco, o mixta) → Revisar → Confirmar.
+4. Verificar: vale en `CONFIRMADO`, movimiento en la caja con descripción `VALE #id - FUNCIONARIO - MOTIVO`,
+   saldo de caja bajado por el monto exacto.
+5. ⋮ → **Anular** sobre esa fila: el vale vuelve a `SOLICITADO`, la solicitud a `SOLICITADO` con
+   `monto_pagado = 0`, y el saldo se restituye.
+
+**Verificado end-to-end el 2026-08-15** contra el central local: pago simple, pago mixto
+(caja mayor + cuenta bancaria), anulación con reversión exacta del saldo, rechazo de pago parcial,
+rechazo de vale sin moneda y rechazo de `anularVale` sobre un vale pagado desde tesorería.
+
+> ⚠️ Sirviendo el desktop como web (`ng serve`), los pasos 2 y 3 del stepper quedan fuera del área
+> visible del diálogo. **No es de este cambio**: pasa igual en el modo COMPRAS, que no se tocó.
+> El contenido está en el DOM y el flujo funciona; es un problema de layout del stepper en browser.
+
+## Tests
+
+- `ValeTesoreriaServiceTest` (6) — listado con saldo, alta sin mover plata, rechazo de vale no pendiente,
+  rechazo de pago parcial, creación perezosa de la obligación, reutilización de la existente.
+- `ValeServiceSincronizacionTest` (5) — CONCLUIDO ⇒ CONFIRMADO + linkeo del movimiento, anulación ⇒
+  SOLICITADO, no toca un vale `DESCONTADO`, ignora solicitudes que no son de vale, guard de `anular`.

--- a/src/main/java/com/franco/dev/domain/rrhh/Vale.java
+++ b/src/main/java/com/franco/dev/domain/rrhh/Vale.java
@@ -66,6 +66,13 @@ public class Vale implements Identifiable<Long> {
     @Column(name = "caja_virtual_id")
     private Long cajaVirtualId;
 
+    /**
+     * Obligacion de pago del vale cuando se paga desde tesoreria (motor CPP).
+     * Null = vale del atajo viejo (crearValeConfirmado: egreso directo a caja mayor).
+     */
+    @Column(name = "solicitud_pago_id")
+    private Long solicitudPagoId;
+
     @Column(name = "movimiento_caja_virtual_id")
     private Long movimientoCajaVirtualId;
 

--- a/src/main/java/com/franco/dev/graphql/financiero/PagoProveedorGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/PagoProveedorGraphQL.java
@@ -83,7 +83,8 @@ public class PagoProveedorGraphQL implements GraphQLQueryResolver, GraphQLMutati
         return service.anularPagoCpp(pagoId, motivo, seg.currentUsuario());
     }
 
-    private List<PagoProveedorService.LineaPago> mapLineas(List<LineaPagoInputWrapper> lineas) {
+    /** Mapeo del input de líneas al modelo del motor de pago. Compartido con el pago de vales. */
+    public static List<PagoProveedorService.LineaPago> mapLineas(List<LineaPagoInputWrapper> lineas) {
         List<PagoProveedorService.LineaPago> ls = new ArrayList<>();
         for (LineaPagoInputWrapper w : lineas) {
             PagoProveedorService.LineaPago l = new PagoProveedorService.LineaPago();

--- a/src/main/java/com/franco/dev/graphql/rrhh/ValeTesoreriaGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/rrhh/ValeTesoreriaGraphQL.java
@@ -1,0 +1,77 @@
+package com.franco.dev.graphql.rrhh;
+
+import com.franco.dev.domain.operaciones.Pago;
+import com.franco.dev.domain.rrhh.Vale;
+import com.franco.dev.graphql.financiero.PagoProveedorGraphQL;
+import com.franco.dev.service.financiero.ValeTesoreriaService;
+import com.franco.dev.service.rrhh.RrhhSecurityService;
+import com.franco.dev.service.rrhh.dto.ValePendienteDto;
+import graphql.kickstart.tools.GraphQLMutationResolver;
+import graphql.kickstart.tools.GraphQLQueryResolver;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Pago de vales desde el hub de egresos de la Caja Mayor ("Pagar Vale").
+ *
+ * <p>Seguridad: mismos roles que ya exigen las operaciones de vale en {@link ValeGraphQL}
+ * ({@code requireVer} para listar, {@code APROBAR} para crear/pagar). Es paridad exacta con
+ * {@code crearValeConfirmado}, que es lo que hacía el hub antes de este flujo: no amplía ni
+ * restringe privilegios respecto de lo que la gente ya podía hacer.</p>
+ */
+@Component
+@AllArgsConstructor
+public class ValeTesoreriaGraphQL implements GraphQLQueryResolver, GraphQLMutationResolver {
+
+    private final ValeTesoreriaService service;
+    private final RrhhSecurityService seg;
+
+    /** Vales pagables (estado SOLICITADO) con su saldo. */
+    public List<ValePendienteDto> valesPendientes() {
+        seg.requireVer();
+        return service.listarValesPendientes();
+    }
+
+    /** Alta de un vale listo para pagar: queda SOLICITADO, sin mover plata. */
+    public Vale crearValeParaPago(ValeParaPagoWrapper input) {
+        seg.requireAnyRole(seg.APROBAR);
+        return service.crearValeParaPago(
+                input.getFuncionarioId(), input.getMotivoId(), input.getMonedaId(),
+                input.getMonto() != null ? BigDecimal.valueOf(input.getMonto()) : null,
+                input.getEsAdelanto(), input.getObservacion(), seg.currentUsuario());
+    }
+
+    /** Paga N vales como un único evento consolidado (caja mayor / banco / cheque). */
+    public Pago pagarValesMixto(List<ValeConLineasWrapper> pagos) {
+        seg.requireAnyRole(seg.APROBAR);
+        List<ValeTesoreriaService.ValeConLineas> ls = new ArrayList<>();
+        for (ValeConLineasWrapper w : pagos) {
+            ValeTesoreriaService.ValeConLineas v = new ValeTesoreriaService.ValeConLineas();
+            v.setValeId(w.getValeId());
+            v.setLineas(PagoProveedorGraphQL.mapLineas(w.getLineas()));
+            ls.add(v);
+        }
+        return service.pagarValesMixto(ls, seg.currentUsuario());
+    }
+
+    @Data
+    public static class ValeParaPagoWrapper {
+        private Long funcionarioId;
+        private Long motivoId;
+        private Long monedaId;
+        private Double monto;
+        private Boolean esAdelanto;
+        private String observacion;
+    }
+
+    @Data
+    public static class ValeConLineasWrapper {
+        private Long valeId;
+        private List<PagoProveedorGraphQL.LineaPagoInputWrapper> lineas;
+    }
+}

--- a/src/main/java/com/franco/dev/repository/rrhh/ValeRepository.java
+++ b/src/main/java/com/franco/dev/repository/rrhh/ValeRepository.java
@@ -38,4 +38,10 @@ public interface ValeRepository extends HelperRepository<Vale, Long> {
     List<Vale> findByEstadoOrderByFechaDesc(ValeEstado estado);
 
     List<Vale> findByFuncionarioIdAndEstado(Long funcionarioId, ValeEstado estado);
+
+    /** Vale que corresponde a una obligacion de pago de tesoreria (puente vale -> SolicitudPago RRHH). */
+    Vale findBySolicitudPagoId(Long solicitudPagoId);
+
+    /** Vales pagables desde tesoreria: SOLICITADO, del mas reciente al mas antiguo. */
+    List<Vale> findByEstadoOrderByFechaDescIdDesc(ValeEstado estado);
 }

--- a/src/main/java/com/franco/dev/service/financiero/PagoProveedorService.java
+++ b/src/main/java/com/franco/dev/service/financiero/PagoProveedorService.java
@@ -62,6 +62,8 @@ public class PagoProveedorService {
     private final com.franco.dev.repository.financiero.PagoSolicitudDetalleRepository detalleRepository;
     private final com.franco.dev.repository.financiero.MovimientoBancarioRepository movimientoBancarioRepository;
     private final PreGastoService preGastoService;
+    // Sin ciclo: ValeService no conoce el motor de pago (el que sí lo usa es ValeTesoreriaService).
+    private final com.franco.dev.service.rrhh.ValeService valeService;
 
     /** Una línea de pago (pago mixto). Puede ser fuente AJUSTE (diferencia de cambio). */
     @Data
@@ -258,6 +260,17 @@ public class PagoProveedorService {
             String desc = gastoSol.getObservaciones() != null ? gastoSol.getObservaciones() : "";
             etiquetaPago = "#" + gastoSol.getId() + " - " + cat + " - " + benef + " - " + desc;
         }
+        // Vales de RRHH: la descripción del vale ya trae "VALE #id - FUNCIONARIO - MOTIVO".
+        // Con varios vales en el mismo evento, una sola de esas etiquetas sería engañosa.
+        List<SolicitudPago> valeSols = spById.values().stream()
+                .filter(s -> s.getTipo() == com.franco.dev.domain.operaciones.enums.TipoSolicitudPago.RRHH)
+                .collect(Collectors.toList());
+        if (valeSols.size() == 1) {
+            String desc = valeSols.get(0).getObservaciones();
+            if (desc != null && !desc.trim().isEmpty()) etiquetaPago = desc;
+        } else if (valeSols.size() > 1) {
+            etiquetaPago = "Pago de vales (" + valeSols.size() + ")";
+        }
         LinkedHashMap<String, GrupoMov> grupos = new LinkedHashMap<>();
         for (SolicitudConLineas p : pagos) {
             for (LineaPago l : p.getLineas()) {
@@ -376,6 +389,9 @@ public class PagoProveedorService {
             }
             // Si el gasto vino de un PreGasto (workflow de aprobación), sincronizar su estado.
             preGastoService.sincronizarDesdeSolicitudPago(sp);
+            // Si la obligación era de un vale de RRHH, dejarlo CONFIRMADO (es lo que mira la
+            // liquidación para descontarlo del sueldo).
+            valeService.sincronizarDesdeSolicitudPago(sp);
         }
 
         // PagoService.save fuerza ABIERTO en el alta; marcar el evento como CONCLUIDO ya con id.
@@ -453,6 +469,8 @@ public class PagoProveedorService {
             solicitudPagoService.desmarcarNotasComoPagadas(sp.getId());
             // Si es un gasto con PreGasto, revertir su estado (PAGADO → ENVIADO_A_TESORERIA).
             preGastoService.sincronizarDesdeSolicitudPago(sp);
+            // Si era el pago de un vale, vuelve a quedar pendiente de entrega (CONFIRMADO → SOLICITADO).
+            valeService.sincronizarDesdeSolicitudPago(sp);
         }
 
         pago.setEstado(PagoEstado.CANCELADO);

--- a/src/main/java/com/franco/dev/service/financiero/ValeTesoreriaService.java
+++ b/src/main/java/com/franco/dev/service/financiero/ValeTesoreriaService.java
@@ -1,0 +1,219 @@
+package com.franco.dev.service.financiero;
+
+import com.franco.dev.domain.financiero.Moneda;
+import com.franco.dev.domain.operaciones.SolicitudPago;
+import com.franco.dev.domain.operaciones.enums.SolicitudPagoEstado;
+import com.franco.dev.domain.personas.Funcionario;
+import com.franco.dev.domain.personas.Usuario;
+import com.franco.dev.domain.rrhh.MotivoVale;
+import com.franco.dev.domain.rrhh.Vale;
+import com.franco.dev.domain.rrhh.enums.ValeEstado;
+import com.franco.dev.repository.rrhh.ValeRepository;
+import com.franco.dev.service.operaciones.SolicitudPagoService;
+import com.franco.dev.service.personas.FuncionarioService;
+import com.franco.dev.service.rrhh.MotivoValeService;
+import com.franco.dev.service.rrhh.dto.ValePendienteDto;
+import graphql.GraphQLException;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Pago de vales de RRHH desde tesoreria, con el <b>mismo</b> motor de pago que CPP
+ * (caja mayor / cuenta bancaria / cheque, multi-moneda).
+ *
+ * <p>Puente: la obligacion de pago del vale se representa con una {@link SolicitudPago} de
+ * tipo {@code RRHH}. El vale sigue siendo la verdad de RRHH (la liquidacion lo descuenta
+ * leyendo {@code rrhh.vale}); la solicitud es solo el documento pagable. Cuando la solicitud
+ * queda CONCLUIDA, {@code ValeService.sincronizarDesdeSolicitudPago} deja el vale CONFIRMADO.</p>
+ *
+ * <p>Los vales creados por el atajo viejo ({@code crearValeConfirmado}, egreso directo
+ * EGRESO/RRHH_VALE) no tienen solicitud y no aparecen aca: ya estan pagados.</p>
+ */
+@Service
+@AllArgsConstructor
+public class ValeTesoreriaService {
+
+    /** Igual criterio que el motor de pago, para que "pago total" signifique lo mismo de los dos lados. */
+    private static final BigDecimal TOLERANCIA = new BigDecimal("0.005");
+
+    private final ValeRepository valeRepository;
+    private final SolicitudPagoService solicitudPagoService;
+    private final PagoProveedorService pagoProveedorService;
+    private final FuncionarioService funcionarioService;
+    private final MotivoValeService motivoValeService;
+    private final MonedaService monedaService;
+
+    /** Un vale a pagar con su reparto de formas de pago (espejo de SolicitudConLineas). */
+    @lombok.Data
+    public static class ValeConLineas {
+        private Long valeId;
+        private List<PagoProveedorService.LineaPago> lineas;
+    }
+
+    /** Vales pagables: estado SOLICITADO (registrados y todavia sin entregar la plata). */
+    @Transactional(readOnly = true)
+    public List<ValePendienteDto> listarValesPendientes() {
+        List<ValePendienteDto> out = new ArrayList<>();
+        for (Vale v : valeRepository.findByEstadoOrderByFechaDescIdDesc(ValeEstado.SOLICITADO)) {
+            out.add(toDto(v));
+        }
+        return out;
+    }
+
+    private ValePendienteDto toDto(Vale v) {
+        ValePendienteDto d = new ValePendienteDto();
+        d.setId(v.getId());
+        d.setFecha(v.getFecha());
+        d.setMonto(v.getMonto());
+        d.setSaldoPendiente(saldoPendiente(v));
+        d.setEsAdelanto(Boolean.TRUE.equals(v.getEsAdelanto()));
+        d.setObservacion(v.getObservacion());
+        d.setMoneda(v.getMoneda());
+        d.setFuncionario(v.getFuncionario());
+        d.setFuncionarioNombre(nombreFuncionario(v.getFuncionario()));
+        d.setMotivo(v.getMotivo());
+        d.setMotivoDescripcion(v.getMotivo() != null ? v.getMotivo().getDescripcion() : null);
+        return d;
+    }
+
+    /**
+     * Saldo a entregar. Si el vale ya tiene solicitud con pagos parciales previos, se descuenta;
+     * en la practica el pago parcial esta prohibido (ver pagarValesMixto), asi que esto es
+     * defensivo ante datos viejos.
+     */
+    private BigDecimal saldoPendiente(Vale v) {
+        BigDecimal total = v.getMonto() != null ? v.getMonto() : BigDecimal.ZERO;
+        if (v.getSolicitudPagoId() == null) return total;
+        SolicitudPago sp = solicitudPagoService.findById(v.getSolicitudPagoId()).orElse(null);
+        if (sp == null || sp.getMontoPagado() == null) return total;
+        BigDecimal saldo = total.subtract(sp.getMontoPagado());
+        return saldo.signum() > 0 ? saldo : BigDecimal.ZERO;
+    }
+
+    /**
+     * Alta de un vale para pagar en el acto: queda SOLICITADO (sin mover plata) junto con su
+     * obligacion de pago. El egreso lo hace despues {@link #pagarValesMixto}.
+     */
+    @Transactional
+    public Vale crearValeParaPago(Long funcionarioId, Long motivoId, Long monedaId, BigDecimal monto,
+                                  Boolean esAdelanto, String observacion, Usuario usuario) {
+        if (funcionarioId == null) throw new GraphQLException("El funcionario es obligatorio");
+        if (monto == null || monto.signum() <= 0) throw new GraphQLException("El monto del vale debe ser positivo");
+        Funcionario funcionario = funcionarioService.findById(funcionarioId)
+                .orElseThrow(() -> new GraphQLException("Funcionario no encontrado"));
+        Moneda moneda = monedaService.findById(monedaId)
+                .orElseThrow(() -> new GraphQLException("Moneda no encontrada"));
+        MotivoVale motivo = motivoId != null ? motivoValeService.findById(motivoId).orElse(null) : null;
+
+        Vale vale = new Vale();
+        vale.setFuncionario(funcionario);
+        vale.setMotivo(motivo);
+        vale.setMoneda(moneda);
+        vale.setMonto(monto);
+        vale.setFecha(LocalDate.now());
+        vale.setEstado(ValeEstado.SOLICITADO);
+        vale.setEsAdelanto(Boolean.TRUE.equals(esAdelanto));
+        vale.setObservacion(observacion != null ? observacion.toUpperCase() : null);
+        vale.setUsuario(usuario);
+        vale.setCreadoEn(LocalDateTime.now());
+        vale = valeRepository.save(vale);
+
+        vale.setSolicitudPagoId(crearSolicitud(vale, usuario).getId());
+        return valeRepository.save(vale);
+    }
+
+    /**
+     * Paga N vales como un unico evento consolidado, con el motor de CPP.
+     *
+     * <p><b>El pago parcial esta prohibido</b>: la liquidacion descuenta {@code vale.monto}
+     * completo, asi que entregar de menos dejaria plata fuera de la caja que nunca se recupera
+     * del sueldo. Se exige que lo aplicado cubra el saldo entero del vale.</p>
+     */
+    @Transactional
+    public com.franco.dev.domain.operaciones.Pago pagarValesMixto(List<ValeConLineas> pagos, Usuario usuario) {
+        if (pagos == null || pagos.isEmpty()) throw new GraphQLException("Seleccione al menos un vale a pagar");
+
+        List<PagoProveedorService.SolicitudConLineas> lote = new ArrayList<>();
+        for (ValeConLineas p : pagos) {
+            Vale vale = valeRepository.findById(p.getValeId())
+                    .orElseThrow(() -> new GraphQLException("Vale no encontrado: " + p.getValeId()));
+            if (vale.getEstado() != ValeEstado.SOLICITADO) {
+                throw new GraphQLException("El vale #" + vale.getId() + " no esta pendiente de pago (esta "
+                        + vale.getEstado() + ")");
+            }
+            if (p.getLineas() == null || p.getLineas().isEmpty()) {
+                throw new GraphQLException("Indique al menos una forma de pago para el vale #" + vale.getId());
+            }
+            // Hay vales viejos sin moneda (dato incompleto): sin ella no se puede armar la
+            // obligacion de pago ni saber en que moneda sale la plata.
+            if (vale.getMoneda() == null) {
+                throw new GraphQLException("El vale #" + vale.getId() + " no tiene moneda definida: "
+                        + "corregilo desde RRHH antes de pagarlo");
+            }
+            BigDecimal saldo = saldoPendiente(vale);
+            BigDecimal aplicado = BigDecimal.ZERO;
+            for (PagoProveedorService.LineaPago l : p.getLineas()) {
+                BigDecimal montoSol = l.getMontoSolicitud() != null ? l.getMontoSolicitud() : l.getMonto();
+                if (montoSol == null) continue;
+                aplicado = aplicado.add(Boolean.TRUE.equals(l.getAumento()) ? montoSol.negate() : montoSol);
+            }
+            if (saldo.subtract(aplicado).abs().compareTo(TOLERANCIA) > 0) {
+                throw new GraphQLException("El vale #" + vale.getId() + " se paga entero o no se paga: "
+                        + "falta cubrir " + saldo.subtract(aplicado).toPlainString());
+            }
+
+            PagoProveedorService.SolicitudConLineas s = new PagoProveedorService.SolicitudConLineas();
+            s.setSolicitudId(asegurarSolicitud(vale, usuario));
+            s.setLineas(p.getLineas());
+            lote.add(s);
+        }
+        return pagoProveedorService.pagarLoteMixto(lote, usuario);
+    }
+
+    /**
+     * Devuelve el id de la obligacion de pago del vale, creandola si el vale es previo a este
+     * flujo (los vales que crea el mobile nacen SOLICITADO y sin solicitud).
+     */
+    private Long asegurarSolicitud(Vale vale, Usuario usuario) {
+        if (vale.getSolicitudPagoId() != null) {
+            SolicitudPago sp = solicitudPagoService.findById(vale.getSolicitudPagoId()).orElse(null);
+            // Si quedo cancelada de un intento anterior, se emite una nueva.
+            if (sp != null && sp.getEstado() != SolicitudPagoEstado.CANCELADO) return sp.getId();
+        }
+        Long id = crearSolicitud(vale, usuario).getId();
+        vale.setSolicitudPagoId(id);
+        valeRepository.save(vale);
+        return id;
+    }
+
+    private SolicitudPago crearSolicitud(Vale vale, Usuario usuario) {
+        return solicitudPagoService.crearSolicitudVale(
+                vale.getMoneda(),
+                vale.getMonto() != null ? vale.getMonto().doubleValue() : 0.0,
+                descripcion(vale),
+                usuario);
+    }
+
+    /** Texto que se ve como "descripcion" del vale en la tabla y en el movimiento de caja. */
+    private String descripcion(Vale vale) {
+        StringBuilder sb = new StringBuilder("VALE");
+        if (vale.getId() != null) sb.append(" #").append(vale.getId());
+        String nombre = nombreFuncionario(vale.getFuncionario());
+        if (nombre != null) sb.append(" - ").append(nombre);
+        if (vale.getMotivo() != null && vale.getMotivo().getDescripcion() != null) {
+            sb.append(" - ").append(vale.getMotivo().getDescripcion());
+        }
+        return sb.toString();
+    }
+
+    private static String nombreFuncionario(Funcionario f) {
+        return (f != null && f.getPersona() != null) ? f.getPersona().getNombre() : null;
+    }
+}

--- a/src/main/java/com/franco/dev/service/operaciones/SolicitudPagoService.java
+++ b/src/main/java/com/franco/dev/service/operaciones/SolicitudPagoService.java
@@ -419,6 +419,24 @@ public class SolicitudPagoService extends CrudService<SolicitudPago, SolicitudPa
     }
 
     /**
+     * Crea la obligacion de pago de un vale de RRHH (tipo RRHH), lista para pagar
+     * (estado SOLICITADO). No tiene proveedor ni notas: el documento es el vale.
+     */
+    public SolicitudPago crearSolicitudVale(Moneda moneda, Double montoTotal, String observaciones,
+                                            com.franco.dev.domain.personas.Usuario usuario) {
+        SolicitudPago solicitud = new SolicitudPago();
+        solicitud.setTipo(com.franco.dev.domain.operaciones.enums.TipoSolicitudPago.RRHH);
+        solicitud.setMoneda(moneda);
+        solicitud.setMontoTotal(montoTotal);
+        solicitud.setObservaciones(observaciones);
+        solicitud.setUsuario(usuario);
+        // save() fuerza PENDIENTE en el alta; se re-marca SOLICITADO (lista para pagar directo).
+        SolicitudPago guardada = save(solicitud);
+        guardada.setEstado(SolicitudPagoEstado.SOLICITADO);
+        return save(guardada);
+    }
+
+    /**
      * Update solicitud pago (solo cuando estado es PENDIENTE).
      * Actualiza moneda, formaPago, fechaPagoPropuesta, observaciones y sincroniza notas.
      * Usado en: Desktop Sí (editar pago desde lista).

--- a/src/main/java/com/franco/dev/service/rrhh/ValeService.java
+++ b/src/main/java/com/franco/dev/service/rrhh/ValeService.java
@@ -44,6 +44,7 @@ public class ValeService extends CrudService<Vale, ValeRepository, Long> {
     private final CajaVirtualService cajaVirtualService;
     private final MovimientoCajaVirtualService movimientoCajaVirtualService;
     private final UsuarioService usuarioService;
+    private final com.franco.dev.repository.financiero.PagoSolicitudDetalleRepository pagoSolicitudDetalleRepository;
 
     @Override
     public ValeRepository getRepository() {
@@ -124,11 +125,61 @@ public class ValeService extends CrudService<Vale, ValeRepository, Long> {
         if (vale.getEstado() == ValeEstado.DESCONTADO) {
             throw new GraphQLException("No se puede anular un vale ya descontado en liquidacion");
         }
+        // Vale pagado desde tesoreria: la plata salio por un evento de pago consolidado
+        // (PAGO_CPP), no por el egreso directo de este servicio. Revertirlo aca dejaria el
+        // dinero fuera de la caja (revertirEgresoCaja hace return si no hay cajaVirtualId) o
+        // duplicaria la reversion. Se anula el pago, y el hook de sincronizacion devuelve el
+        // vale a SOLICITADO.
+        if (vale.getEstado() == ValeEstado.CONFIRMADO && vale.getSolicitudPagoId() != null) {
+            throw new GraphQLException("Este vale se pago desde tesoreria: anula el pago desde el "
+                    + "movimiento de caja (Anular pago) y el vale vuelve a quedar pendiente");
+        }
         if (vale.getEstado() == ValeEstado.CONFIRMADO) {
             revertirEgresoCaja(vale);
         }
         vale.setEstado(ValeEstado.ANULADO);
         return repository.save(vale);
+    }
+
+    /**
+     * Sincroniza el vale con el estado de su obligacion de pago (SolicitudPago tipo RRHH).
+     * Espejo de {@code PreGastoService.sincronizarDesdeSolicitudPago}: lo llama el motor de
+     * pago tanto al pagar como al anular un evento.
+     *
+     * <p>Solicitud CONCLUIDA ⇒ el vale queda CONFIRMADO (es lo que mira la liquidacion para
+     * descontarlo) y se linkean caja + movimiento consolidado, que es el FK inverso que usa
+     * la trazabilidad del ledger. <b>No postea nada en caja</b>: el movimiento ya lo genero
+     * el motor de pago. Cualquier otro estado (se anulo el pago) ⇒ vuelve a SOLICITADO.</p>
+     */
+    @Transactional
+    public void sincronizarDesdeSolicitudPago(com.franco.dev.domain.operaciones.SolicitudPago sp) {
+        if (sp == null || sp.getTipo() != com.franco.dev.domain.operaciones.enums.TipoSolicitudPago.RRHH) return;
+        Vale vale = repository.findBySolicitudPagoId(sp.getId());
+        if (vale == null || vale.getEstado() == ValeEstado.ANULADO
+                || vale.getEstado() == ValeEstado.DESCONTADO) return;
+
+        boolean pagado = sp.getEstado() == com.franco.dev.domain.operaciones.enums.SolicitudPagoEstado.CONCLUIDO;
+        ValeEstado destino = pagado ? ValeEstado.CONFIRMADO : ValeEstado.SOLICITADO;
+        if (pagado) {
+            // Linkear el movimiento de caja del pago (si lo hubo: un pago 100% bancario o con
+            // cheque no genera fila de caja).
+            for (com.franco.dev.domain.financiero.PagoSolicitudDetalle d
+                    : pagoSolicitudDetalleRepository.findBySolicitudPagoIdOrderByCreadoEnAsc(sp.getId())) {
+                if (Boolean.TRUE.equals(d.getAnulado())) continue;
+                if (d.getMovimientoCajaVirtualId() != null) {
+                    vale.setMovimientoCajaVirtualId(d.getMovimientoCajaVirtualId());
+                    vale.setCajaVirtualId(d.getCajaVirtualId());
+                    break;
+                }
+            }
+        } else {
+            vale.setMovimientoCajaVirtualId(null);
+            vale.setCajaVirtualId(null);
+        }
+        if (vale.getEstado() != destino || pagado) {
+            vale.setEstado(destino);
+            repository.save(vale);
+        }
     }
 
     // ---- helpers ----

--- a/src/main/java/com/franco/dev/service/rrhh/dto/ValePendienteDto.java
+++ b/src/main/java/com/franco/dev/service/rrhh/dto/ValePendienteDto.java
@@ -1,0 +1,30 @@
+package com.franco.dev.service.rrhh.dto;
+
+import com.franco.dev.domain.financiero.Moneda;
+import com.franco.dev.domain.personas.Funcionario;
+import com.franco.dev.domain.rrhh.MotivoVale;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+/**
+ * Fila del dialogo "Pagar Vale": un vale pendiente de entrega con su saldo.
+ *
+ * <p>Es una proyeccion y no la entidad porque el saldo no vive en el vale: sale de su
+ * obligacion de pago ({@code SolicitudPago} tipo RRHH), que puede no existir todavia.</p>
+ */
+@Data
+public class ValePendienteDto {
+    private Long id;                    // id del vale (es el "N°" que se muestra)
+    private LocalDate fecha;
+    private BigDecimal monto;
+    private BigDecimal saldoPendiente;
+    private Boolean esAdelanto;
+    private String observacion;
+    private Moneda moneda;
+    private Funcionario funcionario;
+    private String funcionarioNombre;
+    private MotivoVale motivo;
+    private String motivoDescripcion;
+}

--- a/src/main/resources/db/migration/V198.5__rrhh_vale_solicitud_pago.sql
+++ b/src/main/resources/db/migration/V198.5__rrhh_vale_solicitud_pago.sql
@@ -1,0 +1,13 @@
+-- Puente Vale -> SolicitudPago(tipo=RRHH): permite pagar un vale con el motor de pago
+-- de CPP (caja mayor / cuenta bancaria / cheque, multi-moneda), igual que un gasto.
+--
+-- Aditiva: columna nullable. Los vales existentes quedan con NULL, que significa
+-- "vale del atajo viejo" (crearValeConfirmado, egreso directo EGRESO/RRHH_VALE).
+
+ALTER TABLE rrhh.vale
+    ADD COLUMN IF NOT EXISTS solicitud_pago_id BIGINT;
+
+-- Un vale apunta a lo sumo a una solicitud, y una solicitud pertenece a lo sumo a un vale.
+CREATE UNIQUE INDEX IF NOT EXISTS ux_vale_solicitud_pago_id
+    ON rrhh.vale (solicitud_pago_id)
+    WHERE solicitud_pago_id IS NOT NULL;

--- a/src/main/resources/graphql/rrhh/vale-tesoreria.graphqls
+++ b/src/main/resources/graphql/rrhh/vale-tesoreria.graphqls
@@ -1,0 +1,45 @@
+# Pago de vales de RRHH desde tesoreria, con el mismo motor de pago que CPP.
+# El vale sigue siendo la verdad de RRHH; su obligacion de pago es una SolicitudPago tipo RRHH.
+
+# Fila del dialogo "Pagar Vale". Es una proyeccion y no el type Vale porque el saldo
+# no vive en el vale: sale de su obligacion de pago, que puede no existir todavia.
+type ValePendiente {
+    id: ID!
+    fecha: String
+    monto: Float
+    saldoPendiente: Float
+    esAdelanto: Boolean
+    observacion: String
+    moneda: Moneda
+    funcionario: Funcionario
+    funcionarioNombre: String
+    motivo: MotivoVale
+    motivoDescripcion: String
+}
+
+input ValeParaPagoInput {
+    funcionarioId: ID!
+    motivoId: ID
+    monedaId: ID!
+    monto: Float!
+    esAdelanto: Boolean
+    observacion: String
+}
+
+# Un vale con su reparto de formas de pago (espejo de SolicitudConLineasInput).
+input ValeConLineasInput {
+    valeId: ID!
+    lineas: [LineaPagoInput!]!
+}
+
+extend type Query {
+    # Vales en estado SOLICITADO: registrados y todavia sin entregar la plata.
+    valesPendientes: [ValePendiente]
+}
+
+extend type Mutation {
+    # Alta de un vale ya listo para pagar: queda SOLICITADO, sin mover plata.
+    crearValeParaPago(input: ValeParaPagoInput!): Vale!
+    # Paga N vales como un unico evento consolidado. El pago parcial de un vale esta prohibido.
+    pagarValesMixto(pagos: [ValeConLineasInput!]!): Pago
+}

--- a/src/test/java/com/franco/dev/service/financiero/PagoProveedorServiceTest.java
+++ b/src/test/java/com/franco/dev/service/financiero/PagoProveedorServiceTest.java
@@ -54,9 +54,10 @@ class PagoProveedorServiceTest {
         pagoEvento.setId(500L);
         when(pagoService.save(any())).thenReturn(pagoEvento);
         PreGastoService preGastoService = mock(PreGastoService.class);
+        com.franco.dev.service.rrhh.ValeService valeService = mock(com.franco.dev.service.rrhh.ValeService.class);
         service = new PagoProveedorService(solicitudPagoService, pagoService, tesoreriaService, bancoLedgerService,
                 chequeGestionService, chequeraRepo, cajaVirtualRepository, monedaRepository, detalleRepo, movBancarioRepo,
-                preGastoService);
+                preGastoService, valeService);
 
         com.franco.dev.domain.personas.Persona persona = new com.franco.dev.domain.personas.Persona(); persona.setNombre("PROV X");
         Proveedor prov = new Proveedor(); prov.setId(7L); prov.setPersona(persona);

--- a/src/test/java/com/franco/dev/service/financiero/ValeTesoreriaServiceTest.java
+++ b/src/test/java/com/franco/dev/service/financiero/ValeTesoreriaServiceTest.java
@@ -1,0 +1,168 @@
+package com.franco.dev.service.financiero;
+
+import com.franco.dev.domain.financiero.Moneda;
+import com.franco.dev.domain.operaciones.SolicitudPago;
+import com.franco.dev.domain.operaciones.enums.SolicitudPagoEstado;
+import com.franco.dev.domain.operaciones.enums.TipoSolicitudPago;
+import com.franco.dev.domain.personas.Funcionario;
+import com.franco.dev.domain.personas.Persona;
+import com.franco.dev.domain.personas.Usuario;
+import com.franco.dev.domain.rrhh.Vale;
+import com.franco.dev.domain.rrhh.enums.ValeEstado;
+import com.franco.dev.repository.rrhh.ValeRepository;
+import com.franco.dev.service.operaciones.SolicitudPagoService;
+import com.franco.dev.service.personas.FuncionarioService;
+import com.franco.dev.service.rrhh.MotivoValeService;
+import com.franco.dev.service.rrhh.dto.ValePendienteDto;
+import graphql.GraphQLException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Pago de vales desde tesorería: puente vale → SolicitudPago(RRHH) + delegación al motor de CPP.
+ * Lo que se protege acá es que un vale se pague entero y una sola vez.
+ */
+class ValeTesoreriaServiceTest {
+
+    private ValeRepository valeRepository;
+    private SolicitudPagoService solicitudPagoService;
+    private PagoProveedorService pagoProveedorService;
+    private FuncionarioService funcionarioService;
+    private MotivoValeService motivoValeService;
+    private MonedaService monedaService;
+    private ValeTesoreriaService service;
+
+    @BeforeEach
+    void setUp() {
+        valeRepository = mock(ValeRepository.class);
+        solicitudPagoService = mock(SolicitudPagoService.class);
+        pagoProveedorService = mock(PagoProveedorService.class);
+        funcionarioService = mock(FuncionarioService.class);
+        motivoValeService = mock(MotivoValeService.class);
+        monedaService = mock(MonedaService.class);
+        service = new ValeTesoreriaService(valeRepository, solicitudPagoService, pagoProveedorService,
+                funcionarioService, motivoValeService, monedaService);
+        when(valeRepository.save(any(Vale.class))).thenAnswer(i -> i.getArgument(0));
+    }
+
+    private Moneda moneda() { Moneda m = new Moneda(); m.setId(1L); m.setDenominacion("GUARANI"); return m; }
+
+    private Funcionario funcionario(String nombre) {
+        Persona p = new Persona(); p.setId(9L); p.setNombre(nombre);
+        Funcionario f = new Funcionario(); f.setId(5L); f.setPersona(p);
+        return f;
+    }
+
+    private Vale vale(Long id, ValeEstado estado, double monto) {
+        Vale v = new Vale();
+        v.setId(id); v.setEstado(estado); v.setMonto(BigDecimal.valueOf(monto));
+        v.setMoneda(moneda()); v.setFuncionario(funcionario("JUAN PEREZ"));
+        return v;
+    }
+
+    private ValeTesoreriaService.ValeConLineas pago(Long valeId, double montoLinea) {
+        PagoProveedorService.LineaPago l = new PagoProveedorService.LineaPago();
+        l.setMonto(BigDecimal.valueOf(montoLinea));
+        l.setMontoSolicitud(BigDecimal.valueOf(montoLinea));
+        ValeTesoreriaService.ValeConLineas p = new ValeTesoreriaService.ValeConLineas();
+        p.setValeId(valeId); p.setLineas(List.of(l));
+        return p;
+    }
+
+    private SolicitudPago solicitud(Long id) {
+        SolicitudPago sp = new SolicitudPago();
+        sp.setId(id); sp.setTipo(TipoSolicitudPago.RRHH); sp.setEstado(SolicitudPagoEstado.SOLICITADO);
+        return sp;
+    }
+
+    @Test
+    void listaSoloValesSolicitadosConSuSaldo() {
+        when(valeRepository.findByEstadoOrderByFechaDescIdDesc(ValeEstado.SOLICITADO))
+                .thenReturn(List.of(vale(1L, ValeEstado.SOLICITADO, 1_000_000)));
+
+        List<ValePendienteDto> filas = service.listarValesPendientes();
+
+        assertEquals(1, filas.size());
+        assertEquals(0, BigDecimal.valueOf(1_000_000).compareTo(filas.get(0).getSaldoPendiente()));
+        assertEquals("JUAN PEREZ", filas.get(0).getFuncionarioNombre());
+    }
+
+    @Test
+    void creaElValePendienteDePagoSinMoverPlata() {
+        when(funcionarioService.findById(5L)).thenReturn(Optional.of(funcionario("JUAN PEREZ")));
+        when(monedaService.findById(1L)).thenReturn(Optional.of(moneda()));
+        when(solicitudPagoService.crearSolicitudVale(any(), anyDouble(), anyString(), any()))
+                .thenReturn(solicitud(77L));
+
+        Vale creado = service.crearValeParaPago(5L, null, 1L, BigDecimal.valueOf(500_000),
+                true, "adelanto", new Usuario());
+
+        // SOLICITADO = registrado y todavía sin entregar la plata.
+        assertEquals(ValeEstado.SOLICITADO, creado.getEstado());
+        assertEquals(77L, creado.getSolicitudPagoId());
+        assertEquals("ADELANTO", creado.getObservacion());
+        // No se postea ningún movimiento de caja en el alta.
+        verifyNoInteractions(pagoProveedorService);
+    }
+
+    @Test
+    void rechazaPagarUnValeQueNoEstaPendiente() {
+        when(valeRepository.findById(1L)).thenReturn(Optional.of(vale(1L, ValeEstado.CONFIRMADO, 1_000_000)));
+
+        GraphQLException ex = assertThrows(GraphQLException.class,
+                () -> service.pagarValesMixto(List.of(pago(1L, 1_000_000)), new Usuario()));
+
+        assertTrue(ex.getMessage().contains("no esta pendiente"));
+        verifyNoInteractions(pagoProveedorService);
+    }
+
+    @Test
+    void rechazaElPagoParcialDeUnVale() {
+        // La liquidación descuenta el monto total del vale: entregar de menos dejaría plata
+        // fuera de caja que nunca se recupera del sueldo.
+        when(valeRepository.findById(1L)).thenReturn(Optional.of(vale(1L, ValeEstado.SOLICITADO, 1_000_000)));
+
+        GraphQLException ex = assertThrows(GraphQLException.class,
+                () -> service.pagarValesMixto(List.of(pago(1L, 400_000)), new Usuario()));
+
+        assertTrue(ex.getMessage().contains("entero"));
+        verifyNoInteractions(pagoProveedorService);
+    }
+
+    @Test
+    void creaLaObligacionDePagoSiElValeNoLaTiene() {
+        // Caso real: los vales que crea el mobile nacen SOLICITADO y sin SolicitudPago.
+        Vale v = vale(1L, ValeEstado.SOLICITADO, 1_000_000);
+        when(valeRepository.findById(1L)).thenReturn(Optional.of(v));
+        when(solicitudPagoService.crearSolicitudVale(any(), anyDouble(), anyString(), any()))
+                .thenReturn(solicitud(88L));
+
+        service.pagarValesMixto(List.of(pago(1L, 1_000_000)), new Usuario());
+
+        assertEquals(88L, v.getSolicitudPagoId());
+        verify(pagoProveedorService).pagarLoteMixto(argThat(lote ->
+                lote.size() == 1 && lote.get(0).getSolicitudId().equals(88L)), any());
+    }
+
+    @Test
+    void reutilizaLaObligacionDePagoExistenteEnLugarDeDuplicarla() {
+        Vale v = vale(1L, ValeEstado.SOLICITADO, 1_000_000);
+        v.setSolicitudPagoId(88L);
+        when(valeRepository.findById(1L)).thenReturn(Optional.of(v));
+        when(solicitudPagoService.findById(88L)).thenReturn(Optional.of(solicitud(88L)));
+
+        service.pagarValesMixto(List.of(pago(1L, 1_000_000)), new Usuario());
+
+        verify(solicitudPagoService, never()).crearSolicitudVale(any(), anyDouble(), anyString(), any());
+        verify(pagoProveedorService).pagarLoteMixto(argThat(lote ->
+                lote.get(0).getSolicitudId().equals(88L)), any());
+    }
+}

--- a/src/test/java/com/franco/dev/service/rrhh/ValeServiceSincronizacionTest.java
+++ b/src/test/java/com/franco/dev/service/rrhh/ValeServiceSincronizacionTest.java
@@ -1,0 +1,120 @@
+package com.franco.dev.service.rrhh;
+
+import com.franco.dev.domain.financiero.PagoSolicitudDetalle;
+import com.franco.dev.domain.operaciones.SolicitudPago;
+import com.franco.dev.domain.operaciones.enums.SolicitudPagoEstado;
+import com.franco.dev.domain.operaciones.enums.TipoSolicitudPago;
+import com.franco.dev.domain.rrhh.Vale;
+import com.franco.dev.domain.rrhh.enums.ValeEstado;
+import com.franco.dev.repository.financiero.PagoSolicitudDetalleRepository;
+import com.franco.dev.repository.rrhh.ValeRepository;
+import com.franco.dev.service.financiero.CajaVirtualService;
+import com.franco.dev.service.financiero.MovimientoCajaVirtualService;
+import com.franco.dev.service.personas.UsuarioService;
+import graphql.GraphQLException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Sincronización vale ↔ obligación de pago: es lo que decide si la liquidación va a poder
+ * descontar el vale del sueldo (descuenta los CONFIRMADO).
+ */
+class ValeServiceSincronizacionTest {
+
+    private ValeRepository repository;
+    private PagoSolicitudDetalleRepository detalleRepository;
+    private ValeService service;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(ValeRepository.class);
+        detalleRepository = mock(PagoSolicitudDetalleRepository.class);
+        service = new ValeService(repository, mock(CajaVirtualService.class),
+                mock(MovimientoCajaVirtualService.class), mock(UsuarioService.class), detalleRepository);
+        when(repository.save(any(Vale.class))).thenAnswer(i -> i.getArgument(0));
+        when(detalleRepository.findBySolicitudPagoIdOrderByCreadoEnAsc(anyLong())).thenReturn(List.of());
+    }
+
+    private SolicitudPago solicitud(SolicitudPagoEstado estado) {
+        SolicitudPago sp = new SolicitudPago();
+        sp.setId(88L); sp.setTipo(TipoSolicitudPago.RRHH); sp.setEstado(estado);
+        return sp;
+    }
+
+    private Vale vale(ValeEstado estado) {
+        Vale v = new Vale();
+        v.setId(1L); v.setEstado(estado); v.setMonto(BigDecimal.valueOf(1_000_000));
+        v.setSolicitudPagoId(88L);
+        return v;
+    }
+
+    @Test
+    void solicitudConcluidaDejaElValeConfirmadoYLinkeaElMovimientoDeCaja() {
+        Vale v = vale(ValeEstado.SOLICITADO);
+        when(repository.findBySolicitudPagoId(88L)).thenReturn(v);
+        PagoSolicitudDetalle d = new PagoSolicitudDetalle();
+        d.setAnulado(false); d.setMovimientoCajaVirtualId(555L); d.setCajaVirtualId(3L);
+        when(detalleRepository.findBySolicitudPagoIdOrderByCreadoEnAsc(88L)).thenReturn(List.of(d));
+
+        service.sincronizarDesdeSolicitudPago(solicitud(SolicitudPagoEstado.CONCLUIDO));
+
+        // CONFIRMADO es lo que mira la liquidación para descontarlo del sueldo.
+        assertEquals(ValeEstado.CONFIRMADO, v.getEstado());
+        assertEquals(555L, v.getMovimientoCajaVirtualId());
+        assertEquals(3L, v.getCajaVirtualId());
+    }
+
+    @Test
+    void anularElPagoDevuelveElValeAPendiente() {
+        Vale v = vale(ValeEstado.CONFIRMADO);
+        v.setMovimientoCajaVirtualId(555L); v.setCajaVirtualId(3L);
+        when(repository.findBySolicitudPagoId(88L)).thenReturn(v);
+
+        service.sincronizarDesdeSolicitudPago(solicitud(SolicitudPagoEstado.SOLICITADO));
+
+        assertEquals(ValeEstado.SOLICITADO, v.getEstado());
+        assertNull(v.getMovimientoCajaVirtualId());
+        assertNull(v.getCajaVirtualId());
+    }
+
+    @Test
+    void noTocaUnValeYaDescontadoEnLiquidacion() {
+        Vale v = vale(ValeEstado.DESCONTADO);
+        when(repository.findBySolicitudPagoId(88L)).thenReturn(v);
+
+        service.sincronizarDesdeSolicitudPago(solicitud(SolicitudPagoEstado.SOLICITADO));
+
+        assertEquals(ValeEstado.DESCONTADO, v.getEstado());
+        verify(repository, never()).save(any(Vale.class));
+    }
+
+    @Test
+    void ignoraSolicitudesQueNoSonDeVale() {
+        SolicitudPago sp = solicitud(SolicitudPagoEstado.CONCLUIDO);
+        sp.setTipo(TipoSolicitudPago.GASTO);
+
+        service.sincronizarDesdeSolicitudPago(sp);
+
+        verify(repository, never()).findBySolicitudPagoId(anyLong());
+    }
+
+    @Test
+    void noSePuedeAnularPorRrhhUnValePagadoDesdeTesoreria() {
+        // Anularlo acá no devolvería la plata: el egreso salió por un evento de pago consolidado.
+        Vale v = vale(ValeEstado.CONFIRMADO);
+        when(repository.findById(1L)).thenReturn(Optional.of(v));
+
+        GraphQLException ex = assertThrows(GraphQLException.class, () -> service.anular(1L));
+
+        assertTrue(ex.getMessage().contains("tesoreria"));
+        assertEquals(ValeEstado.CONFIRMADO, v.getEstado());
+    }
+}


### PR DESCRIPTION
## Qué resuelve

El hub de egresos de la Caja Mayor solo tenía el atajo **"Registrar Vale"**: creaba el vale y lo confirmaba en una sola transacción, con egreso directo de efectivo. Eso dejaba dos huecos:

1. **No se podían pagar los vales ya registrados.** El mobile crea vales en estado `SOLICITADO` (`RrhhMobileService`), y no había forma de entregarles la plata desde tesorería.
2. **Solo efectivo de caja mayor.** Sin cuenta bancaria, sin cheque, sin multi-moneda — a diferencia de "Pagar Gasto", que ya tenía todo eso.

En el hub, **"Registrar Vale" pasa a ser "Pagar Vale"**, con el mismo stepper de "Pagar Gasto".

## Diseño: puente `Vale ↔ SolicitudPago(tipo = RRHH)`

Un gasto pagable ya es una `SolicitudPago` de `tipo = GASTO`, y el motor de CPP (`PagoProveedorService.procesarEvento`) sabe pagarla con cualquier combinación de formas de pago. El vale reusa ese motor: su **obligación de pago** se representa con una `SolicitudPago` de `tipo = RRHH` — un valor que **ya existía en el enum y estaba sin usar**.

- **El vale sigue siendo la verdad de RRHH.** La liquidación descuenta leyendo `rrhh.vale` (estado `CONFIRMADO`); la solicitud es solo el documento pagable.
- **Cero lógica de pago nueva.** Cheques, banco, ajuste FX, reparto FIFO y anulación por evento vienen del motor existente.
- `ValeService.sincronizarDesdeSolicitudPago` es el espejo de `PreGastoService.sincronizarDesdeSolicitudPago`, llamado por el motor en los mismos dos puntos (al pagar y al anular).

**Sin ciclo de beans:** `PagoProveedorService → ValeService`, y `ValeService` no conoce el motor de pago (quien lo usa es `ValeTesoreriaService`).

### Consecuencia asumida sobre el ledger

El movimiento de caja queda **`PAGO_PROVEEDOR` / `origenTipo = PAGO_CPP`**, no `EGRESO`/`RRHH_VALE` como el atajo viejo. Se preserva `vale.movimiento_caja_virtual_id` apuntando al movimiento consolidado, y la descripción es `VALE #id - FUNCIONARIO - MOTIVO`.

## Tres reglas propias (se apartan de "Pagar Gasto" a propósito)

| Regla | Por qué |
|---|---|
| **Un vale se paga entero o no se paga** (validado en backend; la columna "Monto a pagar" es de solo lectura) | La liquidación descuenta `vale.monto` **completo**. Entregar de menos sacaría plata de la caja que nunca se recupera del sueldo. |
| **`ValeService.anular` rechaza un vale pagado desde tesorería** | `revertirEgresoCaja` hace `return` si no hay `cajaVirtualId`: anularía el vale **sin devolver la plata**, en silencio. |
| **Un vale sin moneda no es pagable** (chip `sin moneda`, fila no seleccionable, más guard en backend) | Hay vales viejos con `moneda_id NULL` — verificado en la base de desarrollo. |

## Impacto en DB

Migración **aditiva** `V198.5__rrhh_vale_solicitud_pago.sql`: columna nullable `rrhh.vale.solicitud_pago_id` + índice único parcial. Sin `DROP`/`RENAME`. Los vales existentes quedan en `NULL` = "vale del atajo viejo".

**Rollback:** la columna sobrante no molesta a la versión anterior del backend.

## Impacto en los clientes

Aditivo: query `valesPendientes`, mutations `crearValeParaPago` y `pagarValesMixto`, type `ValePendiente`. Nada eliminado ni renombrado. `mapLineas` de `PagoProveedorGraphQL` pasó a `public static` para compartir el mapeo en vez de duplicarlo.

## Cómo probarlo

Entorno local según `ENTORNO_LOCAL.md` (central contra `bodega_producto_devoluciones` en 5551).

1. Caja Mayor → **Egreso** → **Pagar Vale**.
2. **+ Nuevo Vale** → funcionario, monto, guardar. Aparece en la lista con saldo, **sin** movimiento de caja.
3. Seleccionar → Siguiente → forma de pago (caja, banco o mixta) → Revisar → Confirmar.
4. Verificar: vale `CONFIRMADO`, movimiento con descripción `VALE #id - …`, saldo bajado por el monto exacto.
5. ⋮ → **Anular** sobre esa fila: el vale vuelve a `SOLICITADO`, la solicitud a `SOLICITADO` con `monto_pagado = 0`, y el saldo se restituye.

### Verificado end-to-end contra el central local

Pago simple por caja, **pago 100% bancario**, **pago mixto caja + banco**, anulación con reversión exacta del saldo, y los tres rechazos (parcial, vale ya pagado, vale sin moneda). Cuadre comprobado en DB: `Σ detalles vivos == monto_total` en cada solicitud, y las cadenas `saldo_anterior/posterior` de los movimientos bancarios coherentes.

## Tests

- `ValeTesoreriaServiceTest` (6) — listado con saldo, alta sin mover plata, rechazo de vale no pendiente, rechazo de pago parcial, creación perezosa de la obligación, reutilización de la existente.
- `ValeServiceSincronizacionTest` (5) — CONCLUIDO ⇒ CONFIRMADO + linkeo del movimiento, anulación ⇒ SOLICITADO, no toca un vale `DESCONTADO`, ignora solicitudes ajenas, guard de `anular`.

Suite completa: **318 tests verdes**.

## Limitación conocida (follow-up, no bloquea)

Un vale pagado **100% por banco o cheque** no genera fila de caja, y la tabla de movimientos bancarios del dashboard **no tiene columna de acciones** → hoy ese pago no se puede anular desde la UI, y el guard de `anularVale` remite a un botón que en ese caso no existe. Se aborda en un cambio aparte: permitir anular desde la lista de vales y/o agregar acciones a la tabla de banco.

Doc completa: `docs/manuales-implementacion/financiero/PAGAR-VALES.md`

## Riesgo

**Medio.** Toca dinero, pero sin lógica de pago nueva: el motor es el mismo que ya paga compras y gastos. Migración aditiva y reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)