### PR TITLE
feat(financiero): control de acceso por caja + pagos de RRHH desde el hub

### DIFF
--- a/docs/manuales-implementacion/BUGS-TESTEO-2026-08-18.md
+++ b/docs/manuales-implementacion/BUGS-TESTEO-2026-08-18.md
@@ -590,3 +590,48 @@ Todos se alimentan de `rrhh/caja-virtual/graphql/CajaVirtualesActivas.ts` →
 **Alcance:** es cambio de UI. Las mutations (`pagarAguinaldo`, `pagarLiquidacion`,
 `confirmarVale`, …) siguen expuestas en GraphQL — aceptable como paso intermedio; el ACL de cajas
 las cubre cuando entre.
+
+---
+
+## F6 🔴 Pago consolidado — la descripción del movimiento muestra solo el primer documento, y el `origenTipo` es siempre PAGO_CPP
+
+**Dónde:** cualquier pago desde el hub que seleccione **más de un** documento. Reportado con
+gastos; aplica igual a compras y vales.
+
+**Síntoma 1 — la etiqueta miente** (`PagoProveedorService.java:257-265`):
+
+```java
+SolicitudPago gastoSol = spById.values().stream()
+    .filter(s -> s.getTipo() == TipoSolicitudPago.GASTO)
+    .findFirst().orElse(null);          // <-- el PRIMERO
+etiquetaPago = "#" + gastoSol.getId() + " - " + cat + " - " + benef + " - " + desc;
+```
+
+Se paga N gastos, el movimiento consolidado queda descrito como si fuera solo el primero.
+**Los datos están bien**: cada documento tiene su fila en `PagoSolicitudDetalle`
+(`pago_id`, `solicitud_pago_id`, `monto_solicitud`). Es la etiqueta, no el asiento.
+
+Los vales ya lo tenían resuelto a medias (`:274` → `"Pago de vales (N)"`); a gastos y compras
+nunca se les aplicó.
+
+**Síntoma 2 — `origenTipo` incorrecto** (`:307`): todos los pagos por este motor postean
+`OrigenMovimientoTipo.PAGO_CPP`, sea gasto, vale, compra o (ahora) liquidación. Con **F4** ya
+aplicado, un pago de gasto se muestra como **"Compra"**. Regresión introducida por F4.
+
+**Fix (3 partes):**
+
+1. **`origenTipo` según el concepto real** del evento: `GASTO` para gastos, `RRHH_*` para los
+   documentos de RRHH, `PAGO_CPP` para compras. Un evento no mezcla conceptos (el diálogo
+   agrupa por modo), pero si llegara a mezclarse se cae a `PAGO_CPP`.
+2. **Descripción por cardinalidad:** 1 documento → descripción específica de siempre;
+   N documentos → `"Pago consolidado de N gastos"` (o vales / compras / liquidaciones).
+   Generaliza lo que los vales ya hacían.
+3. **Detalle navegable:** el dashboard ya tiene el registro genérico *"Ir al origen"*
+   (`caja-virtual-dashboard.component.ts:371`, `origenNav`), que mapea cada `origenTipo` a su
+   pantalla. Se agrega la entrada para los pagos → diálogo **"Detalle del pago"** que lista los
+   documentos del evento con su monto imputado. El movimiento ya lleva
+   `referenciaId = origenId = pago.id` y `PagoSolicitudDetalle` tiene todo por `pago_id`.
+
+**Por qué no basta con cambiar el título:** el asiento tiene que seguir siendo **un** movimiento
+consolidado (es lo contablemente correcto, y la anulación ya opera sobre el evento entero). El
+desglose va aparte, leído de datos reales, no embutido en un string.

--- a/docs/manuales-implementacion/BUGS-TESTEO-2026-08-18.md
+++ b/docs/manuales-implementacion/BUGS-TESTEO-2026-08-18.md
@@ -24,10 +24,10 @@ Estados: 🔴 abierto · 🟡 en análisis · 🟢 corregido
 | B13 | Penalizaciones consolidadas en un ítem, sin detalle | 🔴 |
 | B14 | Aguinaldo sobre último sueldo, no sobre promedio percibido (INVESTIGADO) | 🔴 |
 | B15 | IPS del finiquito: sin prorrateo por días ni vacaciones en la base | 🔴 |
-| F1 | Ajuste de saldo en cuentas bancarias (solo existe en caja) | 🟠 |
-| F2 | Pagar liquidación/finiquito desde el hub de egreso de Caja Mayor | 🟠 |
+| F1 | Ajuste de saldo en cuentas bancarias (solo existe en caja) | ✅ **hecho** |
+| F2 | Pagar liquidación/finiquito desde el hub de egreso de Caja Mayor | ✅ **hecho** |
 | F3 | Retiro de PDV: recepción parcial + selección de monedas | 🟠 |
-| F4 | Todo pago figura "Pago Proveedor"; usar `origenTipo` para el label | 🔴 |
+| F4 | Todo pago figura "Pago Proveedor"; usar `origenTipo` para el label | ✅ **hecho** |
 | F5 | Premisa: pagos de caja mayor solo desde la caja mayor (ocultar en RRHH) | 🟠 |
 | **ACL** | **Acceso por caja: lista de usuarios R/W por caja virtual** — plan en `financiero/PLAN-ACL-CAJAS-VIRTUALES.md` | ⭐ **1ª** |
 
@@ -638,3 +638,54 @@ aplicado, un pago de gasto se muestra como **"Compra"**. Regresión introducida 
 **Por qué no basta con cambiar el título:** el asiento tiene que seguir siendo **un** movimiento
 consolidado (es lo contablemente correcto, y la anulación ya opera sobre el evento entero). El
 desglose va aparte, leído de datos reales, no embutido en un string.
+
+---
+
+## F7 🔴 REGRESIÓN (corregida) — el `origenTipo` real rompió la anulación del pago desde la caja
+
+**Cómo apareció:** probando el pago de liquidación en la UI. Al anular el movimiento desde el
+dashboard de la caja:
+
+> *"Este movimiento proviene de RRHH_LIQUIDACION_SUELDO; anúlelo desde su módulo de origen, no
+> desde la caja mayor."*
+
+**Causa:** la introdujo **F6**. Dos lugares decidían "esto es un pago del motor" mirando
+`origenTipo === 'PAGO_CPP'`:
+
+1. `caja-virtual-dashboard.onAnular` → elegía entre `anularPagoCpp(pagoId)` y el contra-movimiento simple.
+2. `TesoreriaService.anular` → bloquea todo origen que no sea `MANUAL`/`MALETIN`.
+
+Al pasar a postear el concepto real (`GASTO`, `RRHH_VALE`, `RRHH_LIQUIDACION_SUELDO`…), el front
+dejó de reconocer los pagos y los mandaba por el camino simple, que el backend rechaza. **Afectaba
+a todos los pagos hechos por el motor**, no solo a los de RRHH.
+
+**Por qué no alcanzaba con listar los orígenes nuevos en el front:** `RRHH_VALE`,
+`RRHH_LIQUIDACION_*` y `RRHH_AGUINALDO` los setean **tanto el motor de pago como los egresos
+directos viejos** de cada servicio de RRHH. El mismo valor significa dos cosas distintas, así que
+el `origenTipo` ya no puede responder la pregunta.
+
+**Fix:** lo contesta el backend. Campo nuevo `MovimientoCajaVirtual.esPagoConsolidado`, resuelto
+por `MovimientoCajaVirtualFieldResolver` desde `PagoSolicitudDetalle` (que apunta al movimiento
+del evento). El front lo usa para el ruteo de anulación **y** para ofrecer "Ver detalle del pago",
+lo que además eliminó la exclusión de `RRHH_VALE` que había puesto por esta misma ambigüedad.
+
+**Sin migración**: es un campo derivado.
+
+---
+
+## F8 🟠 PENDIENTE — los movimientos históricos siguen etiquetados como "Compra"
+
+**Dónde:** historial y dashboard de caja, movimientos **anteriores** a F6.
+
+**Síntoma:** un pago de vale hecho el 17/08 se muestra como **"Compra"**, y uno de gasto también.
+Verificado en la DB: esas filas tienen `origen_tipo = PAGO_CPP` porque se crearon antes del fix.
+
+F6 corrige los movimientos **nuevos**; no reescribe el pasado. Mientras no se corrija, el
+historial mezcla etiquetas correctas (lo nuevo) con incorrectas (lo viejo), que es más confuso
+que cuando todo decía "Pago Proveedor".
+
+**Fix propuesto:** script de backfill (a mano, como el del ACL) que corrija `origen_tipo` de los
+movimientos de pago, resolviendo el concepto por el tipo de la `SolicitudPago` asociada vía
+`pago_solicitud_detalle`, y para las de tipo RRHH por el documento dueño. Ojo: hay que **excluir
+los egresos directos viejos** (los que no tienen fila en `pago_solicitud_detalle`), que ya tienen
+su origen correcto.

--- a/docs/manuales-implementacion/BUGS-TESTEO-2026-08-18.md
+++ b/docs/manuales-implementacion/BUGS-TESTEO-2026-08-18.md
@@ -1,0 +1,592 @@
+# Bugs de testeo — sesión 2026-08-18
+
+Registro de errores encontrados probando el módulo RRHH en desktop (rama `develop`)
+contra central local. **Sin investigar todavía** — solo captura del síntoma.
+
+Estados: 🔴 abierto · 🟡 en análisis · 🟢 corregido
+
+## Índice
+
+| # | Título | Sev |
+|---|---|---|
+| B1 | Ajuste salario mínimo global — `Integer cannot be cast to Long` al guardar | 🔴 |
+| B2 | Mismo diálogo — "Sueldo actual" muestra `1`/`2`, "Cargo" vacía | 🔴 |
+| B3 | Mismo diálogo — dice 15 seleccionados, lista 10 filas | 🔴 |
+| B4 | No existe CRUD de cargos en desktop (backend listo) | 🔴 |
+| B5 | Toggle IPS en `false` igual descuenta en liquidación mensual | 🔴 |
+| B6 | No se puede eliminar un ítem automático del borrador | 🔴 |
+| B7 | Recibo: total sin descuentos en la firma + 2 vías + línea punteada | 🟠 |
+| B8 | Recibo: header con empresa emisora + "Recibí de … la suma de …" | 🟠 |
+| B9 | Liquidación toma el salario anterior (probable consecuencia de B1) | 🔴 |
+| B10 | Penalización automática: solo un día, falta rango de fechas | 🟠 |
+| B11 | Amonestaciones/advertencias sin monto + contador + acta firmable | 🟠 |
+| B12 | Ítem manual: select de operación (hoy todo sale "AJUSTE") | 🟠 |
+| B13 | Penalizaciones consolidadas en un ítem, sin detalle | 🔴 |
+| B14 | Aguinaldo sobre último sueldo, no sobre promedio percibido (INVESTIGADO) | 🔴 |
+| B15 | IPS del finiquito: sin prorrateo por días ni vacaciones en la base | 🔴 |
+| F1 | Ajuste de saldo en cuentas bancarias (solo existe en caja) | 🟠 |
+| F2 | Pagar liquidación/finiquito desde el hub de egreso de Caja Mayor | 🟠 |
+| F3 | Retiro de PDV: recepción parcial + selección de monedas | 🟠 |
+| F4 | Todo pago figura "Pago Proveedor"; usar `origenTipo` para el label | 🔴 |
+| F5 | Premisa: pagos de caja mayor solo desde la caja mayor (ocultar en RRHH) | 🟠 |
+| **ACL** | **Acceso por caja: lista de usuarios R/W por caja virtual** — plan en `financiero/PLAN-ACL-CAJAS-VIRTUALES.md` | ⭐ **1ª** |
+
+### Causas raíz agrupadas
+
+1. **El sueldo se lee siempre del valor actual y es `Float`.** `FuncionarioSalarioHistorico` se
+   escribe pero nadie lo lee para calcular. → **B14, B9**, sospecha en **B1/B2**.
+2. **Los ítems automáticos no guardan referencia a su origen** ni se pueden editar. → **B6, B13**.
+3. **El recibo no identifica a la empresa ni respeta el formato legal.** → **B7, B8**.
+4. **Backend listo, falta UI** (quick wins): **B4** (`saveCargo`), **F1** (`AJUSTE_POSITIVO/NEGATIVO`),
+   **F2** (`pagar(id, cajaVirtualId)`), **F4** (`origenTipo` ya persistido).
+
+---
+
+## B1 🔴 Actualización de salario mínimo global — `Integer cannot be cast to Long` al guardar
+
+**Dónde:** Configuración RRHH → salario mínimo global → diálogo *"Funcionarios por debajo del nuevo mínimo"* → botón **Ajustar seleccionados (15)**.
+
+**Síntoma:** el mutation falla:
+
+```
+[GraphQL error]: Message: Exception while fetching data (/data) :
+class java.lang.Integer cannot be cast to class java.lang.Long
+(java.lang.Integer and java.lang.Long are in module java.base of loader 'bootstrap'),
+Location: [object Object], Path: data
+```
+
+**Efecto:** ningún ajuste salarial se persiste.
+
+---
+
+## B2 🔴 Mismo diálogo — columna "Sueldo actual" muestra `1` / `2` y "Cargo" viene vacía
+
+**Dónde:** el mismo diálogo *"Funcionarios por debajo del nuevo mínimo"*.
+
+**Síntoma:** de 10 filas visibles, 8 muestran `1` o `2` en **Sueldo actual** y la columna
+**Cargo** está vacía en todas. Solo 2 filas traen sueldo plausible
+(GABRIEL FRANCO AREVALOS 2.800.000, PAMELA STASHAKI 2.900.000).
+
+Consecuencia directa: la columna **Diferencia** calcula sobre ese valor y muestra
+`+3.043.999` / `+3.043.998` (mínimo nuevo 3.044.000 − 1 o − 2).
+
+**Sospecha (sin verificar):** desalineación de columnas — el valor de `cargo` cayendo en
+la celda de sueldo, o `sueldo` llegando null y renderizando otro campo.
+
+---
+
+## B3 🔴 Mismo diálogo — el botón dice 15 seleccionados pero la lista muestra 10 filas
+
+**Síntoma:** **"Ajustar seleccionados (15)"** con solo 10 funcionarios listados y sin
+paginador visible. No se puede ver ni deseleccionar los 5 restantes.
+
+**Sospecha (sin verificar):** lista truncada en el render, o paginador faltante.
+
+---
+
+## B4 🔴 No existe acceso a creación/edición de cargos en desktop
+
+**Dónde:** ningún lado — el CRUD de cargos no está construido en el frontend.
+
+**Estado por capa:**
+
+| Capa | Qué hay |
+|---|---|
+| central | Completo: `empresarial/cargo.graphqls` expone `saveCargo(cargo: CargoInput!)` y `deleteCargo(id)` |
+| desktop | Solo lectura: `app/modules/empresarial/cargo/` tiene `cargo.model.ts`, `cargo.service.ts` (`onGetAll` / `onSearch`) y queries `Cargos` / `CargosSearch` / `cargo(id)`. Sin componentes, sin mutation, sin entrada de acceso |
+| mobile / mobile-pwa | Nada (`saveCargo` no aparece) |
+
+Sus hermanos de `empresarial` sí tienen UI: `sector/` (`list-sector` + `adicionar-sector-dialog`),
+`sucursal/` (`list-sucursal` + `edit-sucursal-dialog`), `zona/` (`adicionar-zona-dialog`).
+Cargo se quedó sin la capa de UI.
+
+**Efecto:** los cargos solo se pueden crear por SQL. RRHH puede *asignarlos*
+(`CambioCargoDialogComponent` → `cargoService.onSearch()`) pero no crearlos.
+
+**Dónde iría el acceso:** los CRUDs de `empresarial` no cuelgan del menú lateral ni de rutas,
+se abren desde el **buscador global** — array `componenteList` en
+`app/shared/widgets/search-bar-dialog/search-bar.service.ts:47`. Falta la entrada análoga a:
+
+```ts
+{ title: 'Lista de sectores', component: ListSectorComponent, visibilityRoles: [ROLES.ADMIN] },
+```
+
+**Piezas a construir (patrón de sector):** mutation `SaveCargo` en `cargo/graphql/`,
+`list-cargo` + `adicionar-cargo-dialog`, y la entrada en `componenteList`.
+
+---
+
+## B5 🔴 Legajo — toggle de IPS en `false` igual genera descuento de IPS en la liquidación mensual
+
+**Dónde:** Legajo del funcionario → toggle de IPS desactivado → liquidación mensual del período.
+
+**Síntoma:** la liquidación arrastra el descuento de IPS aunque el funcionario tenga el
+toggle en `false`. La bandera del legajo no se respeta al armar el borrador.
+
+**Efecto:** neto mal calculado (de menos) para todo funcionario sin IPS.
+
+---
+
+## B6 🔴 Liquidación mensual — no se puede eliminar un ítem generado automáticamente
+
+**Dónde:** Liquidaciones → generar borrador de liquidación mensual → detalle del borrador.
+
+**Síntoma:** los ítems que el motor arma solos (vales, cuotas de préstamo, bonos, aguinaldo,
+horas extra, penalizaciones) no tienen forma de quitarse del borrador. Solo se pueden agregar
+o editar manuales.
+
+**Efecto:** si el motor arrastra un ítem que no corresponde (ver B5 con IPS), no hay salida por
+UI — hay que corregir el dato de origen y regenerar el borrador, o tocar la DB.
+
+**Pedido:** evaluar agregar un **icono de eliminar por fila** en la tabla de ítems del borrador,
+habilitado también para los automáticos.
+
+**A analizar antes de implementar** (no investigado todavía):
+- ¿el borrador es reversible? Si se elimina la cuota de un préstamo, ¿qué pasa con el estado de
+  la cuota al pagar la liquidación (cuota→PAGADA, vale→DESCONTADO)?
+- ¿regenerar el borrador vuelve a insertar el ítem eliminado? Si sí, hace falta marca de
+  exclusión, no borrado físico.
+- ¿debe quedar rastro (auditoría / motivo) de quién quitó un ítem automático?
+- ¿gating por rol — `RRHH LIQUIDAR` alcanza o hace falta uno más alto?
+
+---
+
+## B7 🟠 MEJORA — Recibo de liquidación mensual: mostrar total recibido sin descuentos y duplicar el bloque de firma (2 vías)
+
+**Dónde:** documento PDF de la liquidación mensual — plantilla candidata
+`central/src/main/resources/reports/recibo-liquidacion.jrxml` (confirmar cuál usa el flujo mensual;
+también existen `recibo-rrhh.jrxml`, `recibo-ticket-58/80.jrxml`).
+
+**Pedido (3 cambios):**
+
+1. En la **descripción del sector de firma del funcionario**, que figure el **total recibido sin
+   descontar nada** (bruto / suma de haberes), no el neto.
+2. **Duplicar** al final del documento el bloque completo: *total recibido · descontado · final ·
+   descripción · firma* — para tener **2 vías** (una queda para el funcionario, la otra para la
+   empresa).
+3. **Línea punteada** de corte entre las dos vías.
+
+**A definir:** si el cambio aplica también a la versión **Ticket ESC/POS** (58/80 mm) o solo al
+PDF A4 — en ticket la doble vía se resuelve normalmente imprimiendo dos veces, no duplicando el
+cuerpo.
+
+---
+
+## B8 🟠 MEJORA — Recibo de liquidación: header con datos de la empresa emisora + descripción en primera persona
+
+**Dónde:** misma plantilla que B7 (`recibo-liquidacion.jrxml` y las variantes de recibo RRHH).
+
+**Pedido (2 cambios):**
+
+1. **Header:** agregar los datos de la **empresa emisora** (razón social, RUC, dirección,
+   teléfono — definir el set exacto). Hoy el recibo no identifica quién paga.
+2. **Descripción:** redactarla como declaración del funcionario, nombrando a la empresa.
+   Formato pedido:
+
+   > *"Recibí de la Franco Arevalos S.A. la suma de ......... por concepto de ........."*
+
+   Se combina con B7: el monto de esa frase es el **total recibido sin descuentos**.
+
+**A definir:**
+- ¿de dónde sale la empresa emisora — entidad `Empresa`/`Sucursal` del central, o parámetro de
+  configuración RRHH? Si el recibo se emite por sucursal, ¿los datos son de la sucursal o de la
+  razón social única?
+- ¿el header va también en la versión ticket 58/80 mm (ancho limitado)?
+- si son 2 vías (B7), el header, ¿se repite en la segunda vía o va una sola vez arriba?
+
+---
+
+## B9 🔴 Liquidación mensual — en algunos casos toma el salario anterior y no el nuevo
+
+**Dónde:** Liquidaciones → generar borrador mensual, sobre funcionarios con cambio de salario.
+
+**Síntoma:** el haber de sueldo sale con el **salario anterior** en lugar del vigente. No pasa
+siempre — solo en algunos casos.
+
+**Efecto:** neto mal calculado. Grave, porque es plata pagada de menos (o de más) sin que salte
+ningún error.
+
+**Pistas a chequear** (sin investigar todavía):
+- ¿el motor lee `funcionario.salario` o el **histórico salarial** vigente al período? Si lee el
+  histórico, ¿compara por `fechaDesde <= fin del período` o por fecha de creación del registro?
+- relación con **B1/B2**: los ajustes por salario mínimo global no persisten y la lista muestra
+  sueldos basura — ¿el histórico salarial quedó inconsistente para esos funcionarios?
+- ¿el borrador ya generado antes del cambio de salario se recalcula al regenerar, o queda con el
+  valor viejo congelado?
+- identificar **qué funcionarios** lo reproducen y qué tienen en común (cambio de salario dentro
+  del propio período vs. antes del período).
+
+---
+
+## B10 🟠 MEJORA — Penalizaciones: la generación automática solo acepta un día, hace falta rango de fechas
+
+**Dónde:** RRHH → Penalizaciones → generación automática (por tardanzas/ausencias sobre marcaciones).
+
+**Síntoma:** el selector permite elegir **un solo día**. Para cubrir un período hay que correr el
+proceso día por día.
+
+**Pedido:** permitir **rango de fechas** (desde / hasta), típicamente el período de liquidación
+completo en una sola corrida.
+
+**A definir:**
+- ¿genera **una penalización por día** dentro del rango, o una consolidada por el rango?
+  (afecta el detalle del recibo y el arrastre a la liquidación)
+- **idempotencia:** si el rango se solapa con una corrida anterior, ¿saltea los días ya
+  penalizados o duplica? Hoy con un día suelto el riesgo es bajo; con rango se vuelve crítico.
+- ¿respeta feriados y justificativos ya cargados en todo el rango?
+- ¿preview antes de confirmar (lista de lo que va a generar) o generación directa?
+
+---
+
+## B11 🟠 FEATURE — Penalizaciones: amonestaciones / advertencias (sin monto), acumulador y documento firmable
+
+**Dónde:** RRHH → Penalizaciones. Feature nuevo, no es un fix.
+
+**Pedido (3 partes):**
+
+1. **Generar amonestaciones de advertencia** como tipo de penalización **sin descuento en dinero**
+   — hoy toda penalización termina en un monto que descuenta la liquidación.
+2. **Registrar y acumular la cantidad de advertencias** por funcionario (contador consultable,
+   visible en el legajo / dashboard).
+3. **Documento firmable de advertencia** — recibo/acta imprimible que el funcionario firma,
+   mismo patrón que los 7 recibos existentes (PDF A4 + evaluar ticket).
+
+**A definir:**
+- ¿entidad nueva o un campo `tipo` en `Penalizacion` (`DESCUENTO` / `ADVERTENCIA`)? Si es lo
+  segundo, hay que garantizar que las de tipo advertencia **nunca** entren al borrador de
+  liquidación.
+- **escalamiento:** ¿N advertencias acumuladas disparan algo (penalización con monto, aviso,
+  bloqueo)? ¿el contador se resetea por año / por período?
+- contenido del acta: motivo, fecha del hecho, descripción, quién la emite, número de advertencia
+  ("2ª advertencia"), espacio de firma de funcionario y de la empresa.
+- ¿el funcionario puede **negarse a firmar** — hace falta registrar ese estado?
+- plantilla nueva `.jrxml` (aplican los mismos cambios de header/empresa de B8).
+
+---
+
+## B12 🟠 MEJORA — Liquidación mensual: el ítem manual necesita un select de tipo de operación (hoy sale todo como "AJUSTE")
+
+**Dónde:** Liquidaciones → detalle del borrador mensual → formulario *agregar ítem*.
+
+**Síntoma:** todo ítem cargado a mano se emite como **AJUSTE** en el documento. El recibo no
+explica qué se pagó o descontó, y el signo (haber vs descuento) se elige aparte.
+
+**Pedido:**
+- **select con una lista de operaciones** en el formulario de agregar ítem.
+- que la operación elegida **determine sola si es haber o descuento** — sin campo separado para
+  el signo.
+- que en el documento generado figure el **nombre de la operación**, no "AJUSTE".
+
+**A definir:**
+- ¿lista **parametrizable** (catálogo tipo motivos de vale, editable desde Configuración RRHH) o
+  **enum fijo** en código? Recomendable catálogo: cada entrada con nombre, naturaleza
+  (`HABER`/`DESCUENTO`) y activo/inactivo.
+- ¿se deja "AJUSTE" como entrada genérica para lo que no encaje, o desaparece?
+- **retrocompatibilidad:** los ítems ya guardados como AJUSTE — ¿migran a una operación por
+  defecto o se dejan como están?
+- ¿la naturaleza es fija por operación o admite override manual (con confirmación)?
+- ¿aparecen agrupados por naturaleza en el recibo (haberes arriba, descuentos abajo)?
+
+---
+
+## B13 🔴 Liquidación mensual — las penalizaciones se consolidan en un solo ítem y no se sabe de qué se tratan
+
+**Dónde:** Liquidaciones → borrador mensual → ítems de descuento por penalización.
+
+**Síntoma:** todas las penalizaciones del período colapsan en **un único ítem consolidado**. Ni en
+la UI ni en el recibo se puede saber qué penalizaciones lo componen.
+
+**Efecto:** el funcionario firma un descuento que no puede auditar, y RRHH no puede justificarlo
+sin ir a la DB. Agravado por B6: el ítem consolidado tampoco se puede eliminar.
+
+**Pedido:**
+- **un ítem por penalización** (no uno consolidado).
+- la **observación** de cada ítem con el formato **`tipo: descripción`**
+  (ej. `TARDANZA: 35 min del 2026-07-08`).
+
+**A definir:**
+- ¿aplica el mismo criterio a los otros grupos automáticos (vales, cuotas de préstamo, bonos,
+  horas extra)? ¿o solo penalizaciones? Si el recibo queda muy largo, evaluar detalle por ítem en
+  UI + agrupado en el PDF (decidir explícitamente, no por accidente).
+- **trazabilidad:** cada ítem debería guardar el `penalizacionId` de origen — necesario para B6
+  (borrado selectivo) y para reversar efectos al pagar.
+- se combina con **B12**: el tipo de penalización debería ser una operación del catálogo, así el
+  documento muestra el nombre real en vez de "AJUSTE".
+- ¿las advertencias sin monto de **B11** quedan fuera de la liquidación (sí) pero visibles en algún
+  anexo informativo del recibo?
+
+---
+
+## B14 🔴 Aguinaldo — se calcula sobre el último sueldo, nunca sobre el promedio de lo percibido (INVESTIGADO)
+
+**Reportado como:** "el aguinaldo debe ser el promedio del total recibido mes a mes; parece que
+cuando el funcionario no tiene historial toma el último salario".
+
+**Hallazgo — el matiz del historial no existe: NUNCA mira historial.** El cálculo toma siempre el
+sueldo actual del funcionario, tenga historial salarial o no.
+
+`AguinaldoService.calcularAguinaldosAnio()` (`service/rrhh/AguinaldoService.java:83`):
+
+```java
+BigDecimal sueldo = new BigDecimal(f.getSueldo().toString());   // <-- sueldo ACTUAL
+BigDecimal monto = AguinaldoCalculator.calcularMonto(sueldo, mesesDevengados);
+```
+
+`AguinaldoCalculator.calcularMonto()` = `sueldo × meses / 12`. La única entrada de dinero es ese
+sueldo puntual: no hay promedio, no hay suma de percibido, no se leen las liquidaciones del año.
+
+**Alcance del problema — es transversal, no solo aguinaldo.** `FuncionarioSalarioHistorico`
+(con `fechaVigencia` + `salarioNuevo`) **se escribe pero nadie lo lee para calcular**: solo lo
+consume `FuncionarioRrhhGraphQL.funcionarioSalarioHistoricos()` para mostrarlo en el legajo.
+Todos los cálculos de dinero de RRHH leen `f.getSueldo()` (valor actual, puntual):
+
+| Servicio | Línea |
+|---|---|
+| `AguinaldoService` | :83 |
+| `LiquidacionSueldoService` | :198 |
+| `LiquidacionFinalService` | :167, :240, :483, :518 |
+| `VacacionService` | :237-238 |
+| `HoraExtraService` | :67-69 |
+| `ReporteRrhhService` | :168 |
+
+**Consecuencias:**
+- Si hubo **aumento** durante el año, el aguinaldo paga **de más**; si hubo baja, **de menos**.
+- No entra al promedio nada de lo demás percibido (horas extra, bonos, comisiones), que por ley
+  cuenta como remuneración.
+- **Relación con B9:** que la liquidación "tome el salario anterior" es coherente con esto — el
+  motor lee `f.getSueldo()`, así que si el ajuste no se persistió (B1) el valor viejo es el que
+  queda. B9 puede ser consecuencia de B1, no un bug independiente.
+
+**Hallazgo colateral 🔴 `Funcionario.sueldo` es `Float`** (`domain/personas/Funcionario.java:57`,
+columna `numeric` en DB). Dinero en punto flotante binario: todo cálculo de RRHH arranca de un
+`new BigDecimal(float.toString())`. Candidato a los descuadres de redondeo y sospechoso también de
+B1/B2 (mezcla de tipos numéricos).
+
+**A definir antes de corregir:**
+- **fórmula legal exacta:** aguinaldo = total percibido en el año calendario / 12. Equivale a
+  (promedio mensual × meses trabajados) / 12 — hay que fijar cuál se implementa y qué conceptos
+  entran al "percibido" (¿solo sueldo? ¿+ HE, bonos, comisiones?).
+- **fuente del percibido:** ¿sumar las `LiquidacionSueldo` pagadas del año (real, pero rompe si
+  falta algún mes cargado), o reconstruir desde `FuncionarioSalarioHistorico` por
+  `fechaVigencia` (siempre disponible, pero ignora variables)?
+- **funcionarios sin historial ni liquidaciones** (los nuevos): fallback al sueldo actual —
+  documentarlo como decisión, no dejarlo implícito.
+- ¿se **recalculan** los aguinaldos ya `CALCULADO` del año en curso, y qué pasa con los
+  `APROBADO`/`PAGADO` que quedaron con el monto viejo congelado?
+- migrar `Funcionario.sueldo` a `BigDecimal` (toca las 6 clases de la tabla + GraphQL + desktop).
+
+---
+
+## B15 🔴 Liquidación final — el IPS no es proporcional a los días trabajados ni incluye vacaciones causadas/proporcionales en la base
+
+**Dónde:** Liquidación final / finiquito → descuento automático de IPS.
+
+**Comportamiento actual** (`service/rrhh/LiquidacionFinalService.java:209-314`):
+
+```java
+BigDecimal ipsBase = in.getIpsBase() != null ? in.getIpsBase() : salarioPromedio;   // :209
+...
+BigDecimal ips = base.multiply(ipsPct).divide(new BigDecimal("100"), 0, HALF_UP);   // :314
+```
+
+O sea: **base = salario promedio mensual completo** (o el override manual del diálogo), por el
+`IPS_PORCENTAJE_FUNCIONARIO` (default 9%). No prorratea por días trabajados en el mes de egreso, y
+no suma las vacaciones al base.
+
+**Comportamiento requerido:**
+
+1. **Proporcional a los días trabajados** del mes de egreso — no el mes completo.
+2. La **base** debe ser la suma de:
+   - **sueldo** (la parte proporcional trabajada),
+   - **vacaciones causadas** — las ya vencidas / devengadas y no gozadas del funcionario,
+   - **vacaciones proporcionales** — las devengadas del período en curso, que todavía no llegaron
+     a la fecha en que podían usarse.
+
+**A definir:**
+- **divisor del prorrateo:** ¿30 días fijos, o días reales del mes de egreso? (fijarlo, porque
+  cambia el monto).
+- ¿el override manual `ipsBase` del diálogo se mantiene como escape, y qué muestra por defecto —
+  la base ya calculada con las 3 partes?
+- ¿el aguinaldo entra o no a la base de IPS? (no está en el pedido — confirmar con contabilidad,
+  porque suele estar exento).
+- se combina con **B5**: hay que respetar `ipsActivo=false` acá también (`:238` usa
+  `!Boolean.FALSE.equals(f.getIpsActivo())`, revisar que el default no fuerce el descuento).
+- ¿el recibo de finiquito debe **desglosar** la base del IPS (sueldo + causadas + proporcionales)
+  o mostrar solo el monto? Empalma con B13 (trazabilidad de descuentos).
+
+---
+
+# Módulo Financiero
+
+## F1 🟠 MEJORA — Ajuste de saldo en cuentas bancarias (hoy solo existe para caja)
+
+**Dónde:** Financiero → cuentas bancarias. El ajuste existe únicamente en el hub de ingreso/egreso
+de **caja virtual**.
+
+**Situación actual:**
+- Hub de caja: `registrar-ingreso-dialog.component.ts:29` ofrece
+  `{ tipo: 'AJUSTE', titulo: 'Ajuste de Saldo', descripcion: 'Corrección positiva del saldo con motivo' }`
+  → genera `CajaVirtualTipoMovimiento.AJUSTE` (`:55`). Idem en el hub de egreso.
+- **Backend bancario ya soporta el ajuste:** `MovimientoBancarioTipo` tiene `AJUSTE_POSITIVO` y
+  `AJUSTE_NEGATIVO`, y el dashboard de caja virtual ya los sabe renderizar
+  (`caja-virtual-dashboard.component.ts:86-96` → "Ajuste +" / "Ajuste −" con color).
+- **Falta la UI** en `cuenta-bancaria/` (hoy solo `add-cuenta-bancaria-dialog`) para emitirlos.
+  Verificar si el resolver/mutation de movimiento bancario acepta esos tipos o si también falta ahí.
+
+**Pedido:** poder ajustar el saldo de una cuenta bancaria, con el mismo criterio que el ajuste de
+caja (positivo/negativo + motivo obligatorio).
+
+**A definir:**
+- ¿desde dónde se dispara — un hub de ingreso/egreso propio de la cuenta bancaria, o un botón
+  "Ajustar saldo" en el detalle/lista de cuentas?
+- **motivo obligatorio** y **gating por rol** (un ajuste de saldo bancario es plata creada de la
+  nada: debería exigir rol alto y quedar auditado con usuario + fecha + motivo).
+- ¿el ajuste se ingresa como **monto de corrección** (+/−) o como **saldo objetivo** y el sistema
+  calcula la diferencia? La segunda es más natural para conciliar contra el extracto.
+- ¿impacta conciliación bancaria / algún reporte que asuma que todo movimiento tiene contrapartida?
+
+---
+
+## F2 🟠 MEJORA — Pagar liquidación mensual y finiquito desde el hub de egreso de Caja Mayor (patrón "Pagar Compras" / "Pagar Gasto")
+
+**Dónde:** Financiero → Caja Virtual/Mayor → hub de **Registrar Egreso**. Cruza Financiero ↔ RRHH.
+
+**Situación actual:**
+- El pago **ya existe del lado RRHH**, pero solo desde RRHH:
+  `LiquidacionSueldoService.pagar(id, cajaVirtualId)` (`:457`) y
+  `LiquidacionFinalService.pagar(id, cajaVirtualId)` (`:561`).
+- El hub de egreso (`registrar-egreso-dialog.component.ts:26-32`) ya expone el patrón pedido:
+  `PAGO_CPP` → "Pagar Compras" (con `pagar-compras-dialog`), `GASTO` → "Pagar Gasto",
+  `VALE` → "Registrar Vale". **No hay entrada para liquidaciones.**
+
+**Pedido:** agregar al hub de egreso las opciones para **pagar liquidación mensual** y **pagar
+finiquito**, con el mismo flujo que compras/gastos: elegir de una lista de pendientes → confirmar →
+egreso de caja + cambio de estado.
+
+**A definir:**
+- ¿una sola entrada "Pagar Liquidaciones" con tabs mensual/finiquito, o dos entradas separadas?
+- **pago múltiple:** `pagar-compras-dialog` permite seleccionar varias solicitudes. ¿Se puede pagar
+  la nómina de varios funcionarios en un solo egreso, o uno por uno? Si es múltiple, ¿un movimiento
+  de caja consolidado o uno por funcionario? (afecta la trazabilidad y el recibo).
+- **filtro de estado:** solo liquidaciones aprobadas/pendientes de pago; no mostrar borradores.
+- **reutilizar la mutation existente** (`pagar(id, cajaVirtualId)`) en lugar de duplicar lógica —
+  ahí ya viven los efectos cruzados (vale→DESCONTADO, cuota→PAGADA).
+- ¿el hub ofrece imprimir el recibo al terminar, como se hace hoy desde RRHH?
+- **gating por rol:** el operador de caja no necesariamente tiene rol RRHH. Definir si pagar desde
+  el hub exige `RRHH LIQUIDAR` o alcanza el rol de caja (implica ver montos de sueldos —
+  sensible, ver `seguridad-roles.md` de la skill rrhh-expert).
+
+---
+
+## F3 🟠 MEJORA — Ingreso de retiro de PDV a Caja Mayor: recepción parcial y selección de monedas a recibir
+
+**Dónde:** Caja Mayor → hub Registrar Ingreso → "Ingresar Retiro de PDV"
+(`caja-virtual/ingresar-retiro-caja-mayor-dialog/`).
+
+**Situación actual — es todo o nada:** se tildan retiros de una lista y se llama
+`retiroService.onIngresarACajaMayor(r.id, r.sucursalId, caja.id)` por cada uno
+(`ingresar-retiro-caja-mayor-dialog.component.ts:150-153`). La mutation **no recibe monto ni
+moneda**: entra el retiro completo con sus 3 monedas juntas. El diálogo solo *muestra* el desglose
+(`formatMontos()` → `retiroGs` / `retiroRs` / `retiroDs`) y acumula totales por moneda, pero no
+permite elegir.
+
+**Pedido:**
+1. **Recepción parcial** — poder recibir menos que el total del retiro (lo que efectivamente llegó
+   en el maletín).
+2. **Selección de monedas** — elegir cuáles de Gs / R$ / US$ se reciben, y cuánto de cada una.
+
+**A definir (esto es lo que hace el cambio no trivial):**
+- **¿qué pasa con el remanente?** Un retiro parcialmente recibido no puede quedar "cerrado". Opciones:
+  (a) queda flotante por el saldo, (b) se genera una **diferencia** con destino
+  (ver `DiferenciaDestinoTipo`, que ya existe), (c) queda en estado `PARCIAL` nuevo.
+  **Decidir esto primero** — condiciona el modelo de datos.
+- **estado del retiro:** hoy `EstadoRetiro` probablemente no contempla parcial. Cambio de enum +
+  migración + revisar todo lo que filtra "flotantes" (`RetiroService.findFlotantes`).
+- **replicación:** el retiro nace en el filial/PDV y llega al central por replicación (ver
+  `runbooks/replication.md`). Si el central marca recepción parcial, hay que definir si eso
+  vuelve al origen o queda solo en central.
+- ¿la Caja Mayor maneja las 3 monedas o solo Gs? Si es solo Gs, "seleccionar monedas" implica
+  decidir qué pasa con R$/US$ (¿quedan flotando? ¿van a otra caja?).
+- **auditoría:** quién recibió, cuánto declaró el PDV vs cuánto se recibió, y motivo de la
+  diferencia. Es el punto donde aparecen los faltantes de efectivo — tiene que quedar registrado.
+
+---
+
+## F4 🔴 Caja Mayor — todo pago figura como "Pago Proveedor"; el tipo debería reflejar el concepto (Gasto / Compra / Vale / …)
+
+**Dónde:** Caja Mayor → historial de movimientos y dashboard. Se ve al pagar un gasto: sale
+**"Pago Proveedor"** en lugar de "Gasto".
+
+**Causa (identificada, no corregida) — hay dos enums y la UI muestra el grueso:**
+
+| Enum | Granularidad | Valores |
+|---|---|---|
+| `CajaVirtualTipoMovimiento` | grueso (**el que se muestra**) | `INGRESO`, `EGRESO`, `TRANSFERENCIA_ENTRADA/SALIDA`, `PAGO_PROVEEDOR`, `AJUSTE` |
+| `OrigenMovimientoTipo` | **fino, ya existe y ya se persiste** | `GASTO`, `PAGO_CPP`, `RRHH_VALE`, `RRHH_PRESTAMO`, `RRHH_AGUINALDO`, `RRHH_LIQUIDACION_SUELDO`, `RRHH_LIQUIDACION_FINAL`, `RETIRO_CAJA`, `VENTA_CREDITO_COBRO`, `DEVOLUCION`, `CHEQUE`, `ACREDITACION_POS`, `MALETIN`, `ENTRADA_VARIA`, `OPERACION_FINANCIERA`, `MANUAL`, `ANULACION` |
+
+`PagoProveedorService:298` setea `tipoMovimiento = PAGO_PROVEEDOR` y `:304` setea
+`origenTipo = PAGO_CPP`. El dato fino **ya está guardado**; la UI simplemente no lo usa:
+`historial-movimientos-caja-virtual.component.ts:46` y `caja-virtual-dashboard.component.ts:122`
+mapean labels/colores desde `tipoMovimiento`.
+
+**Pedido:** que el movimiento muestre el concepto real — "Gasto", "Compra", "Vale", "Liquidación",
+"Aguinaldo", etc.
+
+**Fix probable — cambio de UI, no de modelo:** mapear label y color desde **`origenTipo`**
+(con fallback a `tipoMovimiento` cuando sea `MANUAL`), en los dos componentes. No hace falta
+migración ni enum nuevo.
+
+**A verificar:**
+- que **todos** los flujos de pago seteen `origenTipo` correctamente. Confirmado en
+  `PagoProveedorService`; **falta verificar el pago de gastos** — en `GastoTesoreriaService` /
+  `GastoService` no aparecen `setTipoMovimiento` ni `setOrigenTipo`, así que hay que rastrear por
+  dónde crea el movimiento (si va por `PagoProveedorService`, ahí está el porqué del label).
+- el **filtro por tipo** del dashboard (`caja-virtual-dashboard.component.ts:113`) — si el label
+  pasa a ser el origen, el filtro debería filtrar por origen también.
+- `TesoreriaService:49` usa `tipo == PAGO_PROVEEDOR` como condición lógica: **no** tocar
+  `tipoMovimiento` sin revisar ese punto (por eso conviene cambiar solo la presentación).
+
+---
+
+## F5 🟠 PREMISA — "Pagos desde caja mayor solamente estando en caja mayor": ocultar el pago desde las pantallas de RRHH
+
+**Decisión tomada 2026-08-19.** Hoy hay 7 caminos para sacar plata de una caja mayor: el hub de
+egreso, y 6 diálogos de RRHH que traen su propio selector de caja. Se unifica en el hub.
+
+**Componentes que hoy pagan sin estar en la caja** (desktop, todos con selector de caja propio):
+
+| Componente | Concepto |
+|---|---|
+| `rrhh/vale/confirmar-vale-dialog` | vale / adelanto |
+| `rrhh/aguinaldo/pagar-aguinaldo-dialog` | aguinaldo (pago separado) |
+| `rrhh/prestamo/edit-prestamo-dialog` | desembolso de préstamo |
+| `rrhh/prestamo/prestamo-cuotas-dialog` | cobro de cuota (**ingreso**, no egreso) |
+| `rrhh/liquidacion/liquidacion-detalle-dialog` | liquidación mensual |
+| `rrhh/liquidacion-final/liquidacion-final-dialog` | finiquito |
+
+Todos se alimentan de `rrhh/caja-virtual/graphql/CajaVirtualesActivas.ts` →
+`cajaVirtualesActivas()`, **la única query de caja sin gate de seguridad**
+(`CajaVirtualGraphQL:131`). Ocultar estos selectores elimina su consumidor principal.
+
+**Por qué:**
+1. **Separación de funciones** — RRHH liquida y aprueba, tesorería paga. Que la misma persona
+   liquide y saque la plata en la misma pantalla es lo que un control interno evita.
+2. **Habilita el ACL por caja** (ver `financiero/PLAN-ACL-CAJAS-VIRTUALES.md` §7.5): con la premisa,
+   RRHH **no necesita escritura sobre ninguna caja**. Sin ella habría que dársela a todo liquidador.
+3. **Un solo camino auditable** en vez de siete.
+
+**Huecos del hub a completar ANTES de ocultar** (si no, RRHH queda sin poder pagar):
+
+| Concepto | Estado en el hub |
+|---|---|
+| Vale | ✅ egreso → "Registrar Vale" |
+| Liquidación mensual / finiquito | ❌ → **F2** |
+| Aguinaldo (pago separado) | ❌ falta |
+| Desembolso de préstamo | ❌ falta |
+| Cobro de cuota de préstamo | ❌ falta — va al hub de **ingreso** |
+
+**Orden obligatorio:** completar el hub → recién después ocultar los selectores de RRHH.
+
+**Alcance:** es cambio de UI. Las mutations (`pagarAguinaldo`, `pagarLiquidacion`,
+`confirmarVale`, …) siguen expuestas en GraphQL — aceptable como paso intermedio; el ACL de cajas
+las cubre cuando entre.

--- a/docs/manuales-implementacion/BUGS-TESTEO-2026-08-18.md
+++ b/docs/manuales-implementacion/BUGS-TESTEO-2026-08-18.md
@@ -565,8 +565,11 @@ egreso, y 6 diálogos de RRHH que traen su propio selector de caja. Se unifica e
 | `rrhh/liquidacion-final/liquidacion-final-dialog` | finiquito |
 
 Todos se alimentan de `rrhh/caja-virtual/graphql/CajaVirtualesActivas.ts` →
-`cajaVirtualesActivas()`, **la única query de caja sin gate de seguridad**
-(`CajaVirtualGraphQL:131`). Ocultar estos selectores elimina su consumidor principal.
+`cajaVirtualesActivas()`, la query de caja compartida entre Tesorería y RRHH.
+
+> Corrección 2026-08-19: en una lectura anterior figuraba como "sin gate de seguridad". **Sí lo
+> tiene**: exige un rol de Tesorería *o* uno de RRHH. Lo que no tenía era acotamiento por caja
+> — eso lo resuelve el ACL, que ahora la filtra por las cajas visibles del usuario.
 
 **Por qué:**
 1. **Separación de funciones** — RRHH liquida y aprueba, tesorería paga. Que la misma persona

--- a/docs/manuales-implementacion/BUGS-TESTEO-2026-08-18.md
+++ b/docs/manuales-implementacion/BUGS-TESTEO-2026-08-18.md
@@ -29,6 +29,7 @@ Estados: 🔴 abierto · 🟡 en análisis · 🟢 corregido
 | F3 | Retiro de PDV: recepción parcial + selección de monedas | 🟠 |
 | F4 | Todo pago figura "Pago Proveedor"; usar `origenTipo` para el label | ✅ **hecho** |
 | F5 | Premisa: pagos de caja mayor solo desde la caja mayor (ocultar en RRHH) | 🟠 |
+| B16 | Liquidación: consolidar en un ítem las cuotas de ventas a crédito (configurable) | 🟠 |
 | **ACL** | **Acceso por caja: lista de usuarios R/W por caja virtual** — plan en `financiero/PLAN-ACL-CAJAS-VIRTUALES.md` | ⭐ **1ª** |
 
 ### Causas raíz agrupadas
@@ -689,3 +690,45 @@ movimientos de pago, resolviendo el concepto por el tipo de la `SolicitudPago` a
 `pago_solicitud_detalle`, y para las de tipo RRHH por el documento dueño. Ojo: hay que **excluir
 los egresos directos viejos** (los que no tienen fila en `pago_solicitud_detalle`), que ya tienen
 su origen correcto.
+
+---
+
+## B16 🟠 MEJORA — Liquidación: consolidar las cuotas de venta a crédito en un solo ítem (configurable)
+
+**Dónde:** generación de la liquidación mensual. Hoy **cada cuota de venta a crédito entra como un
+ítem de descuento propio**.
+
+**Problema:** hay funcionarios con muchas compras a crédito, y la hoja de liquidación se vuelve
+larguísima sin aportar nada — **el desglose de las ventas a crédito ya se le entrega por otra
+vía**, así que repetirlo cuota por cuota en el recibo es ruido.
+
+**Pedido:** una opción en **Configuración RRHH** para que la liquidación genere **un único ítem
+consolidado** con la suma de las cuotas provenientes de ventas a crédito.
+
+**Alcance exacto — solo las de venta a crédito.** Las cuotas de **préstamo** y cualquier otro tipo
+siguen desglosadas: son pocas por funcionario y ahí el detalle sí importa.
+
+Los dos tipos ya están separados en el código, así que el corte es limpio
+(`LiquidacionSueldoService`):
+
+| Origen | `referenciaTipo` | Se genera en |
+|---|---|---|
+| Venta a crédito (convenio) | `CREDITO_CONVENIO_CUOTA` | `:306-318` — **este es el que se consolida** |
+| Préstamo | `CPP_CUOTA` | `:272-284` — se deja como está |
+
+**A definir:**
+- **Nombre y alcance del parámetro** en `ConfiguracionRrhh`: booleano
+  (`LIQUIDACION_CONSOLIDAR_CUOTAS_CREDITO`) o algo más general si más adelante se quiere
+  consolidar otros grupos.
+- **Descripción del ítem consolidado**: algo como *"COMPRAS A CRÉDITO — N cuotas"*, para que el
+  funcionario sepa cuántas se le descontaron aunque no vea el detalle.
+- **Efectos cruzados:** hoy cada ítem lleva el `referenciaId` de su cuota, y al pagar la
+  liquidación eso es lo que marca cada cuota como PAGADA (`:617`, case
+  `CREDITO_CONVENIO_CUOTA`). **Un ítem consolidado pierde esa referencia.** Hay que resolverlo
+  antes de implementar: o el ítem guarda la lista de cuotas que lo componen, o el consolidado es
+  solo de presentación (el recibo agrupa) y por debajo se siguen guardando los ítems individuales.
+  **La segunda opción es la más segura** y probablemente la correcta: el problema es la hoja
+  impresa, no el modelo.
+- Relación con **B13** (que pide lo contrario para penalizaciones: desglosar en vez de
+  consolidar). Si se implementa como "agrupación de presentación", las dos se resuelven con el
+  mismo mecanismo y la configuración decide qué se agrupa y qué no.

--- a/docs/manuales-implementacion/financiero/PLAN-ACL-CAJAS-VIRTUALES.md
+++ b/docs/manuales-implementacion/financiero/PLAN-ACL-CAJAS-VIRTUALES.md
@@ -1,0 +1,370 @@
+# Plan — Control de acceso por caja virtual (ACL de cajas mayores / chicas)
+
+> **Feature solicitada 2026-08-19.** Hoy el acceso a las cajas es **por rol global**: quien tiene
+> `TESORERIA VER` ve **todas** las cajas de la empresa, y quien tiene `TESORERIA GESTIONAR` puede
+> mover plata en **cualquiera** de ellas. Se pide pasar a un modelo donde **cada caja tiene su
+> propia lista de usuarios habilitados**, con permiso de lectura y/o escritura, administrada por el
+> usuario que creó la caja.
+
+## 1. Veredicto de viabilidad: ALTA
+
+Tres cosas hacen que esto sea mucho menos costoso de lo que parece.
+
+**a) La infraestructura de seguridad ya existe.**
+`service/financiero/TesoreriaSecurityService.java` ya resuelve el usuario autenticado desde el
+`SecurityContext` por nickname y lee sus roles de la DB, sin depender del marshaling JWT→Authentication
+(que está roto a nivel sistema, issue #177). Ya expone `currentUsuario()`, `hasAnyRole()`,
+`requireVer()`, `requireGestionar()`, y ya está **cableado en todos los resolvers de caja**
+(`CajaVirtualGraphQL`, `MovimientoCajaVirtualGraphQL`). No hay que construir el andamiaje: hay que
+agregarle métodos.
+
+**b) Hay un único choke point para el dinero.** Verificado:
+
+```
+RRHH (vale, préstamo, aguinaldo, liquidación, finiquito)
+  └─> MovimientoCajaVirtualService.registrarMovimiento()  ──┐
+Financiero (gastos, CPP, maletín, retiro, entrada varia,     ├──> TesoreriaService.registrar()
+            operación financiera, devolución)  ──────────────┘                    .transferir()
+                                                                                  .anular()
+```
+
+`MovimientoCajaVirtualService.registrarMovimiento()` es un delegate de una línea a
+`TesoreriaService.registrar()`. **Toda** la plata que entra o sale de cualquier caja pasa por
+`TesoreriaService`. Eso significa que el permiso de **escritura** se hace cumplir en **3 métodos**
+(`registrar`, `transferir`, `anular`), no en los 43 puntos de entrada que reciben un `cajaVirtualId`.
+
+**c) El dueño ya está modelado.** `CajaVirtual` ya tiene `usuario_id` (`domain/financiero/CajaVirtual.java:57`).
+Hoy **no se usa en ninguna lógica** — solo se setea desde el input en `saveCajaVirtual`
+(`CajaVirtualGraphQL:157`). Se puede resignificar como *propietario* sin migración de columna, con dos
+cambios: setearlo del usuario autenticado (no del input) y dejar de aceptarlo en el input.
+
+**Lo que sí hay que construir:** la tabla de accesos, el filtrado de las consultas de lectura
+(que son varias y hoy devuelven todo), y la UI de administración de la lista.
+
+## 2. Estado actual — qué gatea qué
+
+| Punto | Gate hoy |
+|---|---|
+| `cajaVirtual(id)`, `cajaVirtuales`, `cajaVirtualesFilter`, `cajaVirtualesPorTipo`, `cajaVirtualesPorSucursal` | `seg.requireVer()` — rol global, sin filtro por caja |
+| `cajaVirtualesActivas()` (`CajaVirtualGraphQL:131`) | **🔴 SIN GATE** — hueco actual, no llama a `requireVer()` |
+| `cajaVirtualSaldos`, `cajaVirtualResumenBancario` | `seg.requireVer()` |
+| `movimientosCajaVirtual*` (3 queries) | `seg.requireVer()` |
+| `saveCajaVirtual`, `deleteCajaVirtual` | `seg.requireGestionar()` |
+| movimientos / anulación | `seg.requireGestionar()` |
+| Desktop | `mainService.tieneAlgunRol([ROLES.TESORERIA_GESTIONAR])` en `list-caja-virtual:82` y `caja-virtual-dashboard:160` |
+
+**Conclusión:** el rol es hoy un interruptor de todo-o-nada. Exactamente lo que la feature quiere
+cambiar.
+
+## 3. Modelo de datos propuesto
+
+### 3.1 Tabla nueva `financiero.caja_virtual_acceso`
+
+```sql
+-- V199.5__financiero_caja_virtual_acceso.sql   (sufijo .5 por convención del repo)
+CREATE TABLE IF NOT EXISTS financiero.caja_virtual_acceso (
+    id                bigint PRIMARY KEY,
+    caja_virtual_id   bigint NOT NULL REFERENCES financiero.caja_virtual(id),
+    usuario_id        bigint NOT NULL REFERENCES personas.usuario(id),
+    puede_leer        boolean NOT NULL DEFAULT true,
+    puede_escribir    boolean NOT NULL DEFAULT false,
+    otorgado_por_id   bigint REFERENCES personas.usuario(id),
+    creado_en         timestamp NOT NULL DEFAULT now(),
+    CONSTRAINT uq_caja_virtual_acceso UNIQUE (caja_virtual_id, usuario_id)
+);
+CREATE INDEX IF NOT EXISTS ix_cva_usuario ON financiero.caja_virtual_acceso(usuario_id);
+CREATE INDEX IF NOT EXISTS ix_cva_caja    ON financiero.caja_virtual_acceso(caja_virtual_id);
+```
+
+Aditiva pura, sin `DROP`/`RENAME` — cumple la regla Flyway del proyecto. El `id` va con
+`AssignedIdentityGenerator` como el resto de las entidades del central.
+
+**Dos booleanos y no un enum de nivel** porque el pedido es explícito ("lectura y/o escritura") y
+permite `leer=true, escribir=false` (el caso más común: el contador mira, no toca).
+
+### 3.2 Propietario
+
+`caja_virtual.usuario_id` pasa a significar **propietario**: quien creó la caja, único que
+administra su lista de accesos. Cambios:
+- `saveCajaVirtual` lo setea desde `seg.currentUsuario()` **solo al crear** (nunca en update).
+- `usuarioId` sale de `CajaVirtualInput` (o se ignora — decidir, ver §7).
+- El propietario tiene lectura + escritura implícitas; **no** necesita fila en `caja_virtual_acceso`.
+
+## 4. Punto de enforcement
+
+### 4.1 Escritura — 3 métodos, riesgo bajo
+
+En `TesoreriaService`, al principio de `registrar()`, `transferir()` (ambas cajas) y `anular()`:
+
+```java
+seg.requireEscrituraCaja(mov.getCajaVirtual().getId());
+```
+
+Con eso quedan cubiertos **todos** los flujos: RRHH (vale, préstamo, aguinaldo, liquidación,
+finiquito), CPP, gastos, maletín, retiro de PDV, entrada varia, operación financiera, devolución.
+
+> ⚠️ **Ojo con los procesos automáticos.** Hay flujos que postean sin un usuario interactivo
+> (replicación de retiros vía `RetiroTesoreriaProcesador`, schedulers). Si `currentUsuario()` es
+> `null` hay que **permitir** (proceso de sistema), no rechazar — si no, se corta la replicación.
+> Esto tiene que quedar explícito y testeado.
+
+### 4.2 Lectura — dos formas según la consulta
+
+| Tipo | Comportamiento | Queries |
+|---|---|---|
+| **Caja puntual** | lanzar excepción si no tiene acceso | `cajaVirtual(id)`, `cajaVirtualSaldos`, `cajaVirtualResumenBancario`, `cajaVirtualConfiguracion`, `movimientosCajaVirtual*`, `entradasVarias` |
+| **Listado** | **filtrar**, no lanzar — devolver solo las cajas accesibles | `cajaVirtuales`, `cajaVirtualesFilter`, `cajaVirtualesPorTipo`, `cajaVirtualesPorSucursal`, `cajaVirtualesActivas` |
+
+Los listados son el trabajo real: hay que empujar el filtro **al repositorio** (un `IN (SELECT
+caja_virtual_id FROM caja_virtual_acceso WHERE usuario_id = :u) OR usuario_id = :u`), no filtrar en
+memoria — si no, la paginación miente (`getTotalElements` cuenta cajas que el usuario no puede ver).
+
+### 4.3 Métodos nuevos en `TesoreriaSecurityService`
+
+```java
+boolean esPropietario(Long cajaId);
+boolean puedeLeerCaja(Long cajaId);
+boolean puedeEscribirCaja(Long cajaId);
+void requireLecturaCaja(Long cajaId);
+void requireEscrituraCaja(Long cajaId);
+void requirePropietarioCaja(Long cajaId);   // para administrar la lista
+List<Long> cajasVisiblesIds();              // para los listados
+```
+
+Con el mismo bypass de superusuario que ya tiene el servicio (rol `ADMIN` o nickname `ADMIN`).
+
+## 5. Relación rol ↔ ACL
+
+Recomendación: **AND, no OR.** El rol dice *qué* puede hacer; el ACL dice *dónde*.
+
+```
+ver una caja      = requireVer()       Y  puedeLeerCaja(id)
+mover plata       = requireGestionar() Y  puedeEscribirCaja(id)
+administrar lista = esPropietario(id)  O  ADMIN
+```
+
+Así el modelo de roles existente no se toca y la feature es puramente aditiva: quien hoy tiene el
+rol, mañana tiene el rol **y** una lista acotada de cajas.
+
+## 6. Fases de implementación
+
+| Fase | Qué | Dónde |
+|---|---|---|
+| **A. Datos** | Migración `V199.5`, entidad `CajaVirtualAcceso`, repository, service | central |
+| **B. Backfill** | Poblar accesos de las cajas existentes (ver §7.2) | migración o script |
+| **C. Seguridad** | Los 6 métodos nuevos en `TesoreriaSecurityService` + tests | central |
+| **D. Escritura** | `requireEscrituraCaja` en `TesoreriaService.registrar/transferir/anular` + bypass de proceso automático | central |
+| **E. Lectura puntual** | `requireLecturaCaja` en las queries de caja única (6 resolvers) | central |
+| **F. Lectura listados** | Filtro en repositorio + paginación correcta (5 queries) | central |
+| **G. API de gestión** | `cajaVirtualAccesos(cajaId)`, `otorgarAccesoCaja(...)`, `revocarAccesoCaja(...)`, `transferirPropiedadCaja(...)` + schema | central |
+| **H. UI** | Diálogo "Gestionar accesos" en `list-caja-virtual` / dashboard: tabla de usuarios, checkboxes leer/escribir, buscador de usuario. Visible solo al propietario y a ADMIN | desktop |
+| **I. UI defensiva** | Que el desktop no ofrezca cajas que el backend va a rechazar (selectores de caja en RRHH, pagar compras, gastos, retiro) | desktop |
+
+**Orden sugerido:** A → C → D → E → F → B → G → H → I.
+La **B (backfill) va después de E/F a propósito**: primero se construye el filtro, después se
+carga la data que evita el apagón. Desplegar F sin backfill deja a todo el mundo sin cajas.
+
+## 7. Decisiones abiertas — hay que responderlas antes de codear
+
+### 7.1 ¿Qué pasa si el propietario se va de la empresa? — ✅ RESUELTO 2026-08-19
+El creador queda como primer usuario con acceso (R+W implícito, sin fila en la tabla).
+**Pero eso no cubre su egreso:** ADMIN siempre puede administrar la lista y **transferir la
+propiedad** (`transferirPropiedadCaja`). Sin ese fallback, el primer tesorero que renuncia deja
+cajas inadministrables. El bypass de ADMIN ya existe en `TesoreriaSecurityService`, es gratis.
+
+> ⚠️ **Corregir primero:** `add-caja-virtual-dialog.component.ts:98` setea
+> `cajaVirtual.usuario = mainService.usuarioActual` **también al editar** (la línea no está bajo
+> `if (!isEditing)`). Hoy `usuario_id` no es *el creador* sino *el último que guardó*. Además el
+> valor viene del cliente: cualquiera puede mandar cualquier `usuarioId`. Fix: setearlo en el
+> backend desde `seg.currentUsuario()` y **solo cuando `input.getId() == null`**.
+
+### 7.2 ¿Qué pasa con las cajas que ya existen? — parcialmente resuelto
+El creador cubre las cajas **nuevas**. Para las existentes hay que mirar el dato antes de confiar
+en él (ver el bug de §7.1 — puede ser el último editor):
+
+```sql
+select id, nombre, tipo, usuario_id, responsable_id from financiero.caja_virtual order by id;
+```
+
+En la DB local hay **1 sola caja** — no sirve como muestra. Correr esto en prod (farmacia y bodega)
+antes de decidir el backfill.
+
+Al activar el filtro, toda caja sin filas de acceso queda invisible para todos salvo ADMIN.
+Opciones de backfill:
+- (a) dar acceso R+W a todos los que hoy tienen `TESORERIA GESTIONAR`, y R a los de `TESORERIA VER`
+  → nadie pierde acceso, pero no cambia nada hasta que alguien depure las listas;
+- (b) dar acceso solo al `responsable_id` / `usuario_id` de cada caja + ADMIN
+  → arranca restrictivo, probablemente rompa operación el día 1;
+- (c) **recomendado:** (a) como red de seguridad, y que el propietario depure caja por caja.
+  Requiere una lista revisada con vos antes de correrla.
+
+### 7.3 ¿El rol `TESORERIA VER` sigue haciendo falta? — ✅ RESUELTO 2026-08-19
+**Sí. Modelo AND confirmado por el usuario:** el rol habilita la capacidad, el ACL delimita el
+alcance. El sistema de roles existente no se toca; la feature es puramente aditiva.
+
+### 7.4 Procesos automáticos sin usuario
+Replicación de retiros, schedulers, y los pagos disparados por RRHH. Definir la regla:
+`currentUsuario() == null` → permitir (sistema). Y verificar que ningún flujo interactivo caiga
+en esa rama por accidente (sería un bypass silencioso).
+
+### 7.5 Interacción con F2 (pagar liquidación desde el hub de caja) — ✅ RESUELTO 2026-08-19
+Se adopta la premisa **"pagos desde caja mayor solamente estando en caja mayor"** (ver F5 en
+`../BUGS-TESTEO-2026-08-18.md`). Consecuencia directa para este plan: **RRHH no necesita permiso
+de escritura sobre ninguna caja.** El liquidador deja la liquidación aprobada; el tesorero la paga
+desde su caja, con su propio acceso. Sin esta premisa habría que dar escritura a todo liquidador y
+el ACL perdería sentido.
+
+### 7.6 ¿Aplica también al filial?
+El módulo de tesorería es del central. Confirmar que ninguna caja se administra desde el filial
+antes de asumir alcance central-only.
+
+### 7.7 ¿Qué ve alguien sin acceso a ninguna caja?
+Definir el estado vacío del dashboard/listado: pantalla vacía con mensaje ("no tenés acceso a
+ninguna caja, pedíselo al responsable") en vez de una tabla vacía sin explicación.
+
+## 8. Riesgos
+
+| Riesgo | Mitigación |
+|---|---|
+| **Apagón operativo** al activar el filtro sin backfill | Fase B antes de F en producción; feature flag por configuración para activar el enforcement |
+| **Bypass por punto de entrada olvidado** | El choke point de `TesoreriaService` cubre escritura; para lectura hay que auditar los 43 puntos con `cajaVirtualId`. Un test que enumere resolvers sin gate ayuda |
+| Paginación mentirosa si se filtra en memoria | Filtro en el repositorio (§4.2) |
+| Corte de replicación por rechazar procesos de sistema | §7.4, con test explícito |
+| `cajaVirtualesActivas()` hoy sin gate | Se corrige en esta misma feature (fase E/F) |
+
+## 9. Tamaño estimado
+
+- **Central:** 1 migración, 1 entidad + repo + service, ~6 métodos de seguridad, ~11 resolvers
+  tocados, 4 mutations nuevas, schema. Es el grueso.
+- **Desktop:** 1 diálogo nuevo (patrón `add-*-dialog` existente, 65vw × 70vh por convención),
+  ajustes en 2 componentes + los selectores de caja.
+- **Sin breaking change de API**: todo aditivo salvo `usuarioId` en `CajaVirtualInput` (§3.2).
+
+El trabajo no está en la lógica de permisos —es simple— sino en **cubrir todos los caminos de
+lectura sin dejar un hueco** y en **no apagarle las cajas a nadie el día del deploy**.
+
+---
+
+# 10. Fase previa obligatoria — completar el hub con el modelo de pago genérico
+
+> Agregado 2026-08-19. Esta fase **va antes** de todo lo anterior: sin ella no se puede aplicar la
+> premisa F5 ("pagos desde caja mayor solo estando en caja mayor"), y sin F5 el ACL obliga a dar
+> escritura de caja a todo liquidador de RRHH.
+
+## 10.1 El componente genérico ya existe — no hay que inventarlo
+
+`PagarComprasDialogComponent` (792 líneas) **ya está parametrizado por modo** y se reutiliza para
+dos conceptos distintos desde el mismo hub:
+
+```ts
+// registrar-egreso-dialog.component.ts:57-58
+if (op.tipo === 'PAGO_CPP' || op.tipo === 'GASTO') {
+  const d: PagarComprasDialogData = { cajaVirtual, modo: op.tipo === 'GASTO' ? 'GASTOS' : 'COMPRAS' };
+```
+
+```ts
+// pagar-compras-dialog.component.ts:26
+modo?: 'COMPRAS' | 'GASTOS';   // GASTOS reusa el mismo builder de pago; default COMPRAS
+```
+
+La ramificación por modo está contenida: **9 usos de `esGasto` en el `.ts` y 6 en el `.html`**.
+Todo lo demás —selección, totales, formas de pago, cheques, cotización— es común.
+
+**Recomendación: extender el modo, no crear 5 diálogos nuevos.** Renombrar el concepto a algo
+como `PagarObligacionesDialogComponent` con
+`modo: 'COMPRAS' | 'GASTOS' | 'LIQUIDACION' | 'FINIQUITO' | 'AGUINALDO' | 'PRESTAMO'`, y extraer las
+diferencias a una **estrategia por modo** en vez de seguir agregando `if (esGasto)`.
+
+## 10.2 Anatomía del modelo de pago genérico (lo que hay que respetar)
+
+**Paso 1 — selección de obligaciones.** Tabla filtrable de pendientes, con `montoAPagar` editable
+por fila (habilita pago parcial), agrupación forzada por ente + moneda (`_disabled` sobre las filas
+incompatibles, `:379`), totales en moneda de la deuda y en moneda principal con cotización.
+
+**Paso 2 — formas de pago (el "builder").** Un *draft* siempre visible que se confirma en líneas:
+- `fuente: 'CAJA_MAYOR' | 'CUENTA_BANCARIA' | 'CHEQUE'`
+- moneda + cotización + monto convertido
+- el draft se prefija con el **restante** (`totalDeuda − totalPago`), así el caso común es un clic
+- cheques: N cuotas encadenadas por intervalo de días, numeración desde la chequera (`:486-508`)
+- líneas editables/eliminables, con recálculo de faltante
+
+**Paso 3 — confirmación en lote.** Una sola mutation con todas las obligaciones y todas las líneas
+de pago (`pagarSolicitudesLoteCajaMayor`), atómica.
+
+**Extra del modo GASTOS:** permite **crear la obligación en el momento** (`abrirNuevoGasto()` /
+`crearGasto()`, `:306-321`). Útil para conceptos que no preexisten.
+
+**Contraste — el vale es el modelo simple.** `registrar-vale-dialog` son 133 líneas: no hay
+selección de deuda porque el vale se *crea* y se paga en el acto. Ese es el otro patrón válido:
+**alta directa**, no *pago de pendientes*.
+
+## 10.3 Qué agregar al hub, y con qué patrón
+
+| Concepto | Hub | Patrón | Estado |
+|---|---|---|---|
+| Compras (CPP) | egreso | pendientes | ✅ existe |
+| Gastos | egreso | pendientes + crear al vuelo | ✅ existe |
+| Vale | egreso | alta directa | ✅ existe |
+| **Liquidación mensual** | egreso | pendientes, **selección simple** | ❌ **F2** |
+| **Finiquito** | egreso | pendientes, **selección simple** | ❌ **F2** |
+| **Aguinaldo** | egreso | pendientes, **selección simple** | ❌ falta |
+| **Desembolso de préstamo** | egreso | **alta directa** (como el vale) | ❌ falta |
+| **Cobro de cuota de préstamo** | **ingreso** | pendientes, **selección simple** | ❌ falta |
+
+Los 4 de tipo *pendientes* son el mismo diálogo con otro `modo` y otra query de origen; los de RRHH
+con **selección simple** (§10.4). El desembolso sigue el patrón vale. El cobro de cuota es el único
+que va al **hub de ingreso**.
+
+## 10.4 Backend — reutilizar, no duplicar
+
+Las mutations de pago **ya existen** y ya tienen los efectos cruzados resueltos
+(vale→DESCONTADO, cuota→PAGADA, aguinaldo→PAGADO y su regla de no-doble-pago en diciembre):
+
+| Concepto | Mutation |
+|---|---|
+| Liquidación mensual | `pagarLiquidacion(id, cajaVirtualId)` — `LiquidacionSueldoService:457` |
+| Finiquito | `pagarLiquidacionFinal(id, cajaVirtualId)` — `LiquidacionFinalService:561` |
+| Aguinaldo | `pagarAguinaldo(id, cajaVirtualId)` — `AguinaldoService.pagar` |
+| Préstamo | `crearPrestamo(input, cajaVirtualId)` / `cobrarCuota(cuotaId, cajaVirtualId, monto)` |
+| Vale | `confirmarVale(id, cajaVirtualId, autorizadoPorId)` |
+
+**Lo que falta del lado backend son las queries de pendientes** por concepto (liquidaciones
+aprobadas sin pagar, aguinaldos aprobados sin pagar, cuotas vencidas), análogas a las que alimentan
+el modo COMPRAS/GASTOS.
+
+**✅ Decisión tomada 2026-08-19 (usuario): los pagos de RRHH son siempre 1 por 1.** Nunca se paga
+la nómina de 30 funcionarios en una sola operación. Consecuencias, todas simplificadoras:
+
+- **No hacen falta mutations en lote.** Se reutilizan tal cual las mutations existentes
+  (`pagarLiquidacion`, `pagarLiquidacionFinal`, `pagarAguinaldo`, `cobrarCuota`), que ya pagan
+  de a una y ya traen resueltos los efectos cruzados. **Cero backend nuevo de pago.**
+- **No hay problema de atomicidad parcial** — desaparece el escenario "pagué 18 de 30 y falló".
+- **Selección simple, no múltiple**, en los modos de RRHH: la tabla de pendientes funciona como
+  *selector de a quién le pago*, no como carrito. Un radio/click por fila en vez de checkboxes.
+
+**Implicancia para el diálogo genérico:** el modo tiene que declarar su cardinalidad.
+
+```ts
+modo: 'COMPRAS' | 'GASTOS'                                    // multi-selección (carrito)
+    | 'LIQUIDACION' | 'FINIQUITO' | 'AGUINALDO' | 'COBRO_CUOTA'  // selección simple
+```
+
+Lo que **no** cambia es el paso 2: el builder de formas de pago (efectivo / cuenta bancaria /
+cheque, multi-moneda con cotización) se usa igual, porque una sola liquidación puede pagarse con
+más de una forma.
+
+## 10.5 Orden de trabajo actualizado
+
+```
+FASE 0 — Hub (esta sección)
+  0.1  Generalizar PagarComprasDialog a PagarObligacionesDialog (estrategia por modo)
+  0.2  Queries de pendientes por concepto (central) — lo ÚNICO nuevo del backend
+  0.3  Cardinalidad por modo en el diálogo (multi para COMPRAS/GASTOS, simple para RRHH)
+  0.4  Modos nuevos: LIQUIDACION, FINIQUITO, AGUINALDO (egreso) + COBRO_CUOTA (ingreso)
+  0.5  Desembolso de préstamo: patrón alta directa (como vale)
+FASE 1 — F5: ocultar los 6 selectores de caja en las pantallas de RRHH
+FASE 2 — ACL: A → C → D → E → F → B → G → H → I  (§6)
+```
+
+**§7.3 resuelta 2026-08-19: modelo AND confirmado.** El rol habilita la capacidad, el ACL
+delimita el alcance.

--- a/docs/manuales-implementacion/financiero/PLAN-ACL-CAJAS-VIRTUALES.md
+++ b/docs/manuales-implementacion/financiero/PLAN-ACL-CAJAS-VIRTUALES.md
@@ -46,7 +46,7 @@ cambios: setearlo del usuario autenticado (no del input) y dejar de aceptarlo en
 | Punto | Gate hoy |
 |---|---|
 | `cajaVirtual(id)`, `cajaVirtuales`, `cajaVirtualesFilter`, `cajaVirtualesPorTipo`, `cajaVirtualesPorSucursal` | `seg.requireVer()` — rol global, sin filtro por caja |
-| `cajaVirtualesActivas()` (`CajaVirtualGraphQL:131`) | **🔴 SIN GATE** — hueco actual, no llama a `requireVer()` |
+| `cajaVirtualesActivas()` | `hasAnyRole(TESORERIA.TODOS)` **o** `RrhhSecurityService.TODOS` — la comparte RRHH para elegir la caja destino. Corregido 2026-08-19: en una lectura anterior figuraba como "sin gate"; sí lo tiene |
 | `cajaVirtualSaldos`, `cajaVirtualResumenBancario` | `seg.requireVer()` |
 | `movimientosCajaVirtual*` (3 queries) | `seg.requireVer()` |
 | `saveCajaVirtual`, `deleteCajaVirtual` | `seg.requireGestionar()` |
@@ -230,7 +230,7 @@ ninguna caja, pedíselo al responsable") en vez de una tabla vacía sin explicac
 | **Bypass por punto de entrada olvidado** | El choke point de `TesoreriaService` cubre escritura; para lectura hay que auditar los 43 puntos con `cajaVirtualId`. Un test que enumere resolvers sin gate ayuda |
 | Paginación mentirosa si se filtra en memoria | Filtro en el repositorio (§4.2) |
 | Corte de replicación por rechazar procesos de sistema | §7.4, con test explícito |
-| `cajaVirtualesActivas()` hoy sin gate | Se corrige en esta misma feature (fase E/F) |
+| Un punto de entrada de lectura sin acotar | El choke point cubre escritura; para lectura se auditaron los 43 puntos con `cajaVirtualId` |
 
 ## 9. Tamaño estimado
 
@@ -368,3 +368,44 @@ FASE 2 — ACL: A → C → D → E → F → B → G → H → I  (§6)
 
 **§7.3 resuelta 2026-08-19: modelo AND confirmado.** El rol habilita la capacidad, el ACL
 delimita el alcance.
+
+---
+
+# 11. Estado de implementación — 2026-08-19
+
+Rama `feat/pagos-hub-acl-cajas` en **central** y **desktop**.
+
+## Hecho
+
+| Fase | Qué se hizo | Dónde |
+|---|---|---|
+| **0** (hub) | Modos `LIQUIDACION` / `FINIQUITO` / `AGUINALDO` en el diálogo genérico + entradas en el hub de egresos. Puente `SolicitudPago` tipo RRHH para los tres, con `sincronizarDesdeSolicitudPago` por concepto | `PagoRrhhTesoreriaService`, `PagoRrhhTesoreriaGraphQL`, `V199.5`, `pagar-compras-dialog` |
+| **F4** | Etiqueta del movimiento desde `origenTipo` (el concepto real) en historial y dashboard | `caja-virtual.model.ts`, 2 componentes |
+| **F6** | `origenTipo` correcto por concepto del evento + etiqueta consolidada con N documentos + `detalleDePago(pagoId)` + diálogo "Detalle del pago" | `PagoProveedorService`, `detalle-pago-dialog` |
+| **A** | Migración `V200.5` (`financiero.caja_virtual_acceso`), entidad, repo, `CajaVirtualAccesoService` | central |
+| **C** | `esSuperusuario` · `esPropietario` · `puedeLeerCaja` · `puedeEscribirCaja` · `requireLecturaCaja` · `requireEscrituraCaja` · `requirePropietarioCaja` · `cajasVisiblesIds` · `esProcesoDeSistema` | `TesoreriaSecurityService` |
+| **D** | Escritura exigida en `registrar` / `transferir` / `anular` | `TesoreriaService` |
+| **E** | Lectura puntual en caja, saldos, resumen bancario, 3 queries de movimientos, entradas varias, configuración | resolvers de `financiero` |
+| **F** | Listados filtrados **en la consulta** (`findAllVisibles`, `filterVisibles`, `findByTipoAndIdIn`, `findBySucursalIdAndIdIn`, `findByActivoTrueAndIdIn`) | repo + service + resolver |
+| **G** | `cajaVirtualAccesos` · `otorgarAccesoCaja` · `revocarAccesoCaja` · `transferirPropiedadCaja`; propietario desde el `SecurityContext` y solo en el alta | schema + resolver |
+| **H** | Diálogo "Gestionar accesos" (alta con buscador, toggle de escritura, revocar, hacer responsable), visible solo al responsable o ADMIN | `gestionar-accesos-caja-dialog` |
+| **B** | Script de backfill con verificación previa y posterior — **se corre a mano** | `backfill-acl-cajas.sql` |
+
+## Decisiones de implementación que no estaban en el plan
+
+- **La lectura no puede apagarse desde la UI.** Un acceso con escritura y sin lectura sería mover
+  plata a ciegas; para sacar el acceso se revoca (borra la fila) en vez de dejar una inerte.
+- **Al responsable no se le puede otorgar una fila de acceso.** Ya tiene permisos implícitos, y
+  una fila sería revocable — dejaría la caja sin quien la administre.
+- **Transferir la propiedad borra el acceso explícito del nuevo responsable**, por lo mismo.
+- **`esProcesoDeSistema()` mira que no haya principal**, no que el usuario no tenga permisos. Un
+  usuario autenticado sin acceso es rechazado; solo pasa lo que corre sin sesión.
+
+## Pendiente
+
+| Qué | Por qué |
+|---|---|
+| **Fase I** — UI defensiva: que los selectores de caja no ofrezcan cajas que el backend va a rechazar | Depende de F5 |
+| **F5** — ocultar los 6 selectores de caja de RRHH | Necesita completar el hub |
+| **Hub: desembolso de préstamo y cobro de cuota** | El desembolso es alta directa (patrón vale); el **cobro de cuota es un ingreso** y no pasa por el motor de pago — necesita su propio camino y una query de cuotas pendientes |
+| **Correr el backfill** | Necesita la lista de cajas de prod revisada (§7.2) |

--- a/docs/manuales-implementacion/financiero/PLAN-DISENADOR-CHEQUES.md
+++ b/docs/manuales-implementacion/financiero/PLAN-DISENADOR-CHEQUES.md
@@ -1,0 +1,184 @@
+# Plan — Diseñador visual de hojas de cheque e impresión
+
+> Pedido 2026-08-19. Portar de `frc-gourmet` el diseñador visual drag-and-drop de plantillas
+> (hoy usado para facturas legales), adaptarlo a **hojas de cheque**, vincular un diseño a una
+> **chequera**, e imprimir el cheque al pagar con él.
+>
+> **Va en un PR aparte de `feat/pagos-hub-acl-cajas`** — ver §7.
+
+## 1. Qué hay en frc-gourmet (medido)
+
+`frc-gourmet/src/app/pages/facturacion/plantillas/` — ~1.500 líneas:
+
+| Archivo | Líneas | Qué hace |
+|---|---|---|
+| `designer/factura-plantilla-designer.component.ts` | 426 | El canvas drag-and-drop |
+| `designer/*.html` + `*.scss` | 233 + 216 | Lienzo, panel de propiedades, paleta |
+| `plantilla-design.model.ts` | 145 | Modelo del diseño serializado |
+| `plantilla-render.util.ts` | 278 | Diseño → PDF |
+| `list-plantillas/` + `create-plantilla-dialog/` | 199 | CRUD |
+
+**Lo que lo hace un buen punto de partida:**
+
+- Coordenadas y tamaños en **milímetros**, no píxeles: mapean directo a la hoja física e
+  independizan del zoom del diseñador.
+- Tiene un modo **`PRE_IMPRESO`**: *"la hoja ya está impresa; el sistema solo posiciona texto
+  sobre coordenadas"*. **Un cheque es exactamente eso** — el formulario ya viene impreso del
+  banco y solo hay que poner fecha, beneficiario, monto y monto en letras en su lugar.
+- **Imagen de fondo de referencia** con transformación (escala/desplazamiento): se escanea un
+  cheque real y se posicionan los campos encima. Es la función que hace usable un diseñador de
+  pre-impreso.
+- El diseño se serializa a **JSON**, no a un formato del motor de impresión.
+
+**Lo que no sirve tal cual:** `itemsTable` / `itemColumn` (tabla de ítems de factura). Un cheque
+no tiene ítems. Se puede dejar fuera del port y el modelo se simplifica bastante.
+
+## 2. La decisión que define el costo: quién genera el PDF
+
+**frc-gourmet no usa Jasper.** `plantilla-render.util.ts` genera el PDF con **pdfMake en el
+cliente** (`pdfMake.createPdf(dd)`), que en Electron abre la ventana de impresión.
+
+El pedido dice "generarlo en pdf usando jasper". Son dos caminos con costos muy distintos:
+
+### Opción A — portar también pdfMake (cliente)
+
+- **Costo:** bajo. El renderer viene hecho; se le sacan las partes de factura.
+- **Contra:** rompe la convención del repo. En `frc-comercial` la impresión de comprobantes va por
+  `ImpresionService` + `ImprimirDialogComponent` (PDF A4 / ticket), con Jasper del lado del
+  central. Sumar pdfMake mete un segundo motor de PDF en el desktop.
+- **Riesgo real bajo:** el cheque es un caso de nicho (pre-impreso, sin ítems, una hoja).
+
+### Opción B — generar con Jasper desde el JSON (lo pedido)
+
+- Hay que escribir un **generador dinámico**: JSON del diseño → `JasperDesign` armado por código
+  (`JRDesignStaticText` / `JRDesignTextField` posicionados en puntos) → compilar → llenar →
+  exportar. No existe hoy.
+- **Costo:** el grueso del trabajo, más que el diseñador.
+- **Riesgo alto y específico de este repo:** `central/CLAUDE.md` avisa que los `.jrxml` **compilan
+  en runtime**, así que un error de plantilla **no se ve en el build ni en CI: revienta al generar
+  el PDF en producción**. Un generador dinámico multiplica esa superficie, porque la plantilla ya
+  no la escribe un humano sino el diseñador. Sumar la regla de fuentes (solo `SansSerif` /
+  `Verdana`, nada nuevo sin instalarlo en todos los servidores).
+
+### Opción C (recomendada) — Jasper con plantilla fija + posiciones variables
+
+Punto medio que respeta la convención sin escribir un generador dinámico:
+
+- Un **`.jrxml` único** para cheques, con los ~8 campos posibles (fecha, beneficiario, monto
+  numérico, monto en letras, concepto, ciudad, "no a la orden", cruzado) como `textField`
+  **con posición parametrizada**.
+- El JSON del diseño se pasa como **parámetros** (x, y, tamaño de fuente, visible) por campo.
+- La plantilla es fija y revisable; el diseño solo mueve cosas dentro de ella.
+- **Limita el diseñador**: no se pueden agregar elementos arbitrarios, solo acomodar y
+  mostrar/ocultar el catálogo de campos. **Para un cheque eso alcanza** — los campos de un cheque
+  son siempre los mismos.
+
+**Recomiendo la C.** Conserva Jasper (convención + impresión server-side), evita el generador
+dinámico, y el diseñador se simplifica: en vez de una paleta libre, es "acomodá estos 8 campos
+sobre la imagen de tu cheque".
+
+## 3. Modelo de datos
+
+```sql
+-- Migración aditiva (numeración a asignar en su momento, sufijo .5)
+CREATE TABLE IF NOT EXISTS financiero.cheque_plantilla (
+    id           bigserial PRIMARY KEY,
+    nombre       varchar(120) NOT NULL,
+    banco_id     bigint REFERENCES financiero.banco(id),   -- opcional: el formato es del banco
+    -- Diseño serializado: posiciones en mm de cada campo + config de página.
+    config       text NOT NULL,
+    -- Imagen de referencia (escaneo del cheque) en base64 o URL. Solo para el diseñador.
+    fondo        text,
+    activo       boolean NOT NULL DEFAULT true,
+    creado_en    timestamp NOT NULL DEFAULT now(),
+    usuario_id   bigint REFERENCES personas.usuario(id)
+);
+
+ALTER TABLE financiero.chequera
+    ADD COLUMN IF NOT EXISTS cheque_plantilla_id BIGINT REFERENCES financiero.cheque_plantilla(id);
+```
+
+El vínculo va en la **chequera** y no en la cuenta: dos chequeras del mismo banco pueden tener
+formatos distintos (chequeras viejas, series distintas), y la chequera ya es lo que se elige al
+pagar.
+
+### Modelo del diseño (JSON en `config`)
+
+Simplificado respecto de gourmet — sin `itemsTable`/`itemColumn`:
+
+```ts
+interface ChequeDiseno {
+  pagina: { anchoMm: number; altoMm: number };
+  fondo?: BackgroundTransform;          // se porta tal cual de gourmet
+  campos: Array<{
+    campo: 'fecha' | 'beneficiario' | 'montoNumero' | 'montoLetras'
+         | 'concepto' | 'ciudad' | 'noALaOrden' | 'cruzado';
+    visible: boolean;
+    xMm: number; yMm: number; wMm?: number;
+    fontSize?: number; bold?: boolean; align?: 'left'|'center'|'right';
+  }>;
+}
+```
+
+### De dónde sale cada dato al imprimir
+
+`Cheque` ya tiene casi todo (`domain/financiero/Cheque.java`):
+
+| Campo del diseño | Origen |
+|---|---|
+| `fecha` | `cheque.fechaPago` (el diferido se imprime con su fecha, no la de hoy) |
+| `beneficiario` | `cheque.orden` |
+| `montoNumero` | `cheque.total` + `cheque.moneda` |
+| `montoLetras` | **ya existe**: `utilitarios.NumeroALetrasService`, el mismo que usan los recibos de RRHH (`ReporteRrhhService`). Reutilizarlo, no escribir otro |
+| `concepto` | `cheque.concepto` |
+| `ciudad`, `noALaOrden`, `cruzado` | del diseño / configuración, no del cheque |
+
+## 4. Puntos de integración
+
+1. **CRUD de plantillas** — lista + diseñador. Entrada de menú bajo *Financiero → Cuentas y
+   Bancos* (y **agregarla al buscador global**, ver issue desktop #235).
+2. **Vincular a la chequera** — selector de plantilla en `gestionar-chequeras-dialog`.
+3. **Imprimir al pagar** — el pago con cheque ya emite N cheques desde `pagar-compras-dialog`
+   (chequera elegida una vez, números consecutivos). Al terminar, ofrecer **"Imprimir cheques"**:
+   por cada cheque emitido, resolver la plantilla de su chequera y generar el PDF.
+   - Si la chequera no tiene plantilla: avisar y no romper el pago. **La impresión no puede ser
+     bloqueante del pago.**
+4. **Reimpresión** — desde el dashboard de cheques, acción "Imprimir" en la fila. Necesario:
+   se traba el papel, sale mal, se reimprime.
+
+## 5. Costo estimado
+
+| Parte | Opción C (recomendada) |
+|---|---|
+| Diseñador (port + simplificación a campos fijos) | 1,5 – 2 días |
+| Backend: entidad, migración, GraphQL, CRUD | 0,5 día |
+| `.jrxml` de cheque + parámetros de posición + servicio de impresión | 1 día |
+| Vínculo con chequera + UI | 0,5 día |
+| Impresión al pagar + reimpresión | 0,5 día |
+| **Total** | **~4 días** |
+
+Con la opción B (generador dinámico de Jasper) sumar **2–3 días** más y el riesgo de §2.
+
+## 6. Riesgos
+
+| Riesgo | Mitigación |
+|---|---|
+| **Calibración**: lo que se ve en pantalla no cae donde debe en el papel | Botón **"Imprimir prueba"** en el diseñador, que saca la hoja con marcas de posición. Es lo primero que hay que construir, no lo último |
+| Márgenes no imprimibles de la impresora corren todo | Documentar por impresora; el ajuste fino vive en el diseño (por eso está en mm) |
+| Un `.jrxml` mal armado revienta recién en producción | Test JUnit que compile + `fillReport` con datos dummy, como ya hacen `ReciboFiniquitoJrxmlTest` y `ReciboRrhhJrxmlTest` |
+| Fuentes | Solo `SansSerif` (lógica de Java, siempre disponible). No ofrecer selector de fuente en el diseñador |
+| Cheque impreso mal y ya emitido | La reimpresión (§4.4) no debe emitir un cheque nuevo ni cambiar su número |
+
+## 7. Por qué no entra en `feat/pagos-hub-acl-cajas`
+
+Esa rama ya lleva 10+ commits en dos repos, tres migraciones y **toca seguridad** (el ACL de
+cajas). Necesita review cuidadoso y un backfill coordinado antes de mergear. Meterle un módulo de
+diseño visual con un motor de impresión nuevo significaría que el control de acceso espere a que
+se revise un diseñador que no tiene nada que ver, y mezclar en un mismo review "quién puede mover
+plata" con "dónde va la fecha en el cheque".
+
+## 8. Primer paso sugerido
+
+Antes de portar nada: **conseguir un cheque real escaneado** de cada banco con el que se opera
+(BNF, STONE) y medirlo. El diseñador se prueba contra eso desde el día uno; sin esa referencia,
+la calibración (§6) se descubre tarde y es el riesgo que hunde este tipo de features.

--- a/docs/manuales-implementacion/financiero/PRUEBA-MANUAL-ACL-Y-PAGOS-HUB.md
+++ b/docs/manuales-implementacion/financiero/PRUEBA-MANUAL-ACL-Y-PAGOS-HUB.md
@@ -1,0 +1,152 @@
+# Prueba manual — ACL de cajas + pagos de RRHH desde el hub
+
+> Rama `feat/pagos-hub-acl-cajas` (central + desktop). Entorno local: central con perfil `dev`
+> contra `bodega_producto_devoluciones` (`:5551`), desktop servido en el browser o Electron.
+> Login con `frc-comercial/dev_user_cred.txt`.
+
+## Preparación
+
+1. **Migraciones**: al levantar el central se aplican `V199.5` (solicitud_pago_id en
+   liquidación / finiquito / aguinaldo) y `V200.5` (`financiero.caja_virtual_acceso`).
+   Verificar:
+   ```sql
+   select version, description, success from flyway_schema_history
+    where version in ('199.5','200.5') order by version;
+   ```
+2. **NO correr el backfill todavía**: las pruebas de ACL necesitan usuarios sin acceso.
+3. Tener a mano dos usuarios: uno con rol de tesorería que **no** sea responsable de la caja,
+   y el responsable de la caja (o ADMIN).
+
+---
+
+## A — ACL de cajas
+
+### A1. El responsable ve su caja y puede administrarla
+1. Lista de cajas → menú de acciones de una caja creada por vos.
+2. ✅ Aparece **"Gestionar accesos"**.
+3. Abrirlo. ✅ El encabezado dice quién es el responsable; la lista arranca vacía.
+
+### A2. Un usuario sin acceso no ve la caja
+1. Loguearse con el otro usuario (con rol de tesorería, sin acceso a esa caja).
+2. ✅ La caja **no aparece** en la lista.
+3. ✅ El contador de la paginación no la cuenta (no hay "1 de N" con filas que no se ven).
+
+### A3. Otorgar lectura
+1. Como responsable: "Gestionar accesos" → buscar al otro usuario → **sin** tildar "Puede mover
+   plata" → Agregar.
+2. Con el otro usuario: ✅ la caja aparece; ✅ puede abrir el dashboard y ver movimientos.
+3. Intentar un egreso. ✅ Falla con *"No tenés permiso para mover plata en esta caja"*.
+
+### A4. Otorgar escritura
+1. Como responsable: activar el toggle **"Mover plata"** de esa fila.
+2. Con el otro usuario: ✅ el egreso ahora funciona.
+
+### A5. Revocar
+1. Como responsable: menú de la fila → **Quitar acceso** → confirmar.
+2. Con el otro usuario: ✅ la caja desaparece de la lista.
+
+### A6. Transferir responsabilidad
+1. Como responsable: otorgar acceso al otro usuario, luego menú → **Hacerlo responsable**.
+2. ✅ El diálogo se cierra y la lista se recarga.
+3. ✅ Ahora **vos** ya no ves "Gestionar accesos" en esa caja; el otro sí.
+4. ✅ La fila de acceso explícita del nuevo responsable desapareció (ya tiene permisos implícitos).
+
+### A7. ADMIN pasa por encima
+1. Con un usuario ADMIN: ✅ ve todas las cajas y puede administrar accesos de cualquiera.
+
+### A8. Procesos automáticos (regresión crítica)
+1. Con un retiro de PDV pendiente, esperar/forzar el procesamiento automático
+   (`RetiroTesoreriaProcesador` / scheduler).
+2. ✅ El retiro ingresa a la caja mayor igual. **Si esto falla, el ACL está rechazando procesos
+   sin sesión y hay que revisar `esProcesoDeSistema()`.**
+
+---
+
+## B — Pagos de RRHH desde el hub
+
+Precondición: una liquidación mensual **APROBADA** sin pagar, un finiquito **APROBADO** y un
+aguinaldo **APROBADO** (se aprueban desde RRHH).
+
+### B1. Pagar liquidación mensual
+1. Caja Mayor → **Registrar Egreso** → **Pagar Liquidación**.
+2. ✅ La tabla lista las liquidaciones aprobadas con funcionario, período y monto.
+3. ✅ Tildar una **destilda** cualquier otra (selección simple).
+4. ✅ El monto no es editable.
+5. Elegir forma de pago (efectivo de la caja) → confirmar.
+6. ✅ Mensaje de éxito. En RRHH la liquidación queda **PAGADA**.
+7. ✅ En la caja hay un egreso por el neto, etiquetado **"Liquidación"** (no "Egreso" ni "Compra").
+8. ✅ Los efectos cruzados se aplicaron: vales de esa liquidación en **DESCONTADO**, cuotas en
+   **PAGADA**.
+
+### B2. Pago mixto (efectivo + banco)
+1. Idem B1 pero repartiendo entre caja y cuenta bancaria.
+2. ✅ El total de las formas de pago debe igualar el neto para poder confirmar.
+3. ✅ Se generan el movimiento de caja **y** el bancario.
+
+### B3. Finiquito
+1. **Pagar Finiquito** → pagar uno.
+2. ✅ Queda PAGADA y **el funcionario queda inactivo**.
+3. ✅ El movimiento se etiqueta **"Finiquito"**.
+
+### B4. Aguinaldo
+1. **Pagar Aguinaldo** → pagar uno.
+2. ✅ Queda PAGADO y **deja de sumarse en la liquidación de diciembre** (verificar generando el
+   borrador de diciembre: no debe aparecer el ítem de aguinaldo).
+3. ✅ El movimiento se etiqueta **"Aguinaldo"**.
+
+### B5. Pago parcial rechazado
+1. Intentar pagar una liquidación con un monto menor al neto.
+2. ✅ Rechaza: *"se paga entero o no se paga: falta cubrir …"*.
+
+### B6. Anulación
+1. Anular el pago desde el evento.
+2. ✅ La liquidación vuelve a **APROBADA**, los efectos cruzados se revierten y la caja recibe el
+   contra-movimiento.
+
+---
+
+## C — Etiqueta y detalle del pago consolidado (F4 / F6)
+
+### C1. Un solo documento
+1. Pagar **un** gasto desde el hub.
+2. ✅ El movimiento conserva la descripción específica del gasto.
+3. ✅ Se etiqueta **"Gasto"**, no "Compra" ni "Pago Proveedor".
+
+### C2. Varios documentos
+1. Pagar **tres** gastos en una sola operación.
+2. ✅ El movimiento dice **"Pago consolidado de 3 gastos"** — no la descripción del primero.
+
+### C3. Detalle
+1. En el dashboard de la caja, menú del movimiento → **"Ver detalle del pago"**.
+2. ✅ Lista los 3 gastos con el monto imputado a cada uno y su estado.
+3. ✅ Los totales se agrupan por moneda (no se suman monedas distintas).
+4. ✅ La suma de los imputados coincide con el monto del movimiento.
+
+### C4. Compras
+1. Pagar dos notas de un proveedor.
+2. ✅ Etiqueta **"Pago a PROVEEDOR (2 notas)"**, etiquetada como **"Compra"**.
+
+---
+
+## Qué mirar en la DB
+
+```sql
+-- Accesos de una caja
+select a.id, u.nickname, a.puede_leer, a.puede_escribir, o.nickname as otorgado_por
+  from financiero.caja_virtual_acceso a
+  join personas.usuario u on u.id = a.usuario_id
+  left join personas.usuario o on o.id = a.otorgado_por_id
+ where a.caja_virtual_id = :cajaId;
+
+-- Puente de pago de un documento de RRHH
+select id, estado, solicitud_pago_id, caja_virtual_id, movimiento_caja_virtual_id
+  from rrhh.liquidacion_sueldo where id = :id;
+
+-- Desglose de un evento de pago
+select solicitud_pago_id, monto_solicitud, movimiento_caja_virtual_id, anulado
+  from financiero.pago_solicitud_detalle where pago_id = :pagoId;
+
+-- Origen y descripcion del movimiento consolidado
+select id, tipo_movimiento, origen_tipo, referencia_id, descripcion, cantidad
+  from financiero.movimiento_caja_virtual order by id desc limit 10;
+```

--- a/docs/manuales-implementacion/financiero/backfill-acl-cajas.sql
+++ b/docs/manuales-implementacion/financiero/backfill-acl-cajas.sql
@@ -1,0 +1,85 @@
+-- Backfill del ACL de cajas — CORRER A MANO, NO ES UNA MIGRACION FLYWAY.
+--
+-- Se mantiene fuera de Flyway a proposito: reparte permisos sobre plata y depende de como
+-- este cada instancia, asi que tiene que correrse con la lista revisada delante, no al azar
+-- de un deploy. Sin backfill, al activar el filtro toda caja sin filas queda invisible salvo
+-- para su propietario y para ADMIN.
+--
+-- Estrategia (la recomendada en PLAN-ACL-CAJAS-VIRTUALES.md §7.2): red de seguridad — nadie
+-- pierde el acceso que ya tenia. Despues cada responsable depura su lista desde la UI.
+--   · TESORERIA GESTIONAR → lectura + escritura
+--   · TESORERIA VER       → lectura
+--
+-- ─────────────────────────────────────────────────────────────────────────────────────────
+-- PASO 0 — mirar el terreno antes de tocar nada
+-- ─────────────────────────────────────────────────────────────────────────────────────────
+-- Quien queda como responsable de cada caja. OJO: hasta esta version, usuario_id se
+-- sobreescribia en cada edicion, asi que puede ser el ultimo que guardo y no el creador.
+-- Revisar y corregir con transferirPropiedadCaja lo que no corresponda.
+--
+--   select c.id, c.nombre, c.tipo, c.activo, u.nickname as responsable
+--     from financiero.caja_virtual c
+--     left join personas.usuario u on u.id = c.usuario_id
+--    order by c.id;
+--
+-- Cuantos usuarios va a alcanzar el backfill:
+--
+--   select r.nombre as rol, count(distinct ur.user_id) as usuarios
+--     from personas.usuario_role ur
+--     join personas.role r on r.id = ur.role_id
+--    where upper(trim(r.nombre)) in ('TESORERIA VER','TESORERIA GESTIONAR')
+--    group by r.nombre;
+
+BEGIN;
+
+-- ─────────────────────────────────────────────────────────────────────────────────────────
+-- PASO 1 — TESORERIA GESTIONAR: lectura + escritura sobre las cajas activas
+-- ─────────────────────────────────────────────────────────────────────────────────────────
+INSERT INTO financiero.caja_virtual_acceso (caja_virtual_id, usuario_id, puede_leer, puede_escribir, otorgado_por_id, creado_en)
+SELECT c.id, ur.user_id, true, true, NULL, now()
+  FROM financiero.caja_virtual c
+  CROSS JOIN (
+      SELECT DISTINCT ur.user_id
+        FROM personas.usuario_role ur
+        JOIN personas.role r ON r.id = ur.role_id
+       WHERE upper(trim(r.nombre)) = 'TESORERIA GESTIONAR'
+  ) ur
+ WHERE COALESCE(c.activo, true) = true
+   AND (c.usuario_id IS NULL OR c.usuario_id <> ur.user_id)   -- el responsable ya tiene acceso implicito
+ON CONFLICT (caja_virtual_id, usuario_id) DO UPDATE
+   SET puede_leer = true, puede_escribir = true;
+
+-- ─────────────────────────────────────────────────────────────────────────────────────────
+-- PASO 2 — TESORERIA VER: solo lectura. No pisa a quien ya quedo con escritura en el paso 1.
+-- ─────────────────────────────────────────────────────────────────────────────────────────
+INSERT INTO financiero.caja_virtual_acceso (caja_virtual_id, usuario_id, puede_leer, puede_escribir, otorgado_por_id, creado_en)
+SELECT c.id, ur.user_id, true, false, NULL, now()
+  FROM financiero.caja_virtual c
+  CROSS JOIN (
+      SELECT DISTINCT ur.user_id
+        FROM personas.usuario_role ur
+        JOIN personas.role r ON r.id = ur.role_id
+       WHERE upper(trim(r.nombre)) = 'TESORERIA VER'
+  ) ur
+ WHERE COALESCE(c.activo, true) = true
+   AND (c.usuario_id IS NULL OR c.usuario_id <> ur.user_id)
+ON CONFLICT (caja_virtual_id, usuario_id) DO NOTHING;
+
+-- ─────────────────────────────────────────────────────────────────────────────────────────
+-- PASO 3 — verificar ANTES de confirmar
+-- ─────────────────────────────────────────────────────────────────────────────────────────
+--   select c.nombre,
+--          count(*) filter (where a.puede_escribir) as con_escritura,
+--          count(*) filter (where a.puede_leer and not a.puede_escribir) as solo_lectura
+--     from financiero.caja_virtual c
+--     left join financiero.caja_virtual_acceso a on a.caja_virtual_id = c.id
+--    group by c.nombre order by c.nombre;
+--
+-- Cajas que quedarian sin nadie mas que su responsable (revisar que sea lo esperado):
+--
+--   select c.id, c.nombre from financiero.caja_virtual c
+--    where COALESCE(c.activo, true) = true
+--      and not exists (select 1 from financiero.caja_virtual_acceso a where a.caja_virtual_id = c.id);
+
+COMMIT;
+-- Si algo no cuadra: ROLLBACK; en vez de COMMIT.

--- a/src/main/java/com/franco/dev/domain/financiero/CajaVirtualAcceso.java
+++ b/src/main/java/com/franco/dev/domain/financiero/CajaVirtualAcceso.java
@@ -1,0 +1,68 @@
+package com.franco.dev.domain.financiero;
+
+import com.franco.dev.domain.personas.Usuario;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.*;
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+/**
+ * Permiso de un usuario sobre una caja virtual.
+ *
+ * <p>El rol de tesoreria habilita la capacidad (ver / gestionar); esta fila delimita
+ * <b>sobre que cajas</b>. Modelo AND: hace falta el rol <i>y</i> el acceso.</p>
+ *
+ * <p>El propietario de la caja ({@code caja_virtual.usuario_id}) no lleva fila: tiene lectura
+ * y escritura implicitas y es quien administra la lista. Un superusuario (rol o nickname
+ * ADMIN) tampoco: pasa por encima de todo.</p>
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "caja_virtual_acceso", schema = "financiero")
+public class CajaVirtualAcceso implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GenericGenerator(
+            name = "assigned-identity",
+            strategy = "com.franco.dev.config.AssignedIdentityGenerator"
+    )
+    @GeneratedValue(
+            generator = "assigned-identity",
+            strategy = GenerationType.IDENTITY
+    )
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "caja_virtual_id", nullable = false)
+    private CajaVirtual cajaVirtual;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "usuario_id", nullable = false)
+    private Usuario usuario;
+
+    /** Ver la caja, sus saldos y sus movimientos. */
+    @Column(name = "puede_leer")
+    private Boolean puedeLeer;
+
+    /** Mover plata: ingresos, egresos, transferencias, anulaciones. Implica lectura. */
+    @Column(name = "puede_escribir")
+    private Boolean puedeEscribir;
+
+    /** Quien otorgo el acceso (auditoria): el propietario de la caja, o un ADMIN. */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "otorgado_por_id", nullable = true)
+    private Usuario otorgadoPor;
+
+    @CreationTimestamp
+    @Column(name = "creado_en")
+    private LocalDateTime creadoEn;
+}

--- a/src/main/java/com/franco/dev/domain/rrhh/Aguinaldo.java
+++ b/src/main/java/com/franco/dev/domain/rrhh/Aguinaldo.java
@@ -67,6 +67,13 @@ public class Aguinaldo implements Identifiable<Long> {
     @Column(name = "caja_virtual_id")
     private Long cajaVirtualId;
 
+    /**
+     * Obligacion de pago (SolicitudPago tipo RRHH) cuando se paga desde el hub de la caja.
+     * NULL = pagada por el atajo viejo (egreso directo desde la pantalla de RRHH).
+     */
+    @Column(name = "solicitud_pago_id")
+    private Long solicitudPagoId;
+
     @Column(name = "movimiento_caja_virtual_id")
     private Long movimientoCajaVirtualId;
 

--- a/src/main/java/com/franco/dev/domain/rrhh/LiquidacionFinal.java
+++ b/src/main/java/com/franco/dev/domain/rrhh/LiquidacionFinal.java
@@ -117,6 +117,13 @@ public class LiquidacionFinal implements Identifiable<Long> {
     @Column(name = "caja_virtual_id")
     private Long cajaVirtualId;
 
+    /**
+     * Obligacion de pago (SolicitudPago tipo RRHH) cuando se paga desde el hub de la caja.
+     * NULL = pagada por el atajo viejo (egreso directo desde la pantalla de RRHH).
+     */
+    @Column(name = "solicitud_pago_id")
+    private Long solicitudPagoId;
+
     @Column(name = "movimiento_caja_virtual_id")
     private Long movimientoCajaVirtualId;
 

--- a/src/main/java/com/franco/dev/domain/rrhh/LiquidacionSueldo.java
+++ b/src/main/java/com/franco/dev/domain/rrhh/LiquidacionSueldo.java
@@ -85,6 +85,13 @@ public class LiquidacionSueldo implements Identifiable<Long> {
     @Column(name = "caja_virtual_id")
     private Long cajaVirtualId;
 
+    /**
+     * Obligacion de pago (SolicitudPago tipo RRHH) cuando se paga desde el hub de la caja.
+     * NULL = pagada por el atajo viejo (egreso directo desde la pantalla de RRHH).
+     */
+    @Column(name = "solicitud_pago_id")
+    private Long solicitudPagoId;
+
     @Column(name = "movimiento_caja_virtual_id")
     private Long movimientoCajaVirtualId;
 

--- a/src/main/java/com/franco/dev/graphql/financiero/CajaVirtualConfiguracionGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/CajaVirtualConfiguracionGraphQL.java
@@ -30,6 +30,7 @@ public class CajaVirtualConfiguracionGraphQL implements GraphQLQueryResolver, Gr
 
     public CajaVirtualConfiguracion cajaVirtualConfiguracion(Long cajaVirtualId) {
         seg.requireVer();
+        seg.requireLecturaCaja(cajaVirtualId);
         return repository.findByCajaVirtualId(cajaVirtualId).orElse(null);
     }
 

--- a/src/main/java/com/franco/dev/graphql/financiero/CajaVirtualGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/CajaVirtualGraphQL.java
@@ -171,6 +171,10 @@ public class CajaVirtualGraphQL implements GraphQLQueryResolver, GraphQLMutation
 
     public CajaVirtual saveCajaVirtual(CajaVirtualInput input) {
         seg.requireGestionar();
+        // Crear una caja queda con el rol; MODIFICAR una existente exige ser su responsable.
+        // Sin esto el modelo AND quedaba incoherente: alguien sin acceso de lectura no podia
+        // ver la caja pero si desactivarla o cambiarle el limite.
+        if (input.getId() != null) seg.requirePropietarioCaja(input.getId());
         CajaVirtual entity = new CajaVirtual();
         if (input.getId() != null) {
             entity = service.findById(input.getId())
@@ -201,6 +205,7 @@ public class CajaVirtualGraphQL implements GraphQLQueryResolver, GraphQLMutation
 
     public Boolean deleteCajaVirtual(Long id) {
         seg.requireGestionar();
+        seg.requirePropietarioCaja(id);
         return service.deleteById(id);
     }
 }

--- a/src/main/java/com/franco/dev/graphql/financiero/CajaVirtualGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/CajaVirtualGraphQL.java
@@ -43,27 +43,33 @@ public class CajaVirtualGraphQL implements GraphQLQueryResolver, GraphQLMutation
     private final CajaVirtualConfiguracionRepository configRepository;
     private final AcreditacionPosRepository acreditacionPosRepository;
     private final TesoreriaSecurityService seg;
+    private final com.franco.dev.service.financiero.CajaVirtualAccesoService accesoService;
     private final RrhhSecurityService rrhhSeg;
+
+    // Modelo AND: el rol habilita la capacidad (requireVer), el ACL delimita el alcance.
+    // Caja puntual → se rechaza; listados → se filtran (devolver menos, no fallar).
 
     public CajaVirtual cajaVirtual(Long id) {
         seg.requireVer();
+        seg.requireLecturaCaja(id);
         return service.findById(id).orElse(null);
     }
 
     public Page<CajaVirtual> cajaVirtuales(int page, int size) {
         seg.requireVer();
         Pageable pageable = PageRequest.of(page, size);
-        return service.findAll(pageable);
+        return service.findAll(seg.cajasVisiblesIds(), pageable);
     }
 
     public Page<CajaVirtual> cajaVirtualesFilter(String nombre, CajaVirtualTipo tipo, Long sucursalId, Boolean activo, int page, int size) {
         seg.requireVer();
-        return service.filter(nombre, tipo, sucursalId, activo, PageRequest.of(page, size));
+        return service.filter(seg.cajasVisiblesIds(), nombre, tipo, sucursalId, activo, PageRequest.of(page, size));
     }
 
     /** Saldo de efectivo por moneda (fuente de verdad: caja_virtual_saldo). */
     public List<CajaVirtualSaldoItem> cajaVirtualSaldos(Long cajaVirtualId) {
         seg.requireVer();
+        seg.requireLecturaCaja(cajaVirtualId);
         return cajaSaldoRepository.findByCajaVirtualId(cajaVirtualId).stream()
                 .map(s -> new CajaVirtualSaldoItem(s.getMoneda(), s.getSaldo()))
                 .collect(Collectors.toList());
@@ -73,6 +79,7 @@ public class CajaVirtualGraphQL implements GraphQLQueryResolver, GraphQLMutation
     @Transactional(readOnly = true)
     public List<CuentaBancariaResumen> cajaVirtualResumenBancario(Long cajaVirtualId) {
         seg.requireVer();
+        seg.requireLecturaCaja(cajaVirtualId);
         CajaVirtualConfiguracion cfg = configRepository.findByCajaVirtualId(cajaVirtualId).orElse(null);
         if (cfg == null || cfg.getCuentasBancariasVisibles() == null || cfg.getCuentasBancariasVisibles().isEmpty()) {
             return new ArrayList<>();
@@ -115,12 +122,12 @@ public class CajaVirtualGraphQL implements GraphQLQueryResolver, GraphQLMutation
 
     public List<CajaVirtual> cajaVirtualesPorTipo(CajaVirtualTipo tipo) {
         seg.requireVer();
-        return service.findByTipo(tipo);
+        return service.findByTipo(seg.cajasVisiblesIds(), tipo);
     }
 
     public List<CajaVirtual> cajaVirtualesPorSucursal(Long sucursalId) {
         seg.requireVer();
-        return service.findBySucursalId(sucursalId);
+        return service.findBySucursalId(seg.cajasVisiblesIds(), sucursalId);
     }
 
     /**
@@ -133,7 +140,33 @@ public class CajaVirtualGraphQL implements GraphQLQueryResolver, GraphQLMutation
                 && !rrhhSeg.hasAnyRole(RrhhSecurityService.TODOS)) {
             throw new GraphQLException("No autorizado: se requiere un rol de Tesorería o de RRHH.");
         }
-        return service.findActivas();
+        return service.findActivas(seg.cajasVisiblesIds());
+    }
+
+    // ── Administracion de accesos ──
+    //
+    // Todo esto exige ser el responsable de la caja (o superusuario): es lo que decide quien
+    // ve y quien mueve plata, asi que no alcanza con TESORERIA GESTIONAR.
+
+    public List<com.franco.dev.domain.financiero.CajaVirtualAcceso> cajaVirtualAccesos(Long cajaVirtualId) {
+        seg.requirePropietarioCaja(cajaVirtualId);
+        return accesoService.listar(cajaVirtualId);
+    }
+
+    public com.franco.dev.domain.financiero.CajaVirtualAcceso otorgarAccesoCaja(
+            Long cajaVirtualId, Long usuarioId, Boolean puedeLeer, Boolean puedeEscribir) {
+        seg.requirePropietarioCaja(cajaVirtualId);
+        return accesoService.otorgar(cajaVirtualId, usuarioId, puedeLeer, puedeEscribir, seg.currentUsuario());
+    }
+
+    public Boolean revocarAccesoCaja(Long cajaVirtualId, Long usuarioId) {
+        seg.requirePropietarioCaja(cajaVirtualId);
+        return accesoService.revocar(cajaVirtualId, usuarioId);
+    }
+
+    public CajaVirtual transferirPropiedadCaja(Long cajaVirtualId, Long nuevoPropietarioId) {
+        seg.requirePropietarioCaja(cajaVirtualId);
+        return accesoService.transferirPropiedad(cajaVirtualId, nuevoPropietarioId);
     }
 
     public CajaVirtual saveCajaVirtual(CajaVirtualInput input) {
@@ -154,8 +187,14 @@ public class CajaVirtualGraphQL implements GraphQLQueryResolver, GraphQLMutation
         if (input.getResponsableId() != null) {
             entity.setResponsable(funcionarioService.findById(input.getResponsableId()).orElse(null));
         }
-        if (input.getUsuarioId() != null) {
-            entity.setUsuario(usuarioService.findById(input.getUsuarioId()).orElse(null));
+        // Propietario: quien crea la caja, tomado del SecurityContext y NO del input.
+        //
+        // Se setea solo en el alta: en un update el campo no se toca, para que editar una caja
+        // ajena no te vuelva su duenio. El usuarioId del input se ignora a proposito — venia del
+        // cliente y cualquiera podia mandar cualquier id. Transferir la propiedad se hace con
+        // transferirPropiedadCaja, que exige ser el duenio o ADMIN.
+        if (input.getId() == null) {
+            entity.setUsuario(seg.currentUsuario());
         }
         return service.save(entity);
     }

--- a/src/main/java/com/franco/dev/graphql/financiero/CuentaBancariaGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/CuentaBancariaGraphQL.java
@@ -28,6 +28,12 @@ public class CuentaBancariaGraphQL implements GraphQLQueryResolver, GraphQLMutat
     private CuentaBancariaService service;
 
     @Autowired
+    private com.franco.dev.service.financiero.BancoLedgerService bancoLedgerService;
+
+    @Autowired
+    private com.franco.dev.service.financiero.TesoreriaSecurityService seg;
+
+    @Autowired
     private UsuarioService usuarioService;
 
     @Autowired
@@ -105,5 +111,33 @@ public class CuentaBancariaGraphQL implements GraphQLQueryResolver, GraphQLMutat
         return service.count();
     }
 
+
+
+    /**
+     * Ajusta el saldo de una cuenta bancaria contra el extracto real.
+     *
+     * <p>Exige {@code TESORERIA GESTIONAR}: un ajuste no tiene contrapartida — es plata que
+     * aparece o desaparece del ledger — asi que el motivo es obligatorio y queda en la
+     * descripcion del movimiento, que es toda su trazabilidad.</p>
+     */
+    public com.franco.dev.domain.financiero.MovimientoBancario ajustarSaldoCuentaBancaria(
+            Long cuentaBancariaId, Double monto, Boolean positivo, String motivo) {
+        seg.requireGestionar();
+        if (monto == null || monto <= 0) {
+            throw new graphql.GraphQLException("El monto del ajuste debe ser mayor a cero");
+        }
+        if (motivo == null || motivo.trim().isEmpty()) {
+            throw new graphql.GraphQLException("El motivo del ajuste es obligatorio");
+        }
+        com.franco.dev.domain.financiero.enums.MovimientoBancarioTipo tipo =
+                Boolean.TRUE.equals(positivo)
+                        ? com.franco.dev.domain.financiero.enums.MovimientoBancarioTipo.AJUSTE_POSITIVO
+                        : com.franco.dev.domain.financiero.enums.MovimientoBancarioTipo.AJUSTE_NEGATIVO;
+        return bancoLedgerService.registrar(
+                cuentaBancariaId, tipo, java.math.BigDecimal.valueOf(monto),
+                "AJUSTE: " + motivo.trim().toUpperCase(),
+                com.franco.dev.domain.financiero.enums.OrigenMovimientoTipo.MANUAL.name(),
+                null, seg.currentUsuario());
+    }
 
 }

--- a/src/main/java/com/franco/dev/graphql/financiero/EntradaVariaGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/EntradaVariaGraphQL.java
@@ -37,6 +37,7 @@ public class EntradaVariaGraphQL implements GraphQLQueryResolver, GraphQLMutatio
 
     public Page<EntradaVaria> entradasVarias(Long cajaVirtualId, int page, int size) {
         seg.requireVer();
+        seg.requireLecturaCaja(cajaVirtualId);
         return service.findByCaja(cajaVirtualId, PageRequest.of(page, size));
     }
 

--- a/src/main/java/com/franco/dev/graphql/financiero/MovimientoCajaVirtualFieldResolver.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/MovimientoCajaVirtualFieldResolver.java
@@ -1,0 +1,28 @@
+package com.franco.dev.graphql.financiero;
+
+import com.franco.dev.domain.financiero.MovimientoCajaVirtual;
+import com.franco.dev.repository.financiero.PagoSolicitudDetalleRepository;
+import graphql.kickstart.tools.GraphQLResolver;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * Campos derivados de {@link MovimientoCajaVirtual}.
+ *
+ * <p>{@code esPagoConsolidado} contesta si el movimiento es el asiento de un evento de pago del
+ * motor de CPP. <b>No se puede deducir del {@code origenTipo}</b>: los origenes de RRHH
+ * (vale, liquidacion, finiquito, aguinaldo) los postean tanto el motor como el egreso directo
+ * viejo de cada modulo, asi que el mismo valor significa dos cosas distintas. La verdad la
+ * tiene {@code PagoSolicitudDetalle}, que apunta al movimiento del evento.</p>
+ */
+@Component
+@AllArgsConstructor
+public class MovimientoCajaVirtualFieldResolver implements GraphQLResolver<MovimientoCajaVirtual> {
+
+    private final PagoSolicitudDetalleRepository detalleRepository;
+
+    public Boolean esPagoConsolidado(MovimientoCajaVirtual mov) {
+        if (mov == null || mov.getId() == null) return false;
+        return detalleRepository.existsByMovimientoCajaVirtualId(mov.getId());
+    }
+}

--- a/src/main/java/com/franco/dev/graphql/financiero/MovimientoCajaVirtualGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/MovimientoCajaVirtualGraphQL.java
@@ -36,12 +36,14 @@ public class MovimientoCajaVirtualGraphQL implements GraphQLQueryResolver, Graph
 
     public Page<MovimientoCajaVirtual> movimientosCajaVirtual(Long cajaVirtualId, int page, int size) {
         seg.requireVer();
+        seg.requireLecturaCaja(cajaVirtualId);
         Pageable pageable = PageRequest.of(page, size);
         return service.findByCajaVirtualId(cajaVirtualId, pageable);
     }
 
     public Page<MovimientoCajaVirtual> movimientosCajaVirtualPorFecha(Long cajaVirtualId, String inicio, String fin, int page, int size) {
         seg.requireVer();
+        seg.requireLecturaCaja(cajaVirtualId);
         Pageable pageable = PageRequest.of(page, size);
         return service.findByCajaVirtualIdAndFecha(cajaVirtualId, inicio, fin, pageable);
     }
@@ -51,6 +53,7 @@ public class MovimientoCajaVirtualGraphQL implements GraphQLQueryResolver, Graph
                                                                     com.franco.dev.domain.financiero.enums.CajaVirtualTipoMovimiento tipo,
                                                                     Boolean soloActivos, int page, int size) {
         seg.requireVer();
+        seg.requireLecturaCaja(cajaVirtualId);
         Pageable pageable = PageRequest.of(page, size);
         return service.filter(cajaVirtualId, desde, fin, tipo, soloActivos != null && soloActivos, pageable);
     }

--- a/src/main/java/com/franco/dev/graphql/financiero/PagoProveedorGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/PagoProveedorGraphQL.java
@@ -30,6 +30,15 @@ public class PagoProveedorGraphQL implements GraphQLQueryResolver, GraphQLMutati
     }
 
     /** Gastos pagables (SolicitudPago tipo GASTO en SOLICITADO/PARCIAL) para el diálogo de gastos. */
+    /**
+     * Desglose de un evento de pago: que documentos se pagaron y cuanto se imputo a cada uno.
+     * Lo consume el detalle del movimiento consolidado en el historial de la caja.
+     */
+    public List<com.franco.dev.service.financiero.dto.DetallePagoItemDto> detalleDePago(Long pagoId) {
+        seg.requireVer();
+        return service.detalleDePago(pagoId);
+    }
+
     public List<SolicitudPago> gastosPendientes() {
         seg.requireVer();
         return service.listarGastosPendientes();

--- a/src/main/java/com/franco/dev/graphql/rrhh/PagoRrhhTesoreriaGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/rrhh/PagoRrhhTesoreriaGraphQL.java
@@ -1,0 +1,68 @@
+package com.franco.dev.graphql.rrhh;
+
+import com.franco.dev.domain.operaciones.Pago;
+import com.franco.dev.graphql.financiero.PagoProveedorGraphQL;
+import com.franco.dev.service.financiero.PagoRrhhTesoreriaService;
+import com.franco.dev.service.rrhh.RrhhSecurityService;
+import com.franco.dev.service.rrhh.dto.PagoRrhhPendienteDto;
+import graphql.kickstart.tools.GraphQLMutationResolver;
+import graphql.kickstart.tools.GraphQLQueryResolver;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Pago de liquidacion mensual, finiquito y aguinaldo desde el hub de egresos de la Caja
+ * Mayor. Hermano de {@link ValeTesoreriaGraphQL}, mismo puente y mismo motor de pago.
+ *
+ * <p>Seguridad: paridad exacta con los pagos que ya existian desde las pantallas de RRHH
+ * ({@code pagarLiquidacion} / {@code pagarLiquidacionFinal} / {@code pagarAguinaldo} exigen
+ * {@code RRHH PAGAR}). Listar exige lectura de RRHH. No amplia ni restringe privilegios
+ * respecto de lo que la gente ya podia hacer.</p>
+ */
+@Component
+@AllArgsConstructor
+public class PagoRrhhTesoreriaGraphQL implements GraphQLQueryResolver, GraphQLMutationResolver {
+
+    private final PagoRrhhTesoreriaService service;
+    private final RrhhSecurityService seg;
+
+    public List<PagoRrhhPendienteDto> liquidacionesPendientesPago() {
+        seg.requireVer();
+        return service.listarLiquidacionesPendientes();
+    }
+
+    public List<PagoRrhhPendienteDto> finiquitosPendientesPago() {
+        seg.requireVer();
+        return service.listarFiniquitosPendientes();
+    }
+
+    public List<PagoRrhhPendienteDto> aguinaldosPendientesPago() {
+        seg.requireVer();
+        return service.listarAguinaldosPendientes();
+    }
+
+    /** Paga documentos de RRHH (caja mayor / banco / cheque). El pago parcial esta prohibido. */
+    public Pago pagarRrhhMixto(List<PagoRrhhConLineasWrapper> pagos) {
+        seg.requireAnyRole(seg.PAGAR);
+        List<PagoRrhhTesoreriaService.PagoRrhhConLineas> ls = new ArrayList<>();
+        for (PagoRrhhConLineasWrapper w : pagos) {
+            PagoRrhhTesoreriaService.PagoRrhhConLineas p = new PagoRrhhTesoreriaService.PagoRrhhConLineas();
+            p.setConcepto(w.getConcepto());
+            p.setDocumentoId(w.getDocumentoId());
+            p.setLineas(PagoProveedorGraphQL.mapLineas(w.getLineas()));
+            ls.add(p);
+        }
+        return service.pagarRrhhMixto(ls, seg.currentUsuario());
+    }
+
+    @Data
+    public static class PagoRrhhConLineasWrapper {
+        private PagoRrhhTesoreriaService.ConceptoRrhh concepto;
+        private Long documentoId;
+        private List<PagoProveedorGraphQL.LineaPagoInputWrapper> lineas;
+    }
+}

--- a/src/main/java/com/franco/dev/repository/financiero/CajaVirtualAccesoRepository.java
+++ b/src/main/java/com/franco/dev/repository/financiero/CajaVirtualAccesoRepository.java
@@ -1,0 +1,30 @@
+package com.franco.dev.repository.financiero;
+
+import com.franco.dev.domain.financiero.CajaVirtualAcceso;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface CajaVirtualAccesoRepository extends JpaRepository<CajaVirtualAcceso, Long> {
+
+    List<CajaVirtualAcceso> findByCajaVirtualIdOrderByIdAsc(Long cajaVirtualId);
+
+    Optional<CajaVirtualAcceso> findByCajaVirtualIdAndUsuarioId(Long cajaVirtualId, Long usuarioId);
+
+    void deleteByCajaVirtualIdAndUsuarioId(Long cajaVirtualId, Long usuarioId);
+
+    /**
+     * Ids de las cajas que el usuario puede ver: las que le fueron otorgadas mas las que
+     * son suyas. Es la consulta caliente — filtra todos los listados de cajas.
+     */
+    @Query("select c.id from CajaVirtual c "
+            + "where c.usuario.id = :usuarioId "
+            + "   or exists (select 1 from CajaVirtualAcceso a "
+            + "              where a.cajaVirtual.id = c.id and a.usuario.id = :usuarioId and a.puedeLeer = true)")
+    List<Long> cajasVisiblesIds(@Param("usuarioId") Long usuarioId);
+}

--- a/src/main/java/com/franco/dev/repository/financiero/CajaVirtualRepository.java
+++ b/src/main/java/com/franco/dev/repository/financiero/CajaVirtualRepository.java
@@ -22,6 +22,21 @@ public interface CajaVirtualRepository extends JpaRepository<CajaVirtual, Long> 
 
     Page<CajaVirtual> findAll(Pageable pageable);
 
+    // ── Variantes acotadas por el ACL de cajas ──
+    //
+    // El filtro va en la consulta y no en memoria a proposito: filtrar despues de paginar
+    // deja getTotalElements contando cajas que el usuario no puede ver (paginacion mentirosa).
+    // Quien ve todas (superusuario, proceso de sistema) usa los metodos de arriba.
+
+    @Query("select c from CajaVirtual c where c.id in :ids")
+    Page<CajaVirtual> findAllVisibles(@Param("ids") List<Long> ids, Pageable pageable);
+
+    List<CajaVirtual> findByTipoAndIdIn(CajaVirtualTipo tipo, List<Long> ids);
+
+    List<CajaVirtual> findBySucursalIdAndIdIn(Long sucursalId, List<Long> ids);
+
+    List<CajaVirtual> findByActivoTrueAndIdIn(List<Long> ids);
+
     /**
      * Filtro combinado (todos opcionales) para la lista de cajas. {@code tipo} llega como
      * String (name del enum) y se compara contra la columna casteada a texto: el enum es un
@@ -38,4 +53,18 @@ public interface CajaVirtualRepository extends JpaRepository<CajaVirtual, Long> 
                              @Param("sucursalId") Long sucursalId,
                              @Param("activo") Boolean activo,
                              Pageable pageable);
+
+    /** Igual que {@link #filter}, acotado a las cajas visibles para el usuario. */
+    @Query("select c from CajaVirtual c where "
+            + "c.id in :ids and "
+            + "(:nombre is null or lower(c.nombre) like lower(concat('%', :nombre, '%'))) and "
+            + "(:tipo is null or cast(c.tipo as string) = :tipo) and "
+            + "(:sucursalId is null or c.sucursal.id = :sucursalId) and "
+            + "(:activo is null or c.activo = :activo)")
+    Page<CajaVirtual> filterVisibles(@Param("ids") List<Long> ids,
+                                     @Param("nombre") String nombre,
+                                     @Param("tipo") String tipo,
+                                     @Param("sucursalId") Long sucursalId,
+                                     @Param("activo") Boolean activo,
+                                     Pageable pageable);
 }

--- a/src/main/java/com/franco/dev/repository/financiero/PagoSolicitudDetalleRepository.java
+++ b/src/main/java/com/franco/dev/repository/financiero/PagoSolicitudDetalleRepository.java
@@ -7,4 +7,7 @@ import java.util.List;
 public interface PagoSolicitudDetalleRepository extends JpaRepository<PagoSolicitudDetalle, Long> {
     List<PagoSolicitudDetalle> findBySolicitudPagoIdOrderByCreadoEnAsc(Long solicitudPagoId);
     List<PagoSolicitudDetalle> findByPagoIdOrderByCreadoEnAsc(Long pagoId);
+
+    /** true si el movimiento es el asiento consolidado de un evento de pago. */
+    boolean existsByMovimientoCajaVirtualId(Long movimientoCajaVirtualId);
 }

--- a/src/main/java/com/franco/dev/repository/rrhh/AguinaldoRepository.java
+++ b/src/main/java/com/franco/dev/repository/rrhh/AguinaldoRepository.java
@@ -4,7 +4,10 @@ import com.franco.dev.domain.rrhh.Aguinaldo;
 import com.franco.dev.repository.HelperRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+
+import javax.persistence.LockModeType;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
@@ -36,4 +39,16 @@ public interface AguinaldoRepository extends HelperRepository<Aguinaldo, Long> {
 
     /** Aguinaldos en un estado dado (pagables = APROBADO). */
     List<Aguinaldo> findByEstadoOrderByAnioDescIdDesc(com.franco.dev.domain.rrhh.enums.AguinaldoEstado estado);
+
+    /**
+     * Toma el documento con lock pesimista antes de resolver su obligacion de pago.
+     *
+     * <p>Sin esto, dos pedidos de pago concurrentes sobre el mismo documento (doble click,
+     * reintento de red) leen los dos {@code solicitud_pago_id == null}, crean una solicitud
+     * cada uno y terminan pagando dos veces el mismo sueldo. El indice unico no lo impide:
+     * evita que dos documentos compartan una solicitud, no que un documento reciba dos.</p>
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select e from Aguinaldo e where e.id = :id")
+    java.util.Optional<Aguinaldo> lockById(@org.springframework.data.repository.query.Param("id") Long id);
 }

--- a/src/main/java/com/franco/dev/repository/rrhh/AguinaldoRepository.java
+++ b/src/main/java/com/franco/dev/repository/rrhh/AguinaldoRepository.java
@@ -30,4 +30,10 @@ public interface AguinaldoRepository extends HelperRepository<Aguinaldo, Long> {
     List<Aguinaldo> findByFuncionarioIdOrderByAnioDesc(Long funcionarioId);
 
     Optional<Aguinaldo> findByFuncionarioIdAndAnio(Long funcionarioId, Integer anio);
+
+    /** Documento dueno de una obligacion de pago (puente tesoreria, V199.5). */
+    Aguinaldo findBySolicitudPagoId(Long solicitudPagoId);
+
+    /** Aguinaldos en un estado dado (pagables = APROBADO). */
+    List<Aguinaldo> findByEstadoOrderByAnioDescIdDesc(com.franco.dev.domain.rrhh.enums.AguinaldoEstado estado);
 }

--- a/src/main/java/com/franco/dev/repository/rrhh/LiquidacionFinalRepository.java
+++ b/src/main/java/com/franco/dev/repository/rrhh/LiquidacionFinalRepository.java
@@ -18,4 +18,7 @@ public interface LiquidacionFinalRepository extends HelperRepository<Liquidacion
     Optional<LiquidacionFinal> findFirstByFuncionarioIdAndEstadoOrderByCreadoEnDesc(Long funcionarioId, LiquidacionFinalEstado estado);
 
     List<LiquidacionFinal> findByEstadoOrderByCreadoEnDesc(LiquidacionFinalEstado estado);
+
+    /** Documento dueno de una obligacion de pago (puente tesoreria, V199.5). */
+    LiquidacionFinal findBySolicitudPagoId(Long solicitudPagoId);
 }

--- a/src/main/java/com/franco/dev/repository/rrhh/LiquidacionFinalRepository.java
+++ b/src/main/java/com/franco/dev/repository/rrhh/LiquidacionFinalRepository.java
@@ -21,4 +21,16 @@ public interface LiquidacionFinalRepository extends HelperRepository<Liquidacion
 
     /** Documento dueno de una obligacion de pago (puente tesoreria, V199.5). */
     LiquidacionFinal findBySolicitudPagoId(Long solicitudPagoId);
+
+    /**
+     * Toma el documento con lock pesimista antes de resolver su obligacion de pago.
+     *
+     * <p>Sin esto, dos pedidos de pago concurrentes sobre el mismo documento (doble click,
+     * reintento de red) leen los dos {@code solicitud_pago_id == null}, crean una solicitud
+     * cada uno y terminan pagando dos veces el mismo sueldo. El indice unico no lo impide:
+     * evita que dos documentos compartan una solicitud, no que un documento reciba dos.</p>
+     */
+    @org.springframework.data.jpa.repository.Lock(javax.persistence.LockModeType.PESSIMISTIC_WRITE)
+    @org.springframework.data.jpa.repository.Query("select e from LiquidacionFinal e where e.id = :id")
+    java.util.Optional<LiquidacionFinal> lockById(@org.springframework.data.repository.query.Param("id") Long id);
 }

--- a/src/main/java/com/franco/dev/repository/rrhh/LiquidacionSueldoRepository.java
+++ b/src/main/java/com/franco/dev/repository/rrhh/LiquidacionSueldoRepository.java
@@ -5,7 +5,10 @@ import com.franco.dev.domain.rrhh.enums.LiquidacionSueldoEstado;
 import com.franco.dev.repository.HelperRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+
+import javax.persistence.LockModeType;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
@@ -62,4 +65,16 @@ public interface LiquidacionSueldoRepository extends HelperRepository<Liquidacio
 
     /** Documento dueno de una obligacion de pago (puente tesoreria, V199.5). */
     LiquidacionSueldo findBySolicitudPagoId(Long solicitudPagoId);
+
+    /**
+     * Toma el documento con lock pesimista antes de resolver su obligacion de pago.
+     *
+     * <p>Sin esto, dos pedidos de pago concurrentes sobre el mismo documento (doble click,
+     * reintento de red) leen los dos {@code solicitud_pago_id == null}, crean una solicitud
+     * cada uno y terminan pagando dos veces el mismo sueldo. El indice unico no lo impide:
+     * evita que dos documentos compartan una solicitud, no que un documento reciba dos.</p>
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select e from LiquidacionSueldo e where e.id = :id")
+    java.util.Optional<LiquidacionSueldo> lockById(@org.springframework.data.repository.query.Param("id") Long id);
 }

--- a/src/main/java/com/franco/dev/repository/rrhh/LiquidacionSueldoRepository.java
+++ b/src/main/java/com/franco/dev/repository/rrhh/LiquidacionSueldoRepository.java
@@ -59,4 +59,7 @@ public interface LiquidacionSueldoRepository extends HelperRepository<Liquidacio
             nativeQuery = true)
     List<Object[]> nominaSeriePorMesRaw(@Param("periodoInicio") String periodoInicio,
                                         @Param("periodoFin") String periodoFin);
+
+    /** Documento dueno de una obligacion de pago (puente tesoreria, V199.5). */
+    LiquidacionSueldo findBySolicitudPagoId(Long solicitudPagoId);
 }

--- a/src/main/java/com/franco/dev/service/financiero/CajaVirtualAccesoService.java
+++ b/src/main/java/com/franco/dev/service/financiero/CajaVirtualAccesoService.java
@@ -1,0 +1,97 @@
+package com.franco.dev.service.financiero;
+
+import com.franco.dev.domain.financiero.CajaVirtual;
+import com.franco.dev.domain.financiero.CajaVirtualAcceso;
+import com.franco.dev.domain.personas.Usuario;
+import com.franco.dev.repository.financiero.CajaVirtualAccesoRepository;
+import com.franco.dev.repository.financiero.CajaVirtualRepository;
+import com.franco.dev.service.personas.UsuarioService;
+import graphql.GraphQLException;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * Administracion de la lista de accesos de una caja virtual.
+ *
+ * <p>Quien administra la lista es el <b>propietario</b> de la caja (quien la creo) o un
+ * superusuario; eso lo verifica el resolver con
+ * {@code TesoreriaSecurityService.requirePropietarioCaja}. Este servicio se ocupa de las
+ * reglas del dato.</p>
+ */
+@Service
+@AllArgsConstructor
+public class CajaVirtualAccesoService {
+
+    private final CajaVirtualAccesoRepository repository;
+    private final CajaVirtualRepository cajaVirtualRepository;
+    private final UsuarioService usuarioService;
+
+    @Transactional(readOnly = true)
+    public List<CajaVirtualAcceso> listar(Long cajaVirtualId) {
+        return repository.findByCajaVirtualIdOrderByIdAsc(cajaVirtualId);
+    }
+
+    /**
+     * Otorga o actualiza el acceso de un usuario a una caja. Idempotente: si ya tenia una fila
+     * se le actualizan los permisos en vez de duplicarla.
+     */
+    @Transactional
+    public CajaVirtualAcceso otorgar(Long cajaVirtualId, Long usuarioId,
+                                     Boolean puedeLeer, Boolean puedeEscribir, Usuario otorgadoPor) {
+        CajaVirtual caja = cajaVirtualRepository.findById(cajaVirtualId)
+                .orElseThrow(() -> new GraphQLException("Caja no encontrada: " + cajaVirtualId));
+        Usuario usuario = usuarioService.findById(usuarioId)
+                .orElseThrow(() -> new GraphQLException("Usuario no encontrado: " + usuarioId));
+
+        // El propietario ya tiene lectura y escritura implicitas: darle una fila seria ruido
+        // que ademas se puede revocar, dejando la caja sin quien la administre.
+        if (caja.getUsuario() != null && caja.getUsuario().getId().equals(usuarioId)) {
+            throw new GraphQLException("El responsable de la caja ya tiene acceso total; no hace falta otorgarselo.");
+        }
+
+        boolean escribir = Boolean.TRUE.equals(puedeEscribir);
+        // Escribir sin poder leer no tiene sentido operativo (moverias plata a ciegas).
+        boolean leer = escribir || Boolean.TRUE.equals(puedeLeer);
+        if (!leer) {
+            throw new GraphQLException("El acceso tiene que habilitar al menos la lectura. Para quitarlo, revocalo.");
+        }
+
+        CajaVirtualAcceso a = repository.findByCajaVirtualIdAndUsuarioId(cajaVirtualId, usuarioId)
+                .orElseGet(CajaVirtualAcceso::new);
+        a.setCajaVirtual(caja);
+        a.setUsuario(usuario);
+        a.setPuedeLeer(leer);
+        a.setPuedeEscribir(escribir);
+        a.setOtorgadoPor(otorgadoPor);
+        return repository.save(a);
+    }
+
+    @Transactional
+    public Boolean revocar(Long cajaVirtualId, Long usuarioId) {
+        repository.findByCajaVirtualIdAndUsuarioId(cajaVirtualId, usuarioId)
+                .ifPresent(repository::delete);
+        return true;
+    }
+
+    /**
+     * Transfiere la propiedad de la caja a otro usuario.
+     *
+     * <p>Sin esto, la caja de alguien que se va de la empresa queda sin quien administre su
+     * lista de accesos. El acceso explicito del nuevo duenio, si lo tenia, se elimina: pasa a
+     * tener permisos implicitos y la fila seria revocable.</p>
+     */
+    @Transactional
+    public CajaVirtual transferirPropiedad(Long cajaVirtualId, Long nuevoPropietarioId) {
+        CajaVirtual caja = cajaVirtualRepository.findById(cajaVirtualId)
+                .orElseThrow(() -> new GraphQLException("Caja no encontrada: " + cajaVirtualId));
+        Usuario nuevo = usuarioService.findById(nuevoPropietarioId)
+                .orElseThrow(() -> new GraphQLException("Usuario no encontrado: " + nuevoPropietarioId));
+        caja.setUsuario(nuevo);
+        repository.findByCajaVirtualIdAndUsuarioId(cajaVirtualId, nuevoPropietarioId)
+                .ifPresent(repository::delete);
+        return cajaVirtualRepository.save(caja);
+    }
+}

--- a/src/main/java/com/franco/dev/service/financiero/CajaVirtualService.java
+++ b/src/main/java/com/franco/dev/service/financiero/CajaVirtualService.java
@@ -45,6 +45,44 @@ public class CajaVirtualService {
         return repository.findByActivoTrue();
     }
 
+    // ── Variantes acotadas por el ACL ──
+    //
+    // Reciben la lista de ids visibles. {@code null} = ve todas (superusuario o proceso de
+    // sistema); lista vacia = no ve ninguna, que NO es lo mismo y devuelve vacio de verdad.
+
+    public Page<CajaVirtual> findAll(List<Long> visibles, Pageable pageable) {
+        if (visibles == null) return repository.findAll(pageable);
+        if (visibles.isEmpty()) return Page.empty(pageable);
+        return repository.findAllVisibles(visibles, pageable);
+    }
+
+    public Page<CajaVirtual> filter(List<Long> visibles, String nombre, CajaVirtualTipo tipo,
+                                    Long sucursalId, Boolean activo, Pageable pageable) {
+        String n = (nombre != null && !nombre.trim().isEmpty()) ? nombre.trim() : null;
+        String tipoStr = tipo != null ? tipo.name() : null;
+        if (visibles == null) return repository.filter(n, tipoStr, sucursalId, activo, pageable);
+        if (visibles.isEmpty()) return Page.empty(pageable);
+        return repository.filterVisibles(visibles, n, tipoStr, sucursalId, activo, pageable);
+    }
+
+    public List<CajaVirtual> findByTipo(List<Long> visibles, CajaVirtualTipo tipo) {
+        if (visibles == null) return repository.findByTipo(tipo);
+        if (visibles.isEmpty()) return java.util.Collections.emptyList();
+        return repository.findByTipoAndIdIn(tipo, visibles);
+    }
+
+    public List<CajaVirtual> findBySucursalId(List<Long> visibles, Long sucursalId) {
+        if (visibles == null) return repository.findBySucursalId(sucursalId);
+        if (visibles.isEmpty()) return java.util.Collections.emptyList();
+        return repository.findBySucursalIdAndIdIn(sucursalId, visibles);
+    }
+
+    public List<CajaVirtual> findActivas(List<Long> visibles) {
+        if (visibles == null) return repository.findByActivoTrue();
+        if (visibles.isEmpty()) return java.util.Collections.emptyList();
+        return repository.findByActivoTrueAndIdIn(visibles);
+    }
+
     public CajaVirtual save(CajaVirtual entity) {
         if (entity.getSaldoGs() == null) entity.setSaldoGs(0.0);
         if (entity.getSaldoRs() == null) entity.setSaldoRs(0.0);

--- a/src/main/java/com/franco/dev/service/financiero/PagoProveedorService.java
+++ b/src/main/java/com/franco/dev/service/financiero/PagoProveedorService.java
@@ -64,6 +64,9 @@ public class PagoProveedorService {
     private final PreGastoService preGastoService;
     // Sin ciclo: ValeService no conoce el motor de pago (el que sí lo usa es ValeTesoreriaService).
     private final com.franco.dev.service.rrhh.ValeService valeService;
+    private final com.franco.dev.service.rrhh.LiquidacionSueldoService liquidacionSueldoService;
+    private final com.franco.dev.service.rrhh.LiquidacionFinalService liquidacionFinalService;
+    private final com.franco.dev.service.rrhh.AguinaldoService aguinaldoService;
 
     /** Una línea de pago (pago mixto). Puede ser fuente AJUSTE (diferencia de cambio). */
     @Data
@@ -392,6 +395,12 @@ public class PagoProveedorService {
             // Si la obligación era de un vale de RRHH, dejarlo CONFIRMADO (es lo que mira la
             // liquidación para descontarlo del sueldo).
             valeService.sincronizarDesdeSolicitudPago(sp);
+            // Idem para los demas conceptos de RRHH pagables desde el hub de la caja
+            // (liquidacion mensual, finiquito, aguinaldo). Cada uno resuelve por su propio
+            // solicitud_pago_id y no hace nada si la obligacion no es suya.
+            liquidacionSueldoService.sincronizarDesdeSolicitudPago(sp);
+            liquidacionFinalService.sincronizarDesdeSolicitudPago(sp);
+            aguinaldoService.sincronizarDesdeSolicitudPago(sp);
         }
 
         // PagoService.save fuerza ABIERTO en el alta; marcar el evento como CONCLUIDO ya con id.
@@ -471,6 +480,12 @@ public class PagoProveedorService {
             preGastoService.sincronizarDesdeSolicitudPago(sp);
             // Si era el pago de un vale, vuelve a quedar pendiente de entrega (CONFIRMADO → SOLICITADO).
             valeService.sincronizarDesdeSolicitudPago(sp);
+            // Idem para los demas conceptos de RRHH pagables desde el hub de la caja
+            // (liquidacion mensual, finiquito, aguinaldo). Cada uno resuelve por su propio
+            // solicitud_pago_id y no hace nada si la obligacion no es suya.
+            liquidacionSueldoService.sincronizarDesdeSolicitudPago(sp);
+            liquidacionFinalService.sincronizarDesdeSolicitudPago(sp);
+            aguinaldoService.sincronizarDesdeSolicitudPago(sp);
         }
 
         pago.setEstado(PagoEstado.CANCELADO);

--- a/src/main/java/com/franco/dev/service/financiero/PagoProveedorService.java
+++ b/src/main/java/com/franco/dev/service/financiero/PagoProveedorService.java
@@ -60,6 +60,7 @@ public class PagoProveedorService {
     private final CajaVirtualRepository cajaVirtualRepository;
     private final MonedaRepository monedaRepository;
     private final com.franco.dev.repository.financiero.PagoSolicitudDetalleRepository detalleRepository;
+    private final TesoreriaSecurityService seguridad;
     private final com.franco.dev.repository.financiero.MovimientoBancarioRepository movimientoBancarioRepository;
     private final PreGastoService preGastoService;
     // Sin ciclo: ValeService no conoce el motor de pago (el que sí lo usa es ValeTesoreriaService).
@@ -113,13 +114,24 @@ public class PagoProveedorService {
      * <p>Es lo que responde la pregunta que el movimiento consolidado no puede contestar solo.
      * Se arma desde {@code PagoSolicitudDetalle}, que ya guarda una fila por documento y linea:
      * se agrupan por solicitud y se suman los {@code montoSolicitud}.</p>
+     *
+     * <p><b>Acotado por el ACL de cajas.</b> Las observaciones de una solicitud de RRHH traen el
+     * nombre del funcionario y el concepto ("LIQUIDACION 2026-07 #123 - JUAN PEREZ"), asi que el
+     * detalle expone sueldos. Solo se devuelven los items pagados desde una caja que el usuario
+     * puede leer; los pagados 100% por banco o cheque no tienen caja y se muestran a quien ya
+     * puede ver el evento. Sin este filtro alcanzaba con iterar pagoId — que es correlativo —
+     * para leer la nomina entera.</p>
      */
     @Transactional(readOnly = true)
     public List<com.franco.dev.service.financiero.dto.DetallePagoItemDto> detalleDePago(Long pagoId) {
+        java.util.List<Long> visibles = seguridad.cajasVisiblesIds();   // null = ve todas
         java.util.LinkedHashMap<Long, java.math.BigDecimal> imputadoPorSolicitud = new java.util.LinkedHashMap<>();
         for (com.franco.dev.domain.financiero.PagoSolicitudDetalle d
                 : detalleRepository.findByPagoIdOrderByCreadoEnAsc(pagoId)) {
             if (Boolean.TRUE.equals(d.getAnulado())) continue;
+            if (visibles != null && d.getCajaVirtualId() != null && !visibles.contains(d.getCajaVirtualId())) {
+                continue;   // pagado desde una caja que este usuario no puede ver
+            }
             java.math.BigDecimal aporte = d.getMontoSolicitud() != null ? d.getMontoSolicitud() : java.math.BigDecimal.ZERO;
             imputadoPorSolicitud.merge(d.getSolicitudPagoId(), aporte, java.math.BigDecimal::add);
         }

--- a/src/main/java/com/franco/dev/service/financiero/PagoProveedorService.java
+++ b/src/main/java/com/franco/dev/service/financiero/PagoProveedorService.java
@@ -105,6 +105,140 @@ public class PagoProveedorService {
         private List<LineaPago> lineas;
     }
 
+
+
+    /**
+     * Desglose de un evento de pago: que documentos se pagaron y cuanto se imputo a cada uno.
+     *
+     * <p>Es lo que responde la pregunta que el movimiento consolidado no puede contestar solo.
+     * Se arma desde {@code PagoSolicitudDetalle}, que ya guarda una fila por documento y linea:
+     * se agrupan por solicitud y se suman los {@code montoSolicitud}.</p>
+     */
+    @Transactional(readOnly = true)
+    public List<com.franco.dev.service.financiero.dto.DetallePagoItemDto> detalleDePago(Long pagoId) {
+        java.util.LinkedHashMap<Long, java.math.BigDecimal> imputadoPorSolicitud = new java.util.LinkedHashMap<>();
+        for (com.franco.dev.domain.financiero.PagoSolicitudDetalle d
+                : detalleRepository.findByPagoIdOrderByCreadoEnAsc(pagoId)) {
+            if (Boolean.TRUE.equals(d.getAnulado())) continue;
+            java.math.BigDecimal aporte = d.getMontoSolicitud() != null ? d.getMontoSolicitud() : java.math.BigDecimal.ZERO;
+            imputadoPorSolicitud.merge(d.getSolicitudPagoId(), aporte, java.math.BigDecimal::add);
+        }
+        List<com.franco.dev.service.financiero.dto.DetallePagoItemDto> out = new ArrayList<>();
+        for (java.util.Map.Entry<Long, java.math.BigDecimal> e : imputadoPorSolicitud.entrySet()) {
+            SolicitudPago sp = solicitudPagoService.findById(e.getKey()).orElse(null);
+            if (sp == null) continue;
+            com.franco.dev.service.financiero.dto.DetallePagoItemDto i =
+                    new com.franco.dev.service.financiero.dto.DetallePagoItemDto();
+            i.setSolicitudPagoId(sp.getId());
+            i.setTipo(sp.getTipo() != null ? sp.getTipo().name() : null);
+            i.setDescripcion(sp.getObservaciones());
+            i.setProveedorNombre(sp.getProveedor() != null && sp.getProveedor().getPersona() != null
+                    ? sp.getProveedor().getPersona().getNombre() : null);
+            if (sp.getMoneda() != null) {
+                i.setMonedaDenominacion(sp.getMoneda().getDenominacion());
+                i.setMonedaSimbolo(sp.getMoneda().getSimbolo());
+                i.setDecimales(sp.getMoneda().getDecimales());
+            }
+            i.setMontoImputado(e.getValue());
+            i.setMontoTotal(sp.getMontoTotal() != null ? java.math.BigDecimal.valueOf(sp.getMontoTotal()) : null);
+            i.setMontoPagado(sp.getMontoPagado());
+            i.setEstado(sp.getEstado() != null ? sp.getEstado().name() : null);
+            out.add(i);
+        }
+        return out;
+    }
+
+    // ─────────────── Concepto del evento de pago: etiqueta + origen del movimiento ───────────────
+
+    /**
+     * Que se esta pagando en este evento. El dialogo agrupa por modo, asi que en la practica un
+     * evento tiene un solo concepto; MIXTO existe por defensa (llamadas por API).
+     */
+    private enum ConceptoEvento { COMPRA, GASTO, VALE, LIQUIDACION, FINIQUITO, AGUINALDO, MIXTO }
+
+    /**
+     * Clasifica el evento por el tipo de sus solicitudes. Las de tipo RRHH se desambiguan
+     * preguntandole a cada modulo cual es dueno de la obligacion: el tipo RRHH es uno solo para
+     * vale, liquidacion, finiquito y aguinaldo.
+     */
+    private ConceptoEvento clasificar(List<SolicitudPago> sols) {
+        ConceptoEvento unico = null;
+        for (SolicitudPago sp : sols) {
+            ConceptoEvento c;
+            if (sp.getTipo() == com.franco.dev.domain.operaciones.enums.TipoSolicitudPago.GASTO) {
+                c = ConceptoEvento.GASTO;
+            } else if (sp.getTipo() == com.franco.dev.domain.operaciones.enums.TipoSolicitudPago.RRHH) {
+                c = conceptoRrhh(sp.getId());
+            } else {
+                c = ConceptoEvento.COMPRA;
+            }
+            if (unico == null) unico = c;
+            else if (unico != c) return ConceptoEvento.MIXTO;
+        }
+        return unico != null ? unico : ConceptoEvento.COMPRA;
+    }
+
+    /** Cual de los modulos de RRHH es dueno de la obligacion. Vale es el caso mas comun: se pregunta primero. */
+    private ConceptoEvento conceptoRrhh(Long solicitudPagoId) {
+        if (valeService.tieneSolicitud(solicitudPagoId)) return ConceptoEvento.VALE;
+        if (liquidacionSueldoService.tieneSolicitud(solicitudPagoId)) return ConceptoEvento.LIQUIDACION;
+        if (liquidacionFinalService.tieneSolicitud(solicitudPagoId)) return ConceptoEvento.FINIQUITO;
+        if (aguinaldoService.tieneSolicitud(solicitudPagoId)) return ConceptoEvento.AGUINALDO;
+        return ConceptoEvento.VALE;   // obligacion RRHH huerfana: se etiqueta como vale
+    }
+
+    /** Origen del movimiento, para que el historial de caja diga el concepto real y no "Compra". */
+    private OrigenMovimientoTipo origenDe(ConceptoEvento c) {
+        switch (c) {
+            case GASTO:       return OrigenMovimientoTipo.GASTO;
+            case VALE:        return OrigenMovimientoTipo.RRHH_VALE;
+            case LIQUIDACION: return OrigenMovimientoTipo.RRHH_LIQUIDACION_SUELDO;
+            case FINIQUITO:   return OrigenMovimientoTipo.RRHH_LIQUIDACION_FINAL;
+            case AGUINALDO:   return OrigenMovimientoTipo.RRHH_AGUINALDO;
+            default:          return OrigenMovimientoTipo.PAGO_CPP;
+        }
+    }
+
+    /**
+     * Descripcion del movimiento consolidado.
+     *
+     * <p>Con un solo documento se muestra su descripcion especifica. Con varios <b>no</b> se
+     * puede mostrar la de uno solo: seria informacion equivocada sobre un asiento que paga a
+     * todos. En ese caso se etiqueta el evento y el desglose se consulta con el detalle del
+     * pago (cada documento tiene su fila en {@code PagoSolicitudDetalle}).</p>
+     */
+    private String etiquetaDe(ConceptoEvento c, List<SolicitudPago> sols, boolean tieneProveedor, String provNombre) {
+        int n = sols.size();
+        if (n > 1) {
+            switch (c) {
+                case GASTO:       return "Pago consolidado de " + n + " gastos";
+                case VALE:        return "Pago consolidado de " + n + " vales";
+                case LIQUIDACION: return "Pago consolidado de " + n + " liquidaciones";
+                case FINIQUITO:   return "Pago consolidado de " + n + " finiquitos";
+                case AGUINALDO:   return "Pago consolidado de " + n + " aguinaldos";
+                case COMPRA:      return (tieneProveedor ? "Pago a " + provNombre : "Pago a proveedor")
+                                        + " (" + n + " notas)";
+                default:          return "Pago consolidado de " + n + " documentos";
+            }
+        }
+        SolicitudPago sp = sols.isEmpty() ? null : sols.get(0);
+        if (sp == null) return tieneProveedor ? ("Pago a " + provNombre) : "Pago";
+        if (c == ConceptoEvento.GASTO) {
+            // Gasto: descripcion rica → "#id - categoria - beneficiario - descripcion".
+            String cat = sp.getTipoGasto() != null ? sp.getTipoGasto().getDescripcion() : "Sin categoría";
+            String benef = tieneProveedor ? provNombre : "—";
+            String desc = sp.getObservaciones() != null ? sp.getObservaciones() : "";
+            return "#" + sp.getId() + " - " + cat + " - " + benef + " - " + desc;
+        }
+        if (c != ConceptoEvento.COMPRA) {
+            // RRHH: la observacion de la solicitud ya trae "VALE #id - FUNCIONARIO - MOTIVO",
+            // "LIQUIDACION 2026-07 #id - FUNCIONARIO", etc.
+            String desc = sp.getObservaciones();
+            if (desc != null && !desc.trim().isEmpty()) return desc;
+        }
+        return tieneProveedor ? ("Pago a " + provNombre) : "Pago de gasto";
+    }
+
     /** Aporte firmado a la deuda saldada: aumento resta, todo lo demás suma. */
     private static BigDecimal aporte(BigDecimal montoSolicitud, Boolean aumento) {
         return Boolean.TRUE.equals(aumento) ? montoSolicitud.negate() : montoSolicitud;
@@ -251,29 +385,10 @@ public class PagoProveedorService {
         // 3) Consolidar líneas físicas por (fuente, caja/cuenta, moneda) y postear un movimiento por grupo.
         boolean tieneProveedor = proveedor != null && proveedor.getPersona() != null && proveedor.getPersona().getNombre() != null;
         String provNombre = tieneProveedor ? proveedor.getPersona().getNombre() : "proveedor";
-        // Un gasto puede no tener beneficiario proveedor → etiqueta genérica en el movimiento/cheque.
-        String etiquetaPago = tieneProveedor ? ("Pago a " + provNombre) : "Pago de gasto";
-        // Gasto: descripción rica en el movimiento → "#id - categoría - proveedor - descripción".
-        SolicitudPago gastoSol = spById.values().stream()
-                .filter(s -> s.getTipo() == com.franco.dev.domain.operaciones.enums.TipoSolicitudPago.GASTO)
-                .findFirst().orElse(null);
-        if (gastoSol != null) {
-            String cat = gastoSol.getTipoGasto() != null ? gastoSol.getTipoGasto().getDescripcion() : "Sin categoría";
-            String benef = tieneProveedor ? provNombre : "—";
-            String desc = gastoSol.getObservaciones() != null ? gastoSol.getObservaciones() : "";
-            etiquetaPago = "#" + gastoSol.getId() + " - " + cat + " - " + benef + " - " + desc;
-        }
-        // Vales de RRHH: la descripción del vale ya trae "VALE #id - FUNCIONARIO - MOTIVO".
-        // Con varios vales en el mismo evento, una sola de esas etiquetas sería engañosa.
-        List<SolicitudPago> valeSols = spById.values().stream()
-                .filter(s -> s.getTipo() == com.franco.dev.domain.operaciones.enums.TipoSolicitudPago.RRHH)
-                .collect(Collectors.toList());
-        if (valeSols.size() == 1) {
-            String desc = valeSols.get(0).getObservaciones();
-            if (desc != null && !desc.trim().isEmpty()) etiquetaPago = desc;
-        } else if (valeSols.size() > 1) {
-            etiquetaPago = "Pago de vales (" + valeSols.size() + ")";
-        }
+        List<SolicitudPago> sols = new ArrayList<>(spById.values());
+        ConceptoEvento concepto = clasificar(sols);
+        String etiquetaPago = etiquetaDe(concepto, sols, tieneProveedor, provNombre);
+        OrigenMovimientoTipo origenPago = origenDe(concepto);
         LinkedHashMap<String, GrupoMov> grupos = new LinkedHashMap<>();
         for (SolicitudConLineas p : pagos) {
             for (LineaPago l : p.getLineas()) {
@@ -304,12 +419,12 @@ public class PagoProveedorService {
                 m.setUsuario(usuario);
                 m.setDescripcion(etiquetaPago);
                 m.setReferenciaId(pago.getId());
-                m.setOrigenTipo(OrigenMovimientoTipo.PAGO_CPP);
+                m.setOrigenTipo(origenPago);
                 m.setOrigenId(pago.getId());
                 g.movimientoId = tesoreriaService.registrar(m).getId();
             } else if (g.fuente == FuentePago.CUENTA_BANCARIA) {
                 MovimientoBancario mb = bancoLedgerService.registrar(g.cuentaBancariaId, MovimientoBancarioTipo.SALIDA_MANUAL,
-                        g.suma, etiquetaPago, OrigenMovimientoTipo.PAGO_CPP.name(), pago.getId(), usuario);
+                        g.suma, etiquetaPago, origenPago.name(), pago.getId(), usuario);
                 g.movimientoId = mb != null ? mb.getId() : null;
             } else {
                 throw new GraphQLException("Fuente de pago no soportada para movimiento consolidado");

--- a/src/main/java/com/franco/dev/service/financiero/PagoRrhhTesoreriaService.java
+++ b/src/main/java/com/franco/dev/service/financiero/PagoRrhhTesoreriaService.java
@@ -1,0 +1,372 @@
+package com.franco.dev.service.financiero;
+
+import com.franco.dev.domain.financiero.Moneda;
+import com.franco.dev.domain.operaciones.SolicitudPago;
+import com.franco.dev.domain.operaciones.enums.SolicitudPagoEstado;
+import com.franco.dev.domain.personas.Funcionario;
+import com.franco.dev.domain.personas.Usuario;
+import com.franco.dev.domain.rrhh.Aguinaldo;
+import com.franco.dev.domain.rrhh.LiquidacionFinal;
+import com.franco.dev.domain.rrhh.LiquidacionSueldo;
+import com.franco.dev.domain.rrhh.enums.AguinaldoEstado;
+import com.franco.dev.domain.rrhh.enums.LiquidacionFinalEstado;
+import com.franco.dev.domain.rrhh.enums.LiquidacionSueldoEstado;
+import com.franco.dev.repository.rrhh.AguinaldoRepository;
+import com.franco.dev.repository.rrhh.LiquidacionFinalRepository;
+import com.franco.dev.repository.rrhh.LiquidacionSueldoRepository;
+import com.franco.dev.service.operaciones.SolicitudPagoService;
+import com.franco.dev.service.rrhh.dto.PagoRrhhPendienteDto;
+import graphql.GraphQLException;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Pago de liquidacion mensual, finiquito y aguinaldo desde tesoreria, con el <b>mismo</b>
+ * motor de pago que CPP (caja mayor / cuenta bancaria / cheque, multi-moneda).
+ *
+ * <p>Extiende a esos tres conceptos el puente que {@link ValeTesoreriaService} abrio para el
+ * vale: la obligacion de pago se representa con una {@link SolicitudPago} de tipo
+ * {@code RRHH}, el documento de RRHH sigue siendo la verdad del modulo, y cuando la solicitud
+ * queda CONCLUIDA cada servicio de RRHH lo marca PAGADO desde su
+ * {@code sincronizarDesdeSolicitudPago}.</p>
+ *
+ * <p>Los documentos pagados por el atajo viejo ({@code pagar(id, cajaVirtualId)}, egreso
+ * directo EGRESO/RRHH_*) no tienen solicitud y no aparecen aca: ya estan pagados.</p>
+ *
+ * <p><b>Pago 1 por 1.</b> El motor acepta un lote porque asi paga CPP, pero en RRHH cada
+ * documento se paga por separado (nunca se paga la nomina entera en una operacion). El lote
+ * se usa igual para no duplicar el motor, y el pago parcial esta prohibido en los tres
+ * conceptos por el mismo motivo que en el vale: el documento no lleva saldo, lo que no se
+ * entrega no se recupera despues.</p>
+ */
+@Service
+@AllArgsConstructor
+public class PagoRrhhTesoreriaService {
+
+    /** Concepto de RRHH pagable. El desktop lo manda tal cual en el input. */
+    public enum ConceptoRrhh {
+        LIQUIDACION,
+        FINIQUITO,
+        AGUINALDO
+    }
+
+    /** Igual criterio que el motor de pago, para que "pago total" signifique lo mismo de los dos lados. */
+    private static final BigDecimal TOLERANCIA = new BigDecimal("0.005");
+
+    private final LiquidacionSueldoRepository liquidacionRepository;
+    private final LiquidacionFinalRepository finiquitoRepository;
+    private final AguinaldoRepository aguinaldoRepository;
+    private final SolicitudPagoService solicitudPagoService;
+    private final PagoProveedorService pagoProveedorService;
+    private final MonedaService monedaService;
+
+    /** Un documento de RRHH a pagar con su reparto de formas de pago. */
+    @lombok.Data
+    public static class PagoRrhhConLineas {
+        private ConceptoRrhh concepto;
+        private Long documentoId;
+        private List<PagoProveedorService.LineaPago> lineas;
+    }
+
+    // ─────────────────────────── listados de pendientes ───────────────────────────
+
+    /** Liquidaciones mensuales APROBADAS: calculadas y aprobadas, todavia sin pagar. */
+    @Transactional(readOnly = true)
+    public List<PagoRrhhPendienteDto> listarLiquidacionesPendientes() {
+        List<PagoRrhhPendienteDto> out = new ArrayList<>();
+        for (LiquidacionSueldo l : liquidacionRepository.findByEstadoOrderByPeriodoDesc(LiquidacionSueldoEstado.APROBADA)) {
+            out.add(toDto(l));
+        }
+        return out;
+    }
+
+    /** Liquidaciones finales (finiquitos) APROBADAS y todavia sin pagar. */
+    @Transactional(readOnly = true)
+    public List<PagoRrhhPendienteDto> listarFiniquitosPendientes() {
+        List<PagoRrhhPendienteDto> out = new ArrayList<>();
+        for (LiquidacionFinal f : finiquitoRepository.findByEstadoOrderByCreadoEnDesc(LiquidacionFinalEstado.APROBADA)) {
+            out.add(toDto(f));
+        }
+        return out;
+    }
+
+    /**
+     * Aguinaldos APROBADOS y todavia sin pagar.
+     *
+     * <p>Se listan solo los APROBADO y no los CALCULADO a proposito: aprobar es lo que congela
+     * el monto (ver {@code AguinaldoService.aprobar}, que ademas impide aprobar antes del mes
+     * de aguinaldo). Pagar un CALCULADO seria pagar un devengado parcial.</p>
+     */
+    @Transactional(readOnly = true)
+    public List<PagoRrhhPendienteDto> listarAguinaldosPendientes() {
+        List<PagoRrhhPendienteDto> out = new ArrayList<>();
+        for (Aguinaldo a : aguinaldoRepository.findByEstadoOrderByAnioDescIdDesc(AguinaldoEstado.APROBADO)) {
+            out.add(toDto(a));
+        }
+        return out;
+    }
+
+    // ─────────────────────────────────── pago ────────────────────────────────────
+
+    /**
+     * Paga documentos de RRHH con el motor de CPP.
+     *
+     * <p><b>El pago parcial esta prohibido</b>: ni la liquidacion ni el finiquito ni el
+     * aguinaldo llevan saldo pendiente, asi que entregar de menos dejaria una diferencia que
+     * nadie reclama despues. Se exige que lo aplicado cubra el saldo entero.</p>
+     */
+    @Transactional
+    public com.franco.dev.domain.operaciones.Pago pagarRrhhMixto(List<PagoRrhhConLineas> pagos, Usuario usuario) {
+        if (pagos == null || pagos.isEmpty()) throw new GraphQLException("Seleccione al menos un documento a pagar");
+
+        List<PagoProveedorService.SolicitudConLineas> lote = new ArrayList<>();
+        for (PagoRrhhConLineas p : pagos) {
+            if (p.getConcepto() == null) throw new GraphQLException("Falta el concepto del documento a pagar");
+            if (p.getLineas() == null || p.getLineas().isEmpty()) {
+                throw new GraphQLException("Indique al menos una forma de pago para el documento #" + p.getDocumentoId());
+            }
+            BigDecimal saldo = validarYSaldo(p.getConcepto(), p.getDocumentoId());
+            BigDecimal aplicado = BigDecimal.ZERO;
+            for (PagoProveedorService.LineaPago l : p.getLineas()) {
+                BigDecimal montoSol = l.getMontoSolicitud() != null ? l.getMontoSolicitud() : l.getMonto();
+                if (montoSol == null) continue;
+                aplicado = aplicado.add(Boolean.TRUE.equals(l.getAumento()) ? montoSol.negate() : montoSol);
+            }
+            if (saldo.subtract(aplicado).abs().compareTo(TOLERANCIA) > 0) {
+                throw new GraphQLException(etiqueta(p.getConcepto()) + " #" + p.getDocumentoId()
+                        + " se paga entero o no se paga: falta cubrir "
+                        + saldo.subtract(aplicado).toPlainString());
+            }
+
+            PagoProveedorService.SolicitudConLineas s = new PagoProveedorService.SolicitudConLineas();
+            s.setSolicitudId(asegurarSolicitud(p.getConcepto(), p.getDocumentoId(), usuario));
+            s.setLineas(p.getLineas());
+            lote.add(s);
+        }
+        return pagoProveedorService.pagarLoteMixto(lote, usuario);
+    }
+
+    // ───────────────────────────── proyecciones a DTO ─────────────────────────────
+
+    private PagoRrhhPendienteDto toDto(LiquidacionSueldo l) {
+        PagoRrhhPendienteDto d = base(ConceptoRrhh.LIQUIDACION, l.getId(), l.getFuncionario());
+        d.setFecha(l.getFechaFin());
+        d.setPeriodo(l.getPeriodo());
+        d.setMonto(l.getTotalNeto());
+        d.setSaldoPendiente(saldoPendiente(l.getTotalNeto(), l.getSolicitudPagoId()));
+        d.setDescripcion(descripcionLiquidacion(l));
+        d.setMoneda(l.getMoneda() != null ? l.getMoneda() : monedaPrincipal());
+        return d;
+    }
+
+    private PagoRrhhPendienteDto toDto(LiquidacionFinal f) {
+        PagoRrhhPendienteDto d = base(ConceptoRrhh.FINIQUITO, f.getId(), f.getFuncionario());
+        d.setFecha(f.getFechaEgreso());
+        d.setPeriodo(f.getFechaEgreso() != null ? f.getFechaEgreso().toString() : null);
+        d.setMonto(f.getTotalLiquidado());
+        d.setSaldoPendiente(saldoPendiente(f.getTotalLiquidado(), f.getSolicitudPagoId()));
+        d.setDescripcion(descripcionFiniquito(f));
+        d.setMoneda(f.getMoneda() != null ? f.getMoneda() : monedaPrincipal());
+        return d;
+    }
+
+    private PagoRrhhPendienteDto toDto(Aguinaldo a) {
+        PagoRrhhPendienteDto d = base(ConceptoRrhh.AGUINALDO, a.getId(), a.getFuncionario());
+        d.setPeriodo(a.getAnio() != null ? String.valueOf(a.getAnio()) : null);
+        d.setMonto(a.getMontoCalculado());
+        d.setSaldoPendiente(saldoPendiente(a.getMontoCalculado(), a.getSolicitudPagoId()));
+        d.setDescripcion(descripcionAguinaldo(a));
+        d.setMoneda(monedaAguinaldo(a));
+        return d;
+    }
+
+    private PagoRrhhPendienteDto base(ConceptoRrhh concepto, Long id, Funcionario f) {
+        PagoRrhhPendienteDto d = new PagoRrhhPendienteDto();
+        d.setConcepto(concepto.name());
+        d.setId(id);
+        d.setFuncionario(f);
+        d.setFuncionarioNombre(nombreFuncionario(f));
+        return d;
+    }
+
+    // ───────────────────────────── validacion y saldo ─────────────────────────────
+
+    /** Verifica que el documento exista y este pagable, y devuelve su saldo a entregar. */
+    private BigDecimal validarYSaldo(ConceptoRrhh concepto, Long id) {
+        switch (concepto) {
+            case LIQUIDACION: {
+                LiquidacionSueldo l = liquidacionRepository.findById(id)
+                        .orElseThrow(() -> new GraphQLException("Liquidacion no encontrada: " + id));
+                if (l.getEstado() != LiquidacionSueldoEstado.APROBADA) {
+                    throw new GraphQLException("La liquidacion #" + id + " no esta pendiente de pago (esta "
+                            + l.getEstado() + ")");
+                }
+                return saldoPendiente(l.getTotalNeto(), l.getSolicitudPagoId());
+            }
+            case FINIQUITO: {
+                LiquidacionFinal f = finiquitoRepository.findById(id)
+                        .orElseThrow(() -> new GraphQLException("Finiquito no encontrado: " + id));
+                if (f.getEstado() != LiquidacionFinalEstado.APROBADA) {
+                    throw new GraphQLException("El finiquito #" + id + " no esta pendiente de pago (esta "
+                            + f.getEstado() + ")");
+                }
+                return saldoPendiente(f.getTotalLiquidado(), f.getSolicitudPagoId());
+            }
+            case AGUINALDO: {
+                Aguinaldo a = aguinaldoRepository.findById(id)
+                        .orElseThrow(() -> new GraphQLException("Aguinaldo no encontrado: " + id));
+                if (a.getEstado() != AguinaldoEstado.APROBADO) {
+                    throw new GraphQLException("El aguinaldo #" + id + " no esta pendiente de pago (esta "
+                            + a.getEstado() + ")");
+                }
+                return saldoPendiente(a.getMontoCalculado(), a.getSolicitudPagoId());
+            }
+            default:
+                throw new GraphQLException("Concepto de RRHH no soportado: " + concepto);
+        }
+    }
+
+    /**
+     * Saldo a entregar. Si el documento ya tiene solicitud con pagos parciales previos se
+     * descuenta; en la practica el pago parcial esta prohibido, asi que esto es defensivo.
+     */
+    private BigDecimal saldoPendiente(BigDecimal total, Long solicitudPagoId) {
+        BigDecimal base = total != null ? total : BigDecimal.ZERO;
+        if (solicitudPagoId == null) return base;
+        SolicitudPago sp = solicitudPagoService.findById(solicitudPagoId).orElse(null);
+        if (sp == null || sp.getMontoPagado() == null) return base;
+        BigDecimal saldo = base.subtract(sp.getMontoPagado());
+        return saldo.signum() > 0 ? saldo : BigDecimal.ZERO;
+    }
+
+    // ──────────────────────────── obligacion de pago ─────────────────────────────
+
+    /**
+     * Devuelve el id de la obligacion de pago del documento, creandola la primera vez (o de
+     * nuevo si la anterior quedo cancelada por un intento fallido).
+     */
+    private Long asegurarSolicitud(ConceptoRrhh concepto, Long id, Usuario usuario) {
+        switch (concepto) {
+            case LIQUIDACION: {
+                LiquidacionSueldo l = liquidacionRepository.findById(id)
+                        .orElseThrow(() -> new GraphQLException("Liquidacion no encontrada: " + id));
+                Long vigente = solicitudVigente(l.getSolicitudPagoId());
+                if (vigente != null) return vigente;
+                Long nueva = crearSolicitud(l.getMoneda() != null ? l.getMoneda() : monedaPrincipal(),
+                        l.getTotalNeto(), descripcionLiquidacion(l), usuario);
+                l.setSolicitudPagoId(nueva);
+                liquidacionRepository.save(l);
+                return nueva;
+            }
+            case FINIQUITO: {
+                LiquidacionFinal f = finiquitoRepository.findById(id)
+                        .orElseThrow(() -> new GraphQLException("Finiquito no encontrado: " + id));
+                Long vigente = solicitudVigente(f.getSolicitudPagoId());
+                if (vigente != null) return vigente;
+                Long nueva = crearSolicitud(f.getMoneda() != null ? f.getMoneda() : monedaPrincipal(),
+                        f.getTotalLiquidado(), descripcionFiniquito(f), usuario);
+                f.setSolicitudPagoId(nueva);
+                finiquitoRepository.save(f);
+                return nueva;
+            }
+            case AGUINALDO: {
+                Aguinaldo a = aguinaldoRepository.findById(id)
+                        .orElseThrow(() -> new GraphQLException("Aguinaldo no encontrado: " + id));
+                Long vigente = solicitudVigente(a.getSolicitudPagoId());
+                if (vigente != null) return vigente;
+                Long nueva = crearSolicitud(monedaAguinaldo(a), a.getMontoCalculado(),
+                        descripcionAguinaldo(a), usuario);
+                a.setSolicitudPagoId(nueva);
+                aguinaldoRepository.save(a);
+                return nueva;
+            }
+            default:
+                throw new GraphQLException("Concepto de RRHH no soportado: " + concepto);
+        }
+    }
+
+    /** Id de la solicitud si sigue siendo usable; null si no existe o quedo cancelada. */
+    private Long solicitudVigente(Long solicitudPagoId) {
+        if (solicitudPagoId == null) return null;
+        SolicitudPago sp = solicitudPagoService.findById(solicitudPagoId).orElse(null);
+        if (sp == null || sp.getEstado() == SolicitudPagoEstado.CANCELADO) return null;
+        return sp.getId();
+    }
+
+    private Long crearSolicitud(Moneda moneda, BigDecimal monto, String descripcion, Usuario usuario) {
+        if (moneda == null) {
+            throw new GraphQLException("No hay moneda principal configurada: no se puede armar la obligacion de pago");
+        }
+        return solicitudPagoService.crearSolicitudVale(
+                moneda,
+                monto != null ? monto.doubleValue() : 0.0,
+                descripcion,
+                usuario).getId();
+    }
+
+    /**
+     * Moneda del aguinaldo. La entidad no la lleva: se replica el criterio de
+     * {@code AguinaldoService.pagar} (moneda del funcionario, si no la principal) para que el
+     * monto salga en la misma moneda por los dos caminos de pago.
+     */
+    private Moneda monedaAguinaldo(Aguinaldo a) {
+        if (a.getFuncionario() != null && a.getFuncionario().getMoneda() != null) {
+            return a.getFuncionario().getMoneda();
+        }
+        return monedaPrincipal();
+    }
+
+    private Moneda monedaPrincipal() {
+        for (Moneda m : monedaService.findAll2()) {
+            if (Boolean.TRUE.equals(m.getPrincipal())) return m;
+        }
+        return null;
+    }
+
+    // ──────────────────────────────── descripciones ───────────────────────────────
+
+    private String descripcionLiquidacion(LiquidacionSueldo l) {
+        StringBuilder sb = new StringBuilder("LIQUIDACION");
+        if (l.getPeriodo() != null) sb.append(" ").append(l.getPeriodo());
+        if (l.getId() != null) sb.append(" #").append(l.getId());
+        String nombre = nombreFuncionario(l.getFuncionario());
+        if (nombre != null) sb.append(" - ").append(nombre);
+        return sb.toString();
+    }
+
+    private String descripcionFiniquito(LiquidacionFinal f) {
+        StringBuilder sb = new StringBuilder("FINIQUITO");
+        if (f.getId() != null) sb.append(" #").append(f.getId());
+        String nombre = nombreFuncionario(f.getFuncionario());
+        if (nombre != null) sb.append(" - ").append(nombre);
+        if (f.getFechaEgreso() != null) sb.append(" - EGRESO ").append(f.getFechaEgreso());
+        return sb.toString();
+    }
+
+    private String descripcionAguinaldo(Aguinaldo a) {
+        StringBuilder sb = new StringBuilder("AGUINALDO");
+        if (a.getAnio() != null) sb.append(" ").append(a.getAnio());
+        if (a.getId() != null) sb.append(" #").append(a.getId());
+        String nombre = nombreFuncionario(a.getFuncionario());
+        if (nombre != null) sb.append(" - ").append(nombre);
+        return sb.toString();
+    }
+
+    private static String etiqueta(ConceptoRrhh c) {
+        switch (c) {
+            case LIQUIDACION: return "La liquidacion";
+            case FINIQUITO:   return "El finiquito";
+            case AGUINALDO:   return "El aguinaldo";
+            default:          return "El documento";
+        }
+    }
+
+    private static String nombreFuncionario(Funcionario f) {
+        return (f != null && f.getPersona() != null) ? f.getPersona().getNombre() : null;
+    }
+}

--- a/src/main/java/com/franco/dev/service/financiero/PagoRrhhTesoreriaService.java
+++ b/src/main/java/com/franco/dev/service/financiero/PagoRrhhTesoreriaService.java
@@ -253,7 +253,9 @@ public class PagoRrhhTesoreriaService {
     private Long asegurarSolicitud(ConceptoRrhh concepto, Long id, Usuario usuario) {
         switch (concepto) {
             case LIQUIDACION: {
-                LiquidacionSueldo l = liquidacionRepository.findById(id)
+                // Lock pesimista: sin el, dos pedidos concurrentes leen los dos que no hay
+                // solicitud, crean una cada uno y el sueldo se paga dos veces.
+                LiquidacionSueldo l = liquidacionRepository.lockById(id)
                         .orElseThrow(() -> new GraphQLException("Liquidacion no encontrada: " + id));
                 Long vigente = solicitudVigente(l.getSolicitudPagoId());
                 if (vigente != null) return vigente;
@@ -264,7 +266,7 @@ public class PagoRrhhTesoreriaService {
                 return nueva;
             }
             case FINIQUITO: {
-                LiquidacionFinal f = finiquitoRepository.findById(id)
+                LiquidacionFinal f = finiquitoRepository.lockById(id)
                         .orElseThrow(() -> new GraphQLException("Finiquito no encontrado: " + id));
                 Long vigente = solicitudVigente(f.getSolicitudPagoId());
                 if (vigente != null) return vigente;
@@ -275,7 +277,7 @@ public class PagoRrhhTesoreriaService {
                 return nueva;
             }
             case AGUINALDO: {
-                Aguinaldo a = aguinaldoRepository.findById(id)
+                Aguinaldo a = aguinaldoRepository.lockById(id)
                         .orElseThrow(() -> new GraphQLException("Aguinaldo no encontrado: " + id));
                 Long vigente = solicitudVigente(a.getSolicitudPagoId());
                 if (vigente != null) return vigente;

--- a/src/main/java/com/franco/dev/service/financiero/TesoreriaSecurityService.java
+++ b/src/main/java/com/franco/dev/service/financiero/TesoreriaSecurityService.java
@@ -31,6 +31,8 @@ public class TesoreriaSecurityService {
 
     @Autowired private UsuarioService usuarioService;
     @Autowired private RoleService roleService;
+    @Autowired private com.franco.dev.repository.financiero.CajaVirtualAccesoRepository accesoRepository;
+    @Autowired private com.franco.dev.repository.financiero.CajaVirtualRepository cajaVirtualRepository;
 
     public static final String ADMIN = "ADMIN";
     public static final String VER = "TESORERIA VER";
@@ -105,4 +107,92 @@ public class TesoreriaSecurityService {
             throw new GraphQLException("No autorizado: se requiere un rol de Tesorería para ver estos datos.");
         }
     }
+
+    // ─────────────────────── Acceso por caja (ACL) ───────────────────────
+    //
+    // El rol habilita la capacidad; el ACL delimita sobre que cajas (modelo AND). El
+    // propietario de la caja tiene lectura y escritura implicitas y no lleva fila en la tabla;
+    // un superusuario pasa por encima de todo.
+
+    /** true si es superusuario: rol ADMIN o nickname ADMIN (cuenta pelada, sin usuario_role). */
+    public boolean esSuperusuario() {
+        String nick = currentNickname();
+        if (nick != null && ADMIN.equalsIgnoreCase(nick)) return true;
+        return currentRoles().contains(ADMIN);
+    }
+
+    /** true si el usuario autenticado creo la caja (y por lo tanto administra su lista). */
+    public boolean esPropietario(Long cajaId) {
+        if (cajaId == null) return false;
+        Usuario u = currentUsuario();
+        if (u == null) return false;
+        com.franco.dev.domain.financiero.CajaVirtual caja = cajaVirtualRepository.findById(cajaId).orElse(null);
+        return caja != null && caja.getUsuario() != null && u.getId().equals(caja.getUsuario().getId());
+    }
+
+    public boolean puedeLeerCaja(Long cajaId) {
+        if (esSuperusuario()) return true;
+        if (esPropietario(cajaId)) return true;
+        return accesoRepository.findByCajaVirtualIdAndUsuarioId(cajaId, idUsuarioActual())
+                .map(a -> Boolean.TRUE.equals(a.getPuedeLeer()) || Boolean.TRUE.equals(a.getPuedeEscribir()))
+                .orElse(false);
+    }
+
+    public boolean puedeEscribirCaja(Long cajaId) {
+        if (esSuperusuario()) return true;
+        if (esPropietario(cajaId)) return true;
+        return accesoRepository.findByCajaVirtualIdAndUsuarioId(cajaId, idUsuarioActual())
+                .map(a -> Boolean.TRUE.equals(a.getPuedeEscribir()))
+                .orElse(false);
+    }
+
+    /**
+     * Proceso de sistema: no hay usuario autenticado en el contexto.
+     *
+     * <p>Los schedulers y la replicacion de retiros postean en caja sin sesion. Si el ACL los
+     * rechazara se cortaria la replicacion, asi que se los deja pasar. Es deliberado y acotado:
+     * solo aplica cuando <b>no hay principal</b>, no cuando hay uno sin permisos.</p>
+     */
+    public boolean esProcesoDeSistema() {
+        return currentNickname() == null;
+    }
+
+    public void requireLecturaCaja(Long cajaId) {
+        if (esProcesoDeSistema()) return;
+        if (!puedeLeerCaja(cajaId)) {
+            throw new GraphQLException("No tenes acceso a esta caja. Pediselo a su responsable.");
+        }
+    }
+
+    public void requireEscrituraCaja(Long cajaId) {
+        if (esProcesoDeSistema()) return;
+        if (!puedeEscribirCaja(cajaId)) {
+            throw new GraphQLException("No tenes permiso para mover plata en esta caja. "
+                    + "Pediselo a su responsable.");
+        }
+    }
+
+    /** Administrar la lista de accesos: solo el propietario de la caja, o un superusuario. */
+    public void requirePropietarioCaja(Long cajaId) {
+        if (esSuperusuario() || esPropietario(cajaId)) return;
+        throw new GraphQLException("Solo el responsable de la caja puede administrar sus accesos.");
+    }
+
+    /**
+     * Ids de las cajas visibles para el usuario autenticado, o {@code null} si ve todas
+     * (superusuario). El null es la senal de "no filtres": es distinto de la lista vacia,
+     * que significa "no ve ninguna".
+     */
+    public java.util.List<Long> cajasVisiblesIds() {
+        if (esProcesoDeSistema() || esSuperusuario()) return null;
+        Long id = idUsuarioActual();
+        if (id == null) return java.util.Collections.emptyList();
+        return accesoRepository.cajasVisiblesIds(id);
+    }
+
+    private Long idUsuarioActual() {
+        Usuario u = currentUsuario();
+        return u != null ? u.getId() : null;
+    }
+
 }

--- a/src/main/java/com/franco/dev/service/financiero/TesoreriaService.java
+++ b/src/main/java/com/franco/dev/service/financiero/TesoreriaService.java
@@ -37,6 +37,8 @@ import java.util.Map;
 public class TesoreriaService {
 
     private final CajaVirtualSaldoRepository saldoRepository;
+
+    private final TesoreriaSecurityService seguridad;
     private final CajaVirtualRepository cajaVirtualRepository;
     private final MonedaRepository monedaRepository;
     private final MovimientoCajaVirtualRepository movimientoRepository;
@@ -68,6 +70,10 @@ public class TesoreriaService {
      */
     @Transactional
     public MovimientoCajaVirtual registrar(MovimientoCajaVirtual mov) {
+        // Choke point del ACL de escritura: TODA la plata que entra o sale de una caja pasa
+        // por aca (RRHH, CPP, gastos, maletin, retiros, entradas varias, devoluciones).
+        // Los procesos de sistema (schedulers, replicacion) no tienen sesion y pasan.
+        seguridad.requireEscrituraCaja(mov.getCajaVirtual() != null ? mov.getCajaVirtual().getId() : null);
         if (mov.getActivo() == null) mov.setActivo(true);
         Moneda moneda = resolverMoneda(mov.getMoneda());
         mov.setMoneda(moneda);
@@ -126,6 +132,9 @@ public class TesoreriaService {
     public Boolean transferir(Long origenId, Long destinoId, Double cantidad,
                               Moneda moneda, String descripcion, Usuario usuario) {
         if (origenId.equals(destinoId)) throw new GraphQLException("La caja origen y destino no pueden ser la misma");
+        // Mover plata entre cajas exige permiso en las dos: es un egreso y un ingreso.
+        seguridad.requireEscrituraCaja(origenId);
+        seguridad.requireEscrituraCaja(destinoId);
         CajaVirtual origen = cajaVirtualRepository.findById(origenId)
                 .orElseThrow(() -> new GraphQLException("Caja origen no encontrada"));
         CajaVirtual destino = cajaVirtualRepository.findById(destinoId)
@@ -173,6 +182,8 @@ public class TesoreriaService {
     public MovimientoCajaVirtual anular(Long movimientoId, String motivo, Usuario usuario) {
         MovimientoCajaVirtual orig = movimientoRepository.findById(movimientoId)
                 .orElseThrow(() -> new GraphQLException("Movimiento no encontrado: " + movimientoId));
+        // Anular mueve plata (contra-movimiento): mismo permiso que registrarla.
+        seguridad.requireEscrituraCaja(orig.getCajaVirtual() != null ? orig.getCajaVirtual().getId() : null);
 
         OrigenMovimientoTipo origen = orig.getOrigenTipo();
         if (origen == OrigenMovimientoTipo.ANULACION) {

--- a/src/main/java/com/franco/dev/service/financiero/dto/DetallePagoItemDto.java
+++ b/src/main/java/com/franco/dev/service/financiero/dto/DetallePagoItemDto.java
@@ -1,0 +1,32 @@
+package com.franco.dev.service.financiero.dto;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+/**
+ * Una linea del detalle de un evento de pago: que documento se pago y cuanto se le imputo.
+ *
+ * <p>Existe porque el evento postea <b>un</b> movimiento consolidado en la caja: la descripcion
+ * de ese movimiento no puede nombrar a los N documentos, asi que el desglose se consulta aparte
+ * (ver {@code PagoProveedorService.etiquetaDe}).</p>
+ */
+@Data
+public class DetallePagoItemDto {
+    /** Id de la obligacion de pago (SolicitudPago). */
+    private Long solicitudPagoId;
+    /** COMPRA | GASTO | RRHH. */
+    private String tipo;
+    /** Descripcion del documento: la observacion de la solicitud. */
+    private String descripcion;
+    private String proveedorNombre;
+    private String monedaDenominacion;
+    private String monedaSimbolo;
+    private Integer decimales;
+    /** Monto imputado a este documento en este evento (suma de sus lineas). */
+    private BigDecimal montoImputado;
+    /** Total del documento, para ver si quedo saldado. */
+    private BigDecimal montoTotal;
+    private BigDecimal montoPagado;
+    private String estado;
+}

--- a/src/main/java/com/franco/dev/service/rrhh/AguinaldoService.java
+++ b/src/main/java/com/franco/dev/service/rrhh/AguinaldoService.java
@@ -166,6 +166,15 @@ public class AguinaldoService extends CrudService<Aguinaldo, AguinaldoRepository
 
 
     /**
+     * true si esta obligacion de pago pertenece a un aguinaldo. Lo usa el motor de pago para
+     * saber que concepto esta pagando y etiquetar el movimiento de caja con su origen real.
+     */
+    @Transactional(readOnly = true)
+    public boolean tieneSolicitud(Long solicitudPagoId) {
+        return solicitudPagoId != null && repository.findBySolicitudPagoId(solicitudPagoId) != null;
+    }
+
+    /**
      * Espejo de {@code ValeService.sincronizarDesdeSolicitudPago}: lo llama el motor de pago
      * cuando el aguinaldo se paga desde el hub de la caja en vez de con {@link #pagar}.
      *

--- a/src/main/java/com/franco/dev/service/rrhh/AguinaldoService.java
+++ b/src/main/java/com/franco/dev/service/rrhh/AguinaldoService.java
@@ -204,7 +204,10 @@ public class AguinaldoService extends CrudService<Aguinaldo, AguinaldoRepository
                 }
             }
             a.setFechaPago(LocalDate.now());
-        } else {
+        } else if (sp.getMontoPagado() == null || sp.getMontoPagado().signum() <= 0) {
+            // Solo se sueltan los links cuando NO queda plata aplicada. Si la obligacion quedo
+            // PARCIAL (se pago en dos eventos y se anulo uno solo), parte del dinero sigue
+            // fuera de la caja: borrar la referencia al movimiento perderia su rastro.
             a.setMovimientoCajaVirtualId(null);
             a.setCajaVirtualId(null);
             a.setFechaPago(null);

--- a/src/main/java/com/franco/dev/service/rrhh/AguinaldoService.java
+++ b/src/main/java/com/franco/dev/service/rrhh/AguinaldoService.java
@@ -35,6 +35,7 @@ import java.util.Optional;
 public class AguinaldoService extends CrudService<Aguinaldo, AguinaldoRepository, Long> {
 
     private final AguinaldoRepository repository;
+    private final com.franco.dev.repository.financiero.PagoSolicitudDetalleRepository pagoSolicitudDetalleRepository;
     private final ConfiguracionRrhhService configuracionRrhhService;
     private final FuncionarioService funcionarioService;
     private final CajaVirtualService cajaVirtualService;
@@ -161,6 +162,46 @@ public class AguinaldoService extends CrudService<Aguinaldo, AguinaldoRepository
         a.setEstado(AguinaldoEstado.PAGADO);
         a.setFechaPago(LocalDate.now());
         return repository.save(a);
+    }
+
+
+    /**
+     * Espejo de {@code ValeService.sincronizarDesdeSolicitudPago}: lo llama el motor de pago
+     * cuando el aguinaldo se paga desde el hub de la caja en vez de con {@link #pagar}.
+     *
+     * <p>Solicitud CONCLUIDA ⇒ aguinaldo PAGADO (y por lo tanto deja de sumarse en la
+     * liquidacion de diciembre, que solo incluye los APROBADO) + link de caja y movimiento.
+     * <b>No postea nada en caja</b>: el movimiento ya lo genero el motor de pago. Si el pago
+     * se anula, vuelve a APROBADO y por ende vuelve a entrar en la liquidacion.</p>
+     */
+    @Transactional
+    public void sincronizarDesdeSolicitudPago(com.franco.dev.domain.operaciones.SolicitudPago sp) {
+        if (sp == null || sp.getTipo() != com.franco.dev.domain.operaciones.enums.TipoSolicitudPago.RRHH) return;
+        Aguinaldo a = repository.findBySolicitudPagoId(sp.getId());
+        if (a == null) return;
+
+        boolean pagado = sp.getEstado() == com.franco.dev.domain.operaciones.enums.SolicitudPagoEstado.CONCLUIDO;
+        AguinaldoEstado destino = pagado ? AguinaldoEstado.PAGADO : AguinaldoEstado.APROBADO;
+        if (a.getEstado() == destino) return;   // idempotente: el motor puede reentrar
+
+        if (pagado) {
+            for (com.franco.dev.domain.financiero.PagoSolicitudDetalle d
+                    : pagoSolicitudDetalleRepository.findBySolicitudPagoIdOrderByCreadoEnAsc(sp.getId())) {
+                if (Boolean.TRUE.equals(d.getAnulado())) continue;
+                if (d.getMovimientoCajaVirtualId() != null) {
+                    a.setMovimientoCajaVirtualId(d.getMovimientoCajaVirtualId());
+                    a.setCajaVirtualId(d.getCajaVirtualId());
+                    break;
+                }
+            }
+            a.setFechaPago(LocalDate.now());
+        } else {
+            a.setMovimientoCajaVirtualId(null);
+            a.setCajaVirtualId(null);
+            a.setFechaPago(null);
+        }
+        a.setEstado(destino);
+        repository.save(a);
     }
 
     @Override

--- a/src/main/java/com/franco/dev/service/rrhh/LiquidacionFinalService.java
+++ b/src/main/java/com/franco/dev/service/rrhh/LiquidacionFinalService.java
@@ -62,6 +62,7 @@ import static com.franco.dev.utilitarios.DateUtils.stringToDate;
 public class LiquidacionFinalService extends CrudService<LiquidacionFinal, LiquidacionFinalRepository, Long> {
 
     private final LiquidacionFinalRepository repository;
+    private final com.franco.dev.repository.financiero.PagoSolicitudDetalleRepository pagoSolicitudDetalleRepository;
     private final LiquidacionFinalItemRepository itemRepository;
     private final FuncionarioService funcionarioService;
     private final LiquidacionSueldoRepository liquidacionSueldoRepository;
@@ -639,6 +640,57 @@ public class LiquidacionFinalService extends CrudService<LiquidacionFinal, Liqui
                     break;
             }
         }
+    }
+
+
+    /**
+     * Espejo de {@code ValeService.sincronizarDesdeSolicitudPago}: lo llama el motor de pago
+     * cuando el finiquito se paga desde el hub de la caja en vez de con {@link #pagar}.
+     *
+     * <p>Solicitud CONCLUIDA ⇒ finiquito PAGADA, se linkean caja + movimiento, el funcionario
+     * queda dado de baja y se saldan vales/cuotas. <b>No postea nada en caja</b>: el movimiento
+     * ya lo genero el motor de pago.</p>
+     *
+     * <p>Al revertirse el pago se deshacen los efectos cruzados pero <b>el funcionario NO se
+     * reactiva</b>, igual que en {@link #anular}: el egreso es un hecho del legajo, no del pago.
+     * Si hubo que reincorporarlo, se hace desde RRHH.</p>
+     */
+    @Transactional
+    public void sincronizarDesdeSolicitudPago(com.franco.dev.domain.operaciones.SolicitudPago sp) {
+        if (sp == null || sp.getTipo() != com.franco.dev.domain.operaciones.enums.TipoSolicitudPago.RRHH) return;
+        LiquidacionFinal lf = repository.findBySolicitudPagoId(sp.getId());
+        if (lf == null || lf.getEstado() == LiquidacionFinalEstado.ANULADA) return;
+
+        boolean pagado = sp.getEstado() == com.franco.dev.domain.operaciones.enums.SolicitudPagoEstado.CONCLUIDO;
+        LiquidacionFinalEstado destino = pagado ? LiquidacionFinalEstado.PAGADA : LiquidacionFinalEstado.APROBADA;
+        if (lf.getEstado() == destino) return;   // idempotente: el motor puede reentrar
+
+        if (pagado) {
+            for (com.franco.dev.domain.financiero.PagoSolicitudDetalle d
+                    : pagoSolicitudDetalleRepository.findBySolicitudPagoIdOrderByCreadoEnAsc(sp.getId())) {
+                if (Boolean.TRUE.equals(d.getAnulado())) continue;
+                if (d.getMovimientoCajaVirtualId() != null) {
+                    lf.setMovimientoCajaVirtualId(d.getMovimientoCajaVirtualId());
+                    lf.setCajaVirtualId(d.getCajaVirtualId());
+                    break;
+                }
+            }
+            lf.setFechaPago(LocalDateTime.now());
+            Funcionario f = lf.getFuncionario();
+            if (f != null) {
+                f.setActivo(false);
+                if (f.getFechaEgreso() == null && lf.getFechaEgreso() != null)
+                    f.setFechaEgreso(lf.getFechaEgreso().atStartOfDay());
+                funcionarioService.save(f);
+            }
+        } else {
+            lf.setMovimientoCajaVirtualId(null);
+            lf.setCajaVirtualId(null);
+            lf.setFechaPago(null);
+        }
+        aplicarEfectosCruzados(lf, pagado);
+        lf.setEstado(destino);
+        repository.save(lf);
     }
 
     /** Anula un finiquito PAGADO: contra-asiento AJUSTE en la caja. */

--- a/src/main/java/com/franco/dev/service/rrhh/LiquidacionFinalService.java
+++ b/src/main/java/com/franco/dev/service/rrhh/LiquidacionFinalService.java
@@ -692,7 +692,10 @@ public class LiquidacionFinalService extends CrudService<LiquidacionFinal, Liqui
                     f.setFechaEgreso(lf.getFechaEgreso().atStartOfDay());
                 funcionarioService.save(f);
             }
-        } else {
+        } else if (sp.getMontoPagado() == null || sp.getMontoPagado().signum() <= 0) {
+            // Solo se sueltan los links cuando NO queda plata aplicada. Si la obligacion quedo
+            // PARCIAL (se pago en dos eventos y se anulo uno solo), parte del dinero sigue
+            // fuera de la caja: borrar la referencia al movimiento perderia su rastro.
             lf.setMovimientoCajaVirtualId(null);
             lf.setCajaVirtualId(null);
             lf.setFechaPago(null);

--- a/src/main/java/com/franco/dev/service/rrhh/LiquidacionFinalService.java
+++ b/src/main/java/com/franco/dev/service/rrhh/LiquidacionFinalService.java
@@ -644,6 +644,15 @@ public class LiquidacionFinalService extends CrudService<LiquidacionFinal, Liqui
 
 
     /**
+     * true si esta obligacion de pago pertenece a un liquidacionfinal. Lo usa el motor de pago para
+     * saber que concepto esta pagando y etiquetar el movimiento de caja con su origen real.
+     */
+    @Transactional(readOnly = true)
+    public boolean tieneSolicitud(Long solicitudPagoId) {
+        return solicitudPagoId != null && repository.findBySolicitudPagoId(solicitudPagoId) != null;
+    }
+
+    /**
      * Espejo de {@code ValeService.sincronizarDesdeSolicitudPago}: lo llama el motor de pago
      * cuando el finiquito se paga desde el hub de la caja en vez de con {@link #pagar}.
      *

--- a/src/main/java/com/franco/dev/service/rrhh/LiquidacionSueldoService.java
+++ b/src/main/java/com/franco/dev/service/rrhh/LiquidacionSueldoService.java
@@ -515,6 +515,15 @@ public class LiquidacionSueldoService extends CrudService<LiquidacionSueldo, Liq
 
 
     /**
+     * true si esta obligacion de pago pertenece a un liquidacionsueldo. Lo usa el motor de pago para
+     * saber que concepto esta pagando y etiquetar el movimiento de caja con su origen real.
+     */
+    @Transactional(readOnly = true)
+    public boolean tieneSolicitud(Long solicitudPagoId) {
+        return solicitudPagoId != null && repository.findBySolicitudPagoId(solicitudPagoId) != null;
+    }
+
+    /**
      * Espejo de {@code ValeService.sincronizarDesdeSolicitudPago}: lo llama el motor de pago
      * tanto al pagar como al anular un evento, cuando la liquidacion se paga desde el hub de
      * la caja en vez de con {@link #pagar}.

--- a/src/main/java/com/franco/dev/service/rrhh/LiquidacionSueldoService.java
+++ b/src/main/java/com/franco/dev/service/rrhh/LiquidacionSueldoService.java
@@ -71,6 +71,7 @@ public class LiquidacionSueldoService extends CrudService<LiquidacionSueldo, Liq
     private final CajaVirtualService cajaVirtualService;
     private final MovimientoCajaVirtualService movimientoCajaVirtualService;
     private final UsuarioService usuarioService;
+    private final com.franco.dev.repository.financiero.PagoSolicitudDetalleRepository pagoSolicitudDetalleRepository;
     private final com.franco.dev.service.administrativo.JornadaService jornadaService;
     private final CreditoConvenioService creditoConvenioService;
 
@@ -510,6 +511,50 @@ public class LiquidacionSueldoService extends CrudService<LiquidacionSueldo, Liq
         }
         liq.setEstado(LiquidacionSueldoEstado.ANULADA);
         return repository.save(liq);
+    }
+
+
+    /**
+     * Espejo de {@code ValeService.sincronizarDesdeSolicitudPago}: lo llama el motor de pago
+     * tanto al pagar como al anular un evento, cuando la liquidacion se paga desde el hub de
+     * la caja en vez de con {@link #pagar}.
+     *
+     * <p>Solicitud CONCLUIDA ⇒ la liquidacion queda PAGADA, se linkean caja + movimiento y se
+     * aplican los efectos cruzados de los items (vale DESCONTADO, cuota PAGADA, aguinaldo
+     * PAGADO...). <b>No postea nada en caja</b>: el movimiento ya lo genero el motor de pago.
+     * Cualquier otro estado (se anulo el pago) ⇒ vuelve a APROBADA y los efectos se revierten.</p>
+     */
+    @Transactional
+    public void sincronizarDesdeSolicitudPago(com.franco.dev.domain.operaciones.SolicitudPago sp) {
+        if (sp == null || sp.getTipo() != com.franco.dev.domain.operaciones.enums.TipoSolicitudPago.RRHH) return;
+        LiquidacionSueldo liq = repository.findBySolicitudPagoId(sp.getId());
+        if (liq == null || liq.getEstado() == LiquidacionSueldoEstado.ANULADA) return;
+
+        boolean pagado = sp.getEstado() == com.franco.dev.domain.operaciones.enums.SolicitudPagoEstado.CONCLUIDO;
+        LiquidacionSueldoEstado destino = pagado ? LiquidacionSueldoEstado.PAGADA : LiquidacionSueldoEstado.APROBADA;
+        if (liq.getEstado() == destino) return;   // idempotente: el motor puede reentrar
+
+        if (pagado) {
+            // Linkear el movimiento de caja del pago (un pago 100% bancario o con cheque no
+            // genera fila de caja: en ese caso los ids quedan nulos, que es correcto).
+            for (com.franco.dev.domain.financiero.PagoSolicitudDetalle d
+                    : pagoSolicitudDetalleRepository.findBySolicitudPagoIdOrderByCreadoEnAsc(sp.getId())) {
+                if (Boolean.TRUE.equals(d.getAnulado())) continue;
+                if (d.getMovimientoCajaVirtualId() != null) {
+                    liq.setMovimientoCajaVirtualId(d.getMovimientoCajaVirtualId());
+                    liq.setCajaVirtualId(d.getCajaVirtualId());
+                    break;
+                }
+            }
+            liq.setFechaPago(LocalDateTime.now());
+        } else {
+            liq.setMovimientoCajaVirtualId(null);
+            liq.setCajaVirtualId(null);
+            liq.setFechaPago(null);
+        }
+        aplicarEfectosCruzados(liq, pagado);
+        liq.setEstado(destino);
+        repository.save(liq);
     }
 
     /** Aplica (pagar=true) o revierte (pagar=false) los efectos cruzados de los items. */

--- a/src/main/java/com/franco/dev/service/rrhh/LiquidacionSueldoService.java
+++ b/src/main/java/com/franco/dev/service/rrhh/LiquidacionSueldoService.java
@@ -556,7 +556,10 @@ public class LiquidacionSueldoService extends CrudService<LiquidacionSueldo, Liq
                 }
             }
             liq.setFechaPago(LocalDateTime.now());
-        } else {
+        } else if (sp.getMontoPagado() == null || sp.getMontoPagado().signum() <= 0) {
+            // Solo se sueltan los links cuando NO queda plata aplicada. Si la obligacion quedo
+            // PARCIAL (se pago en dos eventos y se anulo uno solo), parte del dinero sigue
+            // fuera de la caja: borrar la referencia al movimiento perderia su rastro.
             liq.setMovimientoCajaVirtualId(null);
             liq.setCajaVirtualId(null);
             liq.setFechaPago(null);

--- a/src/main/java/com/franco/dev/service/rrhh/ValeService.java
+++ b/src/main/java/com/franco/dev/service/rrhh/ValeService.java
@@ -142,6 +142,15 @@ public class ValeService extends CrudService<Vale, ValeRepository, Long> {
     }
 
     /**
+     * true si esta obligacion de pago pertenece a un vale. Lo usa el motor de pago para
+     * saber que concepto esta pagando y etiquetar el movimiento de caja con su origen real.
+     */
+    @Transactional(readOnly = true)
+    public boolean tieneSolicitud(Long solicitudPagoId) {
+        return solicitudPagoId != null && repository.findBySolicitudPagoId(solicitudPagoId) != null;
+    }
+
+    /**
      * Sincroniza el vale con el estado de su obligacion de pago (SolicitudPago tipo RRHH).
      * Espejo de {@code PreGastoService.sincronizarDesdeSolicitudPago}: lo llama el motor de
      * pago tanto al pagar como al anular un evento.

--- a/src/main/java/com/franco/dev/service/rrhh/dto/PagoRrhhPendienteDto.java
+++ b/src/main/java/com/franco/dev/service/rrhh/dto/PagoRrhhPendienteDto.java
@@ -1,0 +1,33 @@
+package com.franco.dev.service.rrhh.dto;
+
+import com.franco.dev.domain.financiero.Moneda;
+import com.franco.dev.domain.personas.Funcionario;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+/**
+ * Fila de los dialogos "Pagar Liquidacion" / "Pagar Finiquito" / "Pagar Aguinaldo": un
+ * documento de RRHH aprobado y todavia sin pagar, con su saldo.
+ *
+ * <p>Proyeccion y no la entidad, por el mismo motivo que {@link ValePendienteDto}: el saldo
+ * no vive en el documento sino en su obligacion de pago ({@code SolicitudPago} tipo RRHH),
+ * que puede no existir todavia. Los tres conceptos comparten forma (funcionario + periodo +
+ * monto), asi que comparten DTO y se distinguen por {@code concepto}.</p>
+ */
+@Data
+public class PagoRrhhPendienteDto {
+    /** LIQUIDACION | FINIQUITO | AGUINALDO. Define contra que entidad resuelve el id. */
+    private String concepto;
+    private Long id;
+    private LocalDate fecha;
+    /** Texto corto que ubica el documento: "2026-07" en liquidacion, "2026" en aguinaldo. */
+    private String periodo;
+    private BigDecimal monto;
+    private BigDecimal saldoPendiente;
+    private String descripcion;
+    private Moneda moneda;
+    private Funcionario funcionario;
+    private String funcionarioNombre;
+}

--- a/src/main/resources/db/migration/V199.5__rrhh_solicitud_pago_liquidaciones.sql
+++ b/src/main/resources/db/migration/V199.5__rrhh_solicitud_pago_liquidaciones.sql
@@ -1,0 +1,30 @@
+-- Puente Liquidacion / Finiquito / Aguinaldo -> SolicitudPago(tipo=RRHH).
+--
+-- Extiende a los otros conceptos de RRHH el puente que V198.5 abrio para el vale: pagarlos
+-- con el motor de pago de CPP (caja mayor / cuenta bancaria / cheque, multi-moneda) desde
+-- el hub de egresos de la caja, en vez de con un egreso directo desde las pantallas de RRHH.
+--
+-- Aditiva: columnas nullable. Las filas existentes quedan con NULL, que significa "pagada
+-- por el atajo viejo" (pagar(id, cajaVirtualId), egreso directo EGRESO/RRHH_*).
+
+ALTER TABLE rrhh.liquidacion_sueldo
+    ADD COLUMN IF NOT EXISTS solicitud_pago_id BIGINT;
+
+ALTER TABLE rrhh.liquidacion_final
+    ADD COLUMN IF NOT EXISTS solicitud_pago_id BIGINT;
+
+ALTER TABLE rrhh.aguinaldo
+    ADD COLUMN IF NOT EXISTS solicitud_pago_id BIGINT;
+
+-- Cada obligacion pertenece a lo sumo a un documento de RRHH (mismo criterio que el vale).
+CREATE UNIQUE INDEX IF NOT EXISTS ux_liquidacion_sueldo_solicitud_pago_id
+    ON rrhh.liquidacion_sueldo (solicitud_pago_id)
+    WHERE solicitud_pago_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_liquidacion_final_solicitud_pago_id
+    ON rrhh.liquidacion_final (solicitud_pago_id)
+    WHERE solicitud_pago_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_aguinaldo_solicitud_pago_id
+    ON rrhh.aguinaldo (solicitud_pago_id)
+    WHERE solicitud_pago_id IS NOT NULL;

--- a/src/main/resources/db/migration/V200.5__financiero_caja_virtual_acceso.sql
+++ b/src/main/resources/db/migration/V200.5__financiero_caja_virtual_acceso.sql
@@ -1,0 +1,26 @@
+-- Control de acceso por caja virtual: quien puede ver y quien puede mover plata en cada caja.
+--
+-- Hasta ahora el acceso era por rol global: cualquiera con TESORERIA VER veia TODAS las cajas
+-- de la empresa, y cualquiera con TESORERIA GESTIONAR podia mover plata en cualquiera. El rol
+-- sigue habilitando la capacidad; esta tabla delimita el alcance (modelo AND).
+--
+-- El propietario de la caja (caja_virtual.usuario_id) tiene lectura y escritura implicitas y
+-- NO lleva fila aca: es quien administra la lista.
+--
+-- Aditiva: tabla nueva. Sin backfill en esta migracion — se corre aparte, con la lista
+-- revisada, para no dejar a nadie sin cajas el dia del despliegue.
+
+CREATE TABLE IF NOT EXISTS financiero.caja_virtual_acceso (
+    id                bigserial PRIMARY KEY,
+    caja_virtual_id   bigint NOT NULL REFERENCES financiero.caja_virtual(id),
+    usuario_id        bigint NOT NULL REFERENCES personas.usuario(id),
+    puede_leer        boolean NOT NULL DEFAULT true,
+    puede_escribir    boolean NOT NULL DEFAULT false,
+    otorgado_por_id   bigint REFERENCES personas.usuario(id),
+    creado_en         timestamp NOT NULL DEFAULT now(),
+    CONSTRAINT uq_caja_virtual_acceso UNIQUE (caja_virtual_id, usuario_id)
+);
+
+-- La consulta caliente es "que cajas ve este usuario" (filtra todos los listados).
+CREATE INDEX IF NOT EXISTS ix_caja_virtual_acceso_usuario ON financiero.caja_virtual_acceso (usuario_id);
+CREATE INDEX IF NOT EXISTS ix_caja_virtual_acceso_caja    ON financiero.caja_virtual_acceso (caja_virtual_id);

--- a/src/main/resources/graphql/financiero/caja-virtual.graphqls
+++ b/src/main/resources/graphql/financiero/caja-virtual.graphqls
@@ -74,3 +74,32 @@ enum CajaVirtualTipo {
     CAJA_MAYOR
     CAJA_CHICA
 }
+
+# ── Acceso por caja (ACL) ──
+#
+# El rol de tesoreria habilita la capacidad; estas filas delimitan sobre que cajas (modelo AND).
+# El propietario de la caja (CajaVirtual.usuario) tiene lectura y escritura implicitas y NO
+# aparece en la lista: es quien la administra.
+
+type CajaVirtualAcceso {
+    id: ID!
+    cajaVirtual: CajaVirtual
+    usuario: Usuario
+    puedeLeer: Boolean
+    puedeEscribir: Boolean
+    otorgadoPor: Usuario
+    creadoEn: Date
+}
+
+extend type Query {
+    # Usuarios habilitados en una caja. Solo el responsable de la caja (o ADMIN) puede verla.
+    cajaVirtualAccesos(cajaVirtualId: ID!): [CajaVirtualAcceso]
+}
+
+extend type Mutation {
+    # Otorga o actualiza el acceso de un usuario. Idempotente por (caja, usuario).
+    otorgarAccesoCaja(cajaVirtualId: ID!, usuarioId: ID!, puedeLeer: Boolean, puedeEscribir: Boolean): CajaVirtualAcceso!
+    revocarAccesoCaja(cajaVirtualId: ID!, usuarioId: ID!): Boolean!
+    # Pasa la caja a otro responsable. Evita que quede huerfana si su duenio deja la empresa.
+    transferirPropiedadCaja(cajaVirtualId: ID!, nuevoPropietarioId: ID!): CajaVirtual!
+}

--- a/src/main/resources/graphql/financiero/cuenta-bancaria.graphqls
+++ b/src/main/resources/graphql/financiero/cuenta-bancaria.graphqls
@@ -43,6 +43,10 @@ extend type Query {
 extend type Mutation {
     saveCuentaBancaria(cuentaBancaria:CuentaBancariaInput!):CuentaBancaria!
     deleteCuentaBancaria(id:ID!):Boolean!
+    # Corrige el saldo de la cuenta contra el extracto real. Deja un movimiento AJUSTE_POSITIVO
+    # o AJUSTE_NEGATIVO con el motivo, que es la unica trazabilidad que tiene: un ajuste no
+    # tiene contrapartida, es plata que aparece o desaparece del ledger.
+    ajustarSaldoCuentaBancaria(cuentaBancariaId:ID!, monto:Float!, positivo:Boolean!, motivo:String!):MovimientoBancario!
 }
 
 enum TipoCuenta {

--- a/src/main/resources/graphql/financiero/movimiento-caja-virtual.graphqls
+++ b/src/main/resources/graphql/financiero/movimiento-caja-virtual.graphqls
@@ -14,6 +14,13 @@ type MovimientoCajaVirtual {
     activo: Boolean
     creadoEn: Date
     origenTipo: OrigenMovimientoTipo
+    # true si este movimiento es el asiento consolidado de un evento de pago (motor de CPP).
+    #
+    # No se puede deducir del origenTipo: RRHH_VALE / RRHH_LIQUIDACION_* / RRHH_AGUINALDO los
+    # setean tanto el motor de pago como los egresos directos viejos de cada modulo de RRHH.
+    # El front lo necesita para saber si anular por evento (anularPagoCpp) o con el
+    # contra-movimiento simple, y para ofrecer el detalle del pago.
+    esPagoConsolidado: Boolean
 }
 
 enum OrigenMovimientoTipo {

--- a/src/main/resources/graphql/financiero/pago-proveedor.graphqls
+++ b/src/main/resources/graphql/financiero/pago-proveedor.graphqls
@@ -47,9 +47,29 @@ input GastoParaPagoInput {
     sucursalId: ID
 }
 
+# Una linea del desglose de un evento de pago. Existe porque el evento postea UN movimiento
+# consolidado en la caja: su descripcion no puede nombrar a los N documentos pagados.
+type DetallePagoItem {
+    solicitudPagoId: ID!
+    # COMPRA | GASTO | RRHH
+    tipo: String
+    descripcion: String
+    proveedorNombre: String
+    monedaDenominacion: String
+    monedaSimbolo: String
+    decimales: Int
+    # Monto imputado a este documento en este evento.
+    montoImputado: Float
+    montoTotal: Float
+    montoPagado: Float
+    estado: String
+}
+
 extend type Query {
     solicitudesPagoPendientes(proveedorId: ID): [SolicitudPago]
     gastosPendientes: [SolicitudPago]
+    # Desglose de un evento de pago: que documentos se pagaron y cuanto se imputo a cada uno.
+    detalleDePago(pagoId: ID!): [DetallePagoItem]
 }
 
 extend type Mutation {

--- a/src/main/resources/graphql/rrhh/pago-rrhh-tesoreria.graphqls
+++ b/src/main/resources/graphql/rrhh/pago-rrhh-tesoreria.graphqls
@@ -1,0 +1,50 @@
+# Pago de liquidacion mensual, finiquito y aguinaldo desde tesoreria, con el mismo motor
+# de pago que CPP. Extiende a esos conceptos el puente que vale-tesoreria.graphqls abrio
+# para el vale: el documento de RRHH sigue siendo la verdad del modulo, su obligacion de
+# pago es una SolicitudPago tipo RRHH.
+
+# Fila de los dialogos "Pagar Liquidacion" / "Pagar Finiquito" / "Pagar Aguinaldo".
+# Es una proyeccion y no la entidad porque el saldo no vive en el documento: sale de su
+# obligacion de pago, que puede no existir todavia.
+type PagoRrhhPendiente {
+    # LIQUIDACION | FINIQUITO | AGUINALDO. Define contra que entidad resuelve el id.
+    concepto: String!
+    id: ID!
+    fecha: String
+    # Texto corto que ubica el documento: "2026-07" en liquidacion, "2026" en aguinaldo.
+    periodo: String
+    monto: Float
+    saldoPendiente: Float
+    descripcion: String
+    moneda: Moneda
+    funcionario: Funcionario
+    funcionarioNombre: String
+}
+
+# Un documento de RRHH con su reparto de formas de pago (espejo de ValeConLineasInput).
+input PagoRrhhConLineasInput {
+    concepto: ConceptoRrhhPagable!
+    documentoId: ID!
+    lineas: [LineaPagoInput!]!
+}
+
+enum ConceptoRrhhPagable {
+    LIQUIDACION
+    FINIQUITO
+    AGUINALDO
+}
+
+extend type Query {
+    # Liquidaciones mensuales APROBADAS todavia sin pagar.
+    liquidacionesPendientesPago: [PagoRrhhPendiente]
+    # Finiquitos APROBADOS todavia sin pagar.
+    finiquitosPendientesPago: [PagoRrhhPendiente]
+    # Aguinaldos APROBADOS todavia sin pagar (los CALCULADO no se pagan: monto no congelado).
+    aguinaldosPendientesPago: [PagoRrhhPendiente]
+}
+
+extend type Mutation {
+    # Paga documentos de RRHH con el motor de CPP. El pago parcial esta prohibido.
+    # En la practica se manda de a uno: la nomina nunca se paga en una sola operacion.
+    pagarRrhhMixto(pagos: [PagoRrhhConLineasInput!]!): Pago
+}

--- a/src/test/java/com/franco/dev/service/financiero/PagoProveedorServiceTest.java
+++ b/src/test/java/com/franco/dev/service/financiero/PagoProveedorServiceTest.java
@@ -55,9 +55,21 @@ class PagoProveedorServiceTest {
         when(pagoService.save(any())).thenReturn(pagoEvento);
         PreGastoService preGastoService = mock(PreGastoService.class);
         com.franco.dev.service.rrhh.ValeService valeService = mock(com.franco.dev.service.rrhh.ValeService.class);
+        // Los otros conceptos de RRHH pagables desde el hub. Los mocks devuelven false en
+        // tieneSolicitud, asi que el evento se clasifica como compra/gasto, que es lo que
+        // ejercitan estos tests.
+        com.franco.dev.service.rrhh.LiquidacionSueldoService liquidacionSueldoService =
+                mock(com.franco.dev.service.rrhh.LiquidacionSueldoService.class);
+        com.franco.dev.service.rrhh.LiquidacionFinalService liquidacionFinalService =
+                mock(com.franco.dev.service.rrhh.LiquidacionFinalService.class);
+        com.franco.dev.service.rrhh.AguinaldoService aguinaldoService =
+                mock(com.franco.dev.service.rrhh.AguinaldoService.class);
+        // El ACL de cajas acota detalleDePago; estos tests no lo ejercitan.
+        TesoreriaSecurityService seguridad = mock(TesoreriaSecurityService.class);
         service = new PagoProveedorService(solicitudPagoService, pagoService, tesoreriaService, bancoLedgerService,
-                chequeGestionService, chequeraRepo, cajaVirtualRepository, monedaRepository, detalleRepo, movBancarioRepo,
-                preGastoService, valeService);
+                chequeGestionService, chequeraRepo, cajaVirtualRepository, monedaRepository, detalleRepo,
+                seguridad, movBancarioRepo,
+                preGastoService, valeService, liquidacionSueldoService, liquidacionFinalService, aguinaldoService);
 
         com.franco.dev.domain.personas.Persona persona = new com.franco.dev.domain.personas.Persona(); persona.setNombre("PROV X");
         Proveedor prov = new Proveedor(); prov.setId(7L); prov.setPersona(persona);

--- a/src/test/java/com/franco/dev/service/financiero/TesoreriaServiceTest.java
+++ b/src/test/java/com/franco/dev/service/financiero/TesoreriaServiceTest.java
@@ -35,6 +35,7 @@ class TesoreriaServiceTest {
     private MonedaRepository monedaRepository;
     private MovimientoCajaVirtualRepository movimientoRepository;
     private com.franco.dev.repository.empresarial.ConfiguracionGeneralRepository configRepository;
+    private TesoreriaSecurityService seguridad;
     private TesoreriaService service;
 
     private CajaVirtual caja;
@@ -49,7 +50,11 @@ class TesoreriaServiceTest {
         movimientoRepository = mock(MovimientoCajaVirtualRepository.class);
         configRepository = mock(com.franco.dev.repository.empresarial.ConfiguracionGeneralRepository.class);
         when(configRepository.findAll()).thenReturn(java.util.Collections.emptyList());
-        service = new TesoreriaService(saldoRepository, cajaVirtualRepository, monedaRepository, movimientoRepository, configRepository);
+        // El ACL de cajas se aplica en registrar/transferir/anular. Estos tests ejercitan la
+        // aritmetica de saldos, no los permisos: el mock deja pasar todo (requireEscrituraCaja
+        // es void y no hace nada por default en un mock).
+        seguridad = mock(TesoreriaSecurityService.class);
+        service = new TesoreriaService(saldoRepository, seguridad, cajaVirtualRepository, monedaRepository, movimientoRepository, configRepository);
 
         caja = new CajaVirtual();
         caja.setId(1L);


### PR DESCRIPTION
Acompaña a **https://github.com/GabFrank/frc-sistemas-integrados-angular/pull/236**. **Se mergean juntos**: el desktop consume queries y campos que agrega este.

## Qué entra

### 1. Control de acceso por caja virtual (lo principal)

Hasta ahora el acceso a las cajas era **por rol global**: cualquiera con `TESORERIA VER` veía **todas** las cajas de la empresa, y cualquiera con `TESORERIA GESTIONAR` podía mover plata en **cualquiera**. Ahora cada caja lleva su propia lista de usuarios habilitados, con lectura y/o escritura.

- **Modelo AND**: el rol habilita la *capacidad*, el ACL delimita *sobre qué cajas*. El sistema de roles no se toca.
- **El propietario** (quien crea la caja) tiene ambos permisos implícitos y administra la lista. Se toma del `SecurityContext` y **solo en el alta** — antes venía del input (cualquiera podía mandar cualquier `usuarioId`) y se reescribía en cada edición, así que editar una caja ajena te volvía su dueño.
- **`transferirPropiedadCaja`** evita que la caja quede huérfana si su responsable deja la empresa.

**Dónde se aplica:**

| | |
|---|---|
| **Escritura** | `TesoreriaService.registrar/transferir/anular` — el choke point por donde pasa **toda** la plata de todas las cajas (RRHH, CPP, gastos, maletín, retiros, entradas varias, devoluciones). 3 métodos en vez de los 43 puntos de entrada que reciben un `cajaVirtualId` |
| **Lectura puntual** | Se rechaza (caja, saldos, resumen bancario, movimientos, entradas varias, configuración) |
| **Lectura de listados** | Se **filtra en la consulta**, no en memoria: filtrar después de paginar deja `getTotalElements` contando cajas que el usuario no puede ver |

**Procesos sin sesión** (schedulers, replicación de retiros) pasan a propósito: si el ACL los rechazara se cortaría la replicación. Aplica solo cuando **no hay principal**, no cuando hay uno sin permisos.

### 2. Pagar liquidación, finiquito y aguinaldo desde el hub de la caja

Extiende a esos tres conceptos el puente que `V198.5` abrió para el vale: la obligación de pago pasa a ser una `SolicitudPago` tipo RRHH, y se pagan con el **mismo motor que CPP** (caja mayor / cuenta bancaria / cheque, multi-moneda) en vez de con un egreso directo desde las pantallas de RRHH.

- El documento de RRHH sigue siendo la verdad del módulo: cuando la solicitud queda CONCLUIDA, cada servicio lo marca pagado desde su `sincronizarDesdeSolicitudPago`, linkea caja + movimiento y aplica los efectos cruzados (vale→DESCONTADO, cuota→PAGADA). Si el pago se anula, se revierte.
- **Pago parcial prohibido** en los tres: el documento no lleva saldo, lo que no se entrega no se reclama.
- `asegurarSolicitud` toma **lock pesimista** sobre el documento: sin eso, un doble clic crea dos solicitudes y el sueldo se paga dos veces (el índice único no lo impide — evita que dos documentos compartan una solicitud, no que uno reciba dos).

### 3. Fixes de trazabilidad del pago consolidado

- **La descripción del movimiento mentía**: al pagar N documentos, el asiento consolidado se describía con el **primero**, como si fuera todo el pago. Ahora un documento conserva su descripción y con varios se etiqueta el evento (*"Pago consolidado de N gastos"*).
- **`origenTipo` era siempre `PAGO_CPP`**, fuera gasto, vale o compra. Se clasifica el evento por el tipo de sus solicitudes y se postea el origen real, así el historial de caja dice el concepto y no "Compra" para todo.
- **`detalleDePago(pagoId)`**: el desglose que el movimiento consolidado no puede contestar solo. Acotado por caja visible — las observaciones de RRHH traen nombre y sueldo del funcionario, y el `pagoId` es correlativo.
- **`esPagoConsolidado`**: campo derivado que dice si un movimiento es de un evento de pago. No se puede deducir del `origenTipo` porque los orígenes de RRHH los setean **tanto el motor como los egresos directos viejos**.

### 4. Ajuste de saldo en cuentas bancarias

Solo existía para la caja; el saldo de una cuenta se corregía por SQL. El motor ya lo soportaba (`AJUSTE_POSITIVO`/`NEGATIVO`), faltaba exponerlo. Exige `TESORERIA GESTIONAR` y **motivo obligatorio**: un ajuste no tiene contrapartida, y ese texto más el usuario son toda su trazabilidad.

## Migraciones

Las dos **aditivas**, sufijo `.5`, sin `DROP`/`RENAME`:

- **`V199.5`** — `solicitud_pago_id` nullable + índice único parcial en `liquidacion_sueldo`, `liquidacion_final` y `aguinaldo`.
- **`V200.5`** — tabla `financiero.caja_virtual_acceso`.

## ⚠️ Antes de desplegar

**1. Correr el backfill a mano.** `docs/manuales-implementacion/financiero/backfill-acl-cajas.sql`. **No va en Flyway a propósito**: reparte permisos sobre plata y depende de cada instancia, así que se corre con la lista revisada delante. Sin él, al activar el filtro **toda caja sin filas queda invisible** salvo para su responsable y para ADMIN.

**2. Verificar quién quedó como responsable de cada caja.** Hasta este PR `usuario_id` se sobreescribía en cada edición, así que puede ser el último que guardó y no el creador:

```sql
select c.id, c.nombre, c.tipo, u.nickname as responsable
  from financiero.caja_virtual c
  left join personas.usuario u on u.id = c.usuario_id order by c.id;
```

**3. Esto decide si el ACL sirve de algo.** En la base de dev los 4 roles de tesorería están asignados a **cero usuarios** y hay **10+ usuarios ADMIN**. Como el ADMIN pasa por encima del ACL, si en producción el reparto es parecido el control de acceso **no va a hacer nada** hasta que se deje de operar con cuentas ADMIN:

```sql
select r.nombre, count(*) from personas.usuario_role ur
  join personas.role r on r.id = ur.role_id
 where upper(r.nombre) like 'TESORERIA%' or upper(r.nombre) = 'ADMIN'
 group by r.nombre order by 2 desc;
```

## Cómo probarlo

Guía completa: `docs/manuales-implementacion/PRUEBA-MANUAL-ACL-Y-PAGOS-HUB.md`.

**La regresión crítica a vigilar es A8**: que la replicación de retiros siga posteando en caja. Los procesos sin sesión pasan el ACL a propósito; si eso se rompe, se corta la replicación.

## Qué se probó

Contra el central local, en API y en UI:

- ACL end-to-end con un **usuario restringido**: sin acceso no ve la caja (y `getTotalElements` = 0, no una tabla vacía con contador mentiroso); con lectura la ve; al mover plata lo rechaza el ACL (aislado del gate de rol); con escritura pasa.
- Otorgar / toggle / revocar / transferir responsabilidad, incluido el bypass de ADMIN.
- Pago de liquidación y de aguinaldo completo, con etiqueta correcta en el historial, detalle del pago y anulación con saldo restaurado exacto.
- Pago consolidado de 2 gastos → *"Pago consolidado de 2 gastos"* + detalle con los 2 documentos.
- Rechazo de pago parcial. Ajuste bancario positivo y negativo con validación de motivo.
- **318 tests en verde**, AOT del desktop en verde.

**Sin probar**: pagar finiquito — requiere crear una liquidación final real, y al pagarla el funcionario queda inactivo (la anulación no lo reactiva; comportamiento preexistente).

## Riesgo

**Medio.** Toca el camino por el que pasa toda la plata. Mitigado por: el choke point único para escritura, los tests, y que el backfill se corre a mano con revisión. El apagón operativo es el riesgo real y se evita con el paso 1.

## Tamaño

Más grande que el límite de 400 líneas de la guía (~3.200 líneas, de las cuales ~1.500 son documentación y planes). Creció porque el ACL, el hub y los fixes de trazabilidad comparten el mismo camino de código — separarlos ahora implicaría duplicar el fix de `esPagoConsolidado`.

**Merge commit, no squash.**
