### PR TITLE
fix(rrhh): lote A — calculos de liquidacion y trazabilidad

### DIFF
--- a/docs/manuales-implementacion/BUGS-TESTEO-2026-08-18.md
+++ b/docs/manuales-implementacion/BUGS-TESTEO-2026-08-18.md
@@ -23,23 +23,35 @@ replica a filiales) y **F5** (bloqueado por el hub de pagos).
 que `es_remunerativo` solo se edita por SQL y el `DEFAULT TRUE` deja pasar conceptos nuevos sin que
 nadie lo decida.
 
+## Estado (2026-08-20)
+
+El trabajo se reparte en dos lotes, planificados y auditados:
+
+- **Lote A — fixes**: `docs/manuales-implementacion/rrhh/PLAN-LOTE-A-FIXES.md`.
+  B1, B3, B5, B6, B9, B13 y F8 **implementados y verificados en runtime** contra el central
+  local (rama `fix/rrhh-calculos-y-trazabilidad`). Detalle de la verificación en §11 del plan.
+- **Lote B — features**: `docs/manuales-implementacion/rrhh/PLAN-LOTE-B-FEATS.md`.
+  B4, B7, B8, B10, B11, B12 y B16.
+- **Fuera de los lotes**: B14 + B15 (necesitan decidir la fuente de verdad del salario y
+  ~8 preguntas de negocio) y F3 (cross-repo, toca filial, con una pregunta bloqueante).
+
 ## Índice
 
 | # | Título | Sev |
 |---|---|---|
-| B1 | Ajuste salario mínimo global — `Integer cannot be cast to Long` al guardar | 🔴 |
-| B2 | Mismo diálogo — "Sueldo actual" muestra `1`/`2`, "Cargo" vacía | 🔴 |
-| B3 | Mismo diálogo — dice 15 seleccionados, lista 10 filas | 🔴 |
+| B1 | Ajuste salario mínimo global — `Integer cannot be cast to Long` al guardar | ✅ **hecho** |
+| B2 | Mismo diálogo — "Sueldo actual" muestra `1`/`2`, "Cargo" vacía | ⚪ **no es código** — data sucia, ver §B2 |
+| B3 | Mismo diálogo — dice 15 seleccionados, lista 10 filas | ✅ **hecho** |
 | B4 | No existe CRUD de cargos en desktop (backend listo) | 🔴 |
-| B5 | Toggle IPS en `false` igual descuenta en liquidación mensual | 🔴 |
-| B6 | No se puede eliminar un ítem automático del borrador | 🔴 |
+| B5 | Toggle IPS en `false` igual descuenta en liquidación mensual | ✅ **hecho** |
+| B6 | No se puede eliminar un ítem automático del borrador | ✅ **hecho** |
 | B7 | Recibo: total sin descuentos en la firma + 2 vías + línea punteada | 🟠 |
 | B8 | Recibo: header con empresa emisora + "Recibí de … la suma de …" | 🟠 |
-| B9 | Liquidación toma el salario anterior (probable consecuencia de B1) | 🔴 |
+| B9 | Liquidación toma el salario anterior (probable consecuencia de B1) | ✅ **hecho** |
 | B10 | Penalización automática: solo un día, falta rango de fechas | 🟠 |
 | B11 | Amonestaciones/advertencias sin monto + contador + acta firmable | 🟠 |
 | B12 | Ítem manual: select de operación (hoy todo sale "AJUSTE") | 🟠 |
-| B13 | Penalizaciones consolidadas en un ítem, sin detalle | 🔴 |
+| B13 | Penalizaciones consolidadas en un ítem, sin detalle | ✅ **hecho** |
 | B14 | Aguinaldo sobre último sueldo, no sobre promedio percibido | ✅ PR #234 |
 | B15 | IPS del finiquito: sin prorrateo por días ni vacaciones en la base | ✅ PR #234 |
 | F1 | Ajuste de saldo en cuentas bancarias (solo existe en caja) | ✅ **hecho** |
@@ -47,6 +59,7 @@ nadie lo decida.
 | F3 | Retiro de PDV: recepción parcial + selección de monedas | 🟠 |
 | F4 | Todo pago figura "Pago Proveedor"; usar `origenTipo` para el label | ✅ **hecho** |
 | F5 | Premisa: pagos de caja mayor solo desde la caja mayor (ocultar en RRHH) | 🟠 |
+| F8 | Movimientos históricos siguen etiquetados "Compra" tras el fix de F4 | ✅ **hecho** (script) |
 | B16 | Liquidación: consolidar en un ítem las cuotas de ventas a crédito (configurable) | 🟠 |
 | **ACL** | **Acceso por caja: lista de usuarios R/W por caja virtual** — plan en `financiero/PLAN-ACL-CAJAS-VIRTUALES.md` | ⭐ **1ª** |
 

--- a/docs/manuales-implementacion/financiero/backfill-origen-tipo.sql
+++ b/docs/manuales-implementacion/financiero/backfill-origen-tipo.sql
@@ -1,0 +1,119 @@
+-- Backfill de origen_tipo en movimientos historicos de caja — CORRER A MANO, NO ES FLYWAY.
+--
+-- Contexto. Hasta el fix de F4/F6, PagoProveedorService grababa siempre origen_tipo =
+-- 'PAGO_CPP' sin mirar el concepto real, asi que en el dashboard de la caja todo pago
+-- figura como "Compra": los gastos, los vales y las liquidaciones tambien. El codigo ya
+-- clasifica bien de aca en adelante; esto corrige lo que quedo atras.
+--
+-- Por que no es una migracion Flyway. Hay precedente de las dos formas: V180.5 hizo un
+-- backfill de esta misma columna dentro de la migracion. Pero ese caso era deterministico
+-- (FK 1:1, nada que decidir). Aca hay tres clases de fila que NO se pueden derivar:
+--
+--   · eventos MIXTO — una linea de caja que paga solicitudes de tipos distintos. Para esos
+--     'PAGO_CPP' es la clasificacion correcta, no un bug.
+--   · RRHH huerfano — solicitud tipo RRHH sin fila en ninguna tabla puente. El codigo en
+--     vivo asume VALE por default, pero eso es una heuristica para el flujo en tiempo real,
+--     no evidencia para reescribir historia.
+--   · pagos anteriores a V182.5, sin fila en pago_solicitud_detalle.
+--
+-- Una migracion corre ciega al bootear: no hay punto donde alguien vea los conteos antes de
+-- aplicar. Y son tres instancias (alpha / farmacia / bodega) con historiales distintos. Si
+-- la clasificacion tuviera un error, aca se reedita y se re-corre; en una migracion ya
+-- aplicada habria que escribir otra migracion correctiva por algo puramente cosmetico.
+--
+-- Filial no se toca. financiero.movimiento_caja_virtual no existe en su schema ni esta en
+-- ninguna publicacion de replicacion — la caja mayor es central-only.
+--
+-- Es idempotente: el WHERE filtra por origen_tipo = 'PAGO_CPP', asi que una fila ya
+-- corregida deja de matchear. Se puede correr de nuevo sin efecto.
+--
+-- ─────────────────────────────────────────────────────────────────────────────────────────
+-- PASO 0 — mirar el terreno antes de tocar nada
+-- ─────────────────────────────────────────────────────────────────────────────────────────
+-- Reparto actual. Sirve de "antes" para comparar al final:
+--
+--   select origen_tipo, count(*)
+--     from financiero.movimiento_caja_virtual
+--    group by origen_tipo
+--    order by 2 desc;
+--
+-- Que pasaria si se aplicara: correr la CTE del PASO 1 cambiando el UPDATE por
+--
+--   select coalesce(nuevo_origen, '(sin cambio)') as destino, count(*)
+--     from clasificado group by 1 order by 2 desc;
+--
+-- Si el numero de '(sin cambio)' es alto, no es un error: son las compras reales, que ya
+-- estaban bien etiquetadas, mas las tres clases ambiguas de arriba.
+
+BEGIN;
+
+-- ─────────────────────────────────────────────────────────────────────────────────────────
+-- PASO 1 — reclasificar solo lo que se puede derivar sin ambiguedad
+-- ─────────────────────────────────────────────────────────────────────────────────────────
+-- El movimiento no tiene FK al pago; el vinculo va por la tabla puente. Para RRHH, el tipo
+-- de la solicitud no alcanza (los cuatro conceptos comparten tipo RRHH), asi que se
+-- desambigua por cual tabla la reclama — cada una tiene indice unico sobre solicitud_pago_id.
+--
+-- Todas las condiciones exigen count(distinct sp.tipo) = 1: si el evento pago solicitudes de
+-- mas de un tipo, es MIXTO y se deja como esta.
+
+WITH clasificado AS (
+  SELECT m.id,
+    CASE
+      WHEN count(DISTINCT sp.tipo) = 1 AND max(sp.tipo::text) = 'GASTO'
+           THEN 'GASTO'
+      WHEN count(DISTINCT sp.tipo) = 1 AND max(sp.tipo::text) = 'RRHH'
+           AND count(DISTINCT sp.id) = count(DISTINCT v.solicitud_pago_id)
+           THEN 'RRHH_VALE'
+      WHEN count(DISTINCT sp.tipo) = 1 AND max(sp.tipo::text) = 'RRHH'
+           AND count(DISTINCT sp.id) = count(DISTINCT ls.solicitud_pago_id)
+           THEN 'RRHH_LIQUIDACION_SUELDO'
+      WHEN count(DISTINCT sp.tipo) = 1 AND max(sp.tipo::text) = 'RRHH'
+           AND count(DISTINCT sp.id) = count(DISTINCT lf.solicitud_pago_id)
+           THEN 'RRHH_LIQUIDACION_FINAL'
+      WHEN count(DISTINCT sp.tipo) = 1 AND max(sp.tipo::text) = 'RRHH'
+           AND count(DISTINCT sp.id) = count(DISTINCT ag.solicitud_pago_id)
+           THEN 'RRHH_AGUINALDO'
+      ELSE NULL   -- COMPRA (ya correcto), MIXTO, RRHH huerfano, o sin puente: no tocar
+    END AS nuevo_origen
+    FROM financiero.movimiento_caja_virtual m
+    JOIN financiero.pago_solicitud_detalle psd ON psd.movimiento_caja_virtual_id = m.id
+    JOIN operaciones.solicitud_pago sp         ON sp.id = psd.solicitud_pago_id
+    LEFT JOIN rrhh.vale               v  ON v.solicitud_pago_id  = sp.id
+    LEFT JOIN rrhh.liquidacion_sueldo ls ON ls.solicitud_pago_id = sp.id
+    LEFT JOIN rrhh.liquidacion_final  lf ON lf.solicitud_pago_id = sp.id
+    LEFT JOIN rrhh.aguinaldo          ag ON ag.solicitud_pago_id = sp.id
+   WHERE m.origen_tipo = 'PAGO_CPP'
+   GROUP BY m.id
+)
+UPDATE financiero.movimiento_caja_virtual m
+   SET origen_tipo = c.nuevo_origen
+  FROM clasificado c
+ WHERE m.id = c.id
+   AND c.nuevo_origen IS NOT NULL;
+
+-- ─────────────────────────────────────────────────────────────────────────────────────────
+-- PASO 2 — verificar ANTES de confirmar
+-- ─────────────────────────────────────────────────────────────────────────────────────────
+-- Correr esto todavia dentro de la transaccion y comparar contra el "antes" del PASO 0:
+--
+--   select origen_tipo, count(*)
+--     from financiero.movimiento_caja_virtual
+--    group by origen_tipo
+--    order by 2 desc;
+--
+-- Que esperar: PAGO_CPP baja; GASTO y los RRHH_* suben en la misma cantidad. El total
+-- general no cambia — esto no crea ni borra movimientos.
+--
+-- Control de que no se toco nada que no correspondia: los movimientos reclasificados a
+-- RRHH_* tienen que tener su documento del lado de RRHH.
+--
+--   select m.origen_tipo, count(*)
+--     from financiero.movimiento_caja_virtual m
+--    where m.origen_tipo like 'RRHH_%'
+--    group by m.origen_tipo;
+--
+-- Si algo no cierra: ROLLBACK; y revisar. Si cierra:
+
+COMMIT;
+-- ROLLBACK;   -- <- descomentar esta y comentar el COMMIT para un ensayo en seco

--- a/docs/manuales-implementacion/rrhh/PLAN-LOTE-A-FIXES.md
+++ b/docs/manuales-implementacion/rrhh/PLAN-LOTE-A-FIXES.md
@@ -1,0 +1,302 @@
+# Plan — Lote A: fixes de RRHH y Financiero
+
+> Rama: **`fix/rrhh-calculos-y-trazabilidad`** (central + desktop), sale de `develop`.
+> Origen: `docs/manuales-implementacion/BUGS-TESTEO-2026-08-18.md`.
+> Investigación item por item completada el 2026-08-19; cada sección cita `archivo:línea` verificado.
+
+## 0. Composición del lote y qué cambió tras investigar
+
+| # | Título | Veredicto de la investigación |
+|---|---|---|
+| **B1** | `Integer cannot be cast to Long` al ajustar salarios | Confirmado. Mismatch schema/Java. 3 líneas |
+| **B3** | Dice 15 seleccionados, lista 10 filas | **No es cosmético.** Ver §2 |
+| **B5** | Toggle IPS en `false` igual descuenta | Confirmado. 1 línea + verificación de datos pre-deploy |
+| **B9** | Liquidación toma el salario anterior | **Dos causas**, una de ellas independiente de B1 |
+| **B13** | Penalizaciones consolidadas sin detalle | Confirmado. Sin migración, sin tocar el `.jrxml` |
+| **B6** | No se puede eliminar un ítem automático | El backend **ya está hecho**. Es un `*ngIf` |
+| **F8** | Movimientos históricos con `origen_tipo` mal | Script manual, no migración. Filial no se toca |
+| **R1** | *(nuevo)* Deduplicar el armado de filas del recibo | Habilitador de B16; sale del hallazgo de B13/B16 |
+
+**Salieron del lote:**
+
+- **B2** (sueldo `1`/`2`, cargo vacío) — **no hay código que arreglar**. La cadena schema → repository → query → template está correcta de punta a punta. Es data sucia: 75 funcionarios activos con `sueldo` entre 1 y 30 y `cargo_id` NULL en la base de dev. Queda como verificación en §9, no como fix.
+- **B15** (IPS del finiquito proporcional) — no es un fix, es un feature. "Vacaciones proporcionales" **no existe en el código**: `VacacionService.devengar()` solo crea filas al completar un año de servicio. Va al PR de cálculo de salario junto con B14.
+
+## 1. B1 — `Integer cannot be cast to Long`
+
+**Causa raíz.** El schema declara `[Int]`, el resolver recibe `List<Long>`:
+
+```
+configuracion-rrhh.graphqls:94   ajustarSalariosAlMinimo(funcionarioIds: [Int], ...)
+ConfiguracionRrhhGraphQL.java:90 public ... (List<Long> funcionarioIds, ...)
+AjusteSalarioMinimoService.java:57  for (Long id : funcionarioIds)   ← ClassCastException
+```
+
+`graphql-java-kickstart` puebla la lista con `Integer` sin importar el genérico Java — el borrado de tipos hace que el `List<Long>` sea una promesa vacía. El unboxing implícito del for-each explota en el primer elemento. Como `ajustarAlMinimo` es `@Transactional`, no se persiste **ningún** ajuste.
+
+**El fix ya está escrito en este repo.** `LiquidacionSueldoGraphQL.java:109-114` tiene el mismo schema `[Int]` y convierte a mano, con un comentario que explica exactamente esta trampa. Replicar ese patrón.
+
+**Alcance verificado:** dentro de `graphql/rrhh/` solo estos dos métodos reciben listas de ids, y solo `ajustarSalariosAlMinimo` está sin convertir.
+
+**Fuera de RRHH el patrón existe y no está cubierto por este lote.** La auditoría encontró dos casos estructuralmente idénticos que hoy no se manifiestan:
+
+- `CambioGraphQL.java:77` — `saveCambio(..., List<Long> sucursalesIdList)` con schema `[Int]`. No revienta porque **el parámetro nunca se usa**: es código muerto.
+- `CajaVirtualConfiguracionGraphQL` — el wrapper de input declara `List<Long> formasPagoVisiblesIds` / `cuentasBancariasVisiblesIds` (schema `[Int]`) e itera con `for (Long id : ...)`. No se pudo confirmar sin prueba en runtime si el binding de **campos de input** vía Jackson pierde los genéricos igual que el binding de **argumentos de método**. Sospechoso, sin veredicto.
+
+No bloquea este lote. Va como issue aparte — el resumen de B1 no debe leerse como "no hay más ocurrencias en toda la app".
+
+**Archivos:** `graphql/rrhh/ConfiguracionRrhhGraphQL.java`. Sin cambio de schema, sin cambio en desktop, sin migración.
+
+## 2. B3 — el contador dice 15 y se ven 10
+
+**No es paginación ni filtro.** Se descartaron las cuatro hipótesis con evidencia: no hay `MatPaginator`, el template recorre `dataSource.data` completo sin `*ngIf` por fila, la selección se inicializa sobre el mismo array que alimenta la tabla, y el backend (`FuncionarioRepository.findConSueldoMenorA`) no pagina ni trunca.
+
+**La causa es CSS.** `ajuste-salario-minimo-dialog.component.scss:27-30`:
+
+```scss
+.tabla { max-height: 45vh; overflow: auto; }
+```
+
+Los 15 `<tr>` están todos en el DOM; ~10 entran en el viewport. El header lleva `sticky: true` (`.html:48`), así que el checkbox de "seleccionar todos" queda siempre visible e interactuable, y `onToggleTodos()` (`.ts:63-71`) hace `dataSource.data.forEach(f => this.seleccion.select(f))` sobre el array **completo**. En Electron/macOS con la scrollbar auto-oculta no hay ninguna señal de que haya más filas.
+
+**Por qué esto importa.** `onConfirmar()` (`.ts:82-89`) manda `seleccion.selected` tal cual. Después de un click en "seleccionar todos", eso incluye los 5 funcionarios que el usuario nunca scrolleó para ver. **Se ajustan salarios de gente no revisada, con histórico legal.** Hoy no ocurre solo porque B1 hace explotar el mutation antes de persistir.
+
+> **B1 y B3 tienen que ir en el mismo PR.** Arreglar B1 sin B3 deja el flujo armado para escribir cambios de sueldo sobre funcionarios que nadie miró.
+
+**Fix:** subir el `max-height` a un valor que raramente recorte (o hacerlo función del alto de fila con tope ~70vh), agregar un contador fijo "Funcionarios afectados: N" fuera del botón, y un tooltip en el checkbox de seleccionar todos aclarando que abarca los que no se ven.
+
+El código ya documenta la intención en un comentario propio (`.ts:20-21`): ajustar un salario es una decisión explícita. Esconder registros detrás de un `overflow` sin affordance la contradice.
+
+**Archivos:** los tres del diálogo, en desktop. La lógica de `SelectionModel` no se toca — está bien.
+
+## 3. B5 — el toggle de IPS se ignora
+
+**Causa raíz: cálculo, no persistencia.** `LiquidacionSueldoService.java:211-214` arma el ítem incondicionalmente:
+
+```java
+BigDecimal ipsPct = configuracionRrhhService.getNumber("IPS_PORCENTAJE_FUNCIONARIO", new BigDecimal("9"));
+BigDecimal ips = salarioBase.multiply(ipsPct).divide(new BigDecimal("100"), 2, RoundingMode.HALF_UP);
+if (ips.signum() > 0) items.add(item(liq, "IPS_DESCUENTO", "DESCUENTO IPS", ips, ...));
+```
+
+`ipsActivo` no aparece ni una vez en todo el archivo. La persistencia del toggle se verificó completa (template → `FormControl` → input → `.graphqls` → `ModelMapper` → entidad) y **está correcta**.
+
+**El patrón correcto ya existe en el servicio hermano**, `LiquidacionFinalService.java:212`:
+
+```java
+boolean descontarIps = in.getDescontarIps() != null
+        ? in.getDescontarIps()
+        : !Boolean.FALSE.equals(f.getIpsActivo());
+```
+
+`!Boolean.FALSE.equals(...)` trata `null` como activo y solo `false` explícito desactiva. Portar eso.
+
+**Alcance:** acotado a la liquidación mensual. El finiquito ya está bien; el aguinaldo no aplica IPS. Hallazgo aparte, fuera de este lote: `ReporteRrhhService.resumenIpsBase64:103-136` recalcula el aporte desde cero sin mirar el flag ni si la liquidación llevó el ítem — va a seguir sobreestimando aun después de este fix.
+
+**⚠️ Verificación obligatoria antes de deployar.** `V154.0:23` creó la columna con `ADD COLUMN ... DEFAULT false`, así que Postgres persistió `false` — no `NULL` — en todas las filas existentes. Todo funcionario que nunca pasó por el legajo a tildar el toggle tiene `ips_activo=false` guardado. Arreglar el cálculo **deja de descontar IPS de golpe** para toda esa gente. Ver §9.
+
+**Archivos:** `service/rrhh/LiquidacionSueldoService.java`. Sin migración.
+
+## 4. B9 — la liquidación toma el salario anterior
+
+Son **dos causas distintas**, no una.
+
+**(a) Consecuencia de B1.** Para los 15 funcionarios de ese diálogo: el ajuste nunca se persistió, así que el "salario nuevo" nunca existió en DB. Se resuelve solo al arreglar B1.
+
+**(b) Staleness del caché de primer nivel de Hibernate — independiente.** `generarLote` (`LiquidacionSueldoService.java:643-662`) es `@Transactional` y carga todos los funcionarios al inicio; después llama `generarBorrador(f.getId(), ...)` por cada uno, que también es `@Transactional` con propagación `REQUIRED` y por lo tanto **se une a la misma transacción**. Su `funcionarioService.findById()` devuelve la instancia ya gestionada del identity map de la sesión, no una fila fresca.
+
+No hay caché de segundo nivel en el repo (se buscó `@Cacheable`, no existe). Es puro comportamiento L1.
+
+La mutation de un solo funcionario abre transacción propia y está sana. Solo la generación masiva puede servir un sueldo viejo — lo que explica el "en algunos casos" del reporte: depende de qué botón se usó.
+
+**⚠️ Anotar `REQUIRES_NEW` NO alcanza — self-invocation de Spring.** `generarLote:659` llama `generarBorrador(f.getId(), ...)` **sin calificar, dentro de la misma clase**. Verificado: no hay auto-inyección `@Lazy` de sí misma, no hay `AopContext.currentProxy()`, no hay AspectJ weaving en el `pom.xml`. Con proxies de Spring (JDK o CGLIB) una llamada interna entre métodos del mismo bean **no pasa por el proxy**, así que la anotación se ignora en silencio y `generarBorrador` sigue corriendo en la transacción compartida.
+
+Ese es el peor tipo de fix posible: compila, pasa un review a simple vista, y el bug sigue exactamente igual.
+
+**Fix real — extraer un bean aparte.** Un `@Component LiquidacionLoteWorker` con el trabajo por funcionario anotado `@Transactional(propagation = REQUIRES_NEW)`, inyectado en `LiquidacionSueldoService`. La llamada `worker.generarBorradorNuevaTx(...)` sí atraviesa el proxy del otro bean.
+
+Alternativas descartadas: auto-inyección `@Lazy` de la clase en sí misma (funciona, pero es un ciclo que oscurece el diseño) y `TransactionTemplate` programático (funciona, pero deja la semántica transaccional escondida en el cuerpo del loop en vez de declarada).
+
+**Beneficio colateral:** hoy `:661` tiene un `catch (Exception ignored)` que se traga los fallos individuales. Con transacción propia por funcionario, el fallo de uno deja de poder tumbar a los ya commiteados — hoy sí puede, porque comparten transacción.
+
+**Riesgo a vigilar:** una transacción por funcionario en un lote grande cambia el perfil de locking. Medir con un lote real antes de dar por cerrado.
+
+**Verificación de que el fix funciona:** no alcanza con leer el código. Hay que probar en runtime — cambiar el sueldo de un funcionario y generar el lote en la misma sesión, confirmando que toma el valor nuevo. Si se hubiera aplicado solo la anotación, esta prueba habría fallado y el review no.
+
+**Archivos:** `service/rrhh/LiquidacionSueldoService.java` + `service/rrhh/LiquidacionLoteWorker.java` (nuevo). Sin migración.
+
+## 5. B13 — una penalización, un ítem
+
+**Hoy** (`LiquidacionSueldoService.java:223-228`):
+
+```java
+BigDecimal pen = BigDecimal.ZERO;
+for (Penalizacion p : penalizacionRepository.findByFuncionarioIdAndFechaBetweenAndAnuladaFalse(fid, inicio, fin)) {
+    if (p.getMonto() != null) pen = pen.add(p.getMonto());
+}
+if (pen.signum() > 0) items.add(item(liq, "PENALIZACION", "PENALIZACIONES", pen, DESCUENTO, null, null));
+```
+
+`referenciaId` y `referenciaTipo` van en `null`, que es exactamente por qué no hay detalle **y** por qué el ítem no se puede borrar con reversión segura.
+
+**Cambio:** un `items.add(...)` por penalización, con `referenciaId = p.getId()`, `referenciaTipo = "PENALIZACION"` y descripción `tipo + ": " + descripcion`.
+
+**Efectos colaterales — verificados, ninguno bloqueante:**
+
+- **`aplicarEfectosCruzados` (`:573-629`)**: filtra con `if (tipo == null || refId == null) continue;`. Al setear el par, `PENALIZACION` cae en el `default: break;`. **No hace falta un `case` nuevo** — `Penalizacion` no tiene estado que revertir al pagar o anular (solo `anulada`, que este flujo no toca).
+- **El recibo**: la banda `<detail>` del `.jrxml` **ya es iterable** y `ReciboLiquidacionService:88-96` ya itera `findItems()` uno a uno usando `getDescripcion()` como observación. Pasar de 1 a N ítems lista N filas solo. **No se toca el `.jrxml`.**
+- **Totales**: `LiquidacionCalculator.calcular():38-52` suma por `tipo`. Un ítem de 50.000 y tres que suman 50.000 dan el mismo total.
+- **Liquidaciones ya generadas**: quedan como están. `generarBorrador` borra y reconstruye los automáticos en cada llamada, y la query filtra por rango de fecha, así que no hay duplicación ni al regenerar ni entre períodos. **No hay que migrar datos.**
+
+**Mejora que se habilita de paso — con trabajo real, no gratis.** `ReciboLiquidacionService.fechaItem():203-233` corta antes del switch por el guard `if (ref != null && tipo != null)`, y además no tiene case para `"PENALIZACION"`. Con `referenciaId` poblado, cada fila puede mostrar la fecha del hecho en vez del fallback.
+
+Pero `ReciboLiquidacionService` **no tiene `PenalizacionRepository` inyectado** — el constructor solo trae `ValeRepository`, `BonoRepository`, `VacacionVentaRepository` y `PrestamoCuotaRepository`. Hay que agregar la dependencia además del `case`.
+
+**Archivos:** `service/rrhh/LiquidacionSueldoService.java`, `service/rrhh/ReciboLiquidacionService.java` (`fechaItem`). Sin migración, sin desktop.
+
+## 6. B6 — eliminar un ítem automático
+
+**El backend ya está completo.** `LiquidacionSueldoService.eliminarItem(itemId):385-399` existe, valida `estado == BORRADOR`, borra y recalcula totales, y **no filtra por `manual`**. Está expuesto (`liquidacion-sueldo.graphqls:74`, resolver con `seg.requireAnyRole(seg.LIQUIDAR)`), y desktop tiene el `EliminarItemGQL`, el método del servicio y el handler del componente ya conectados.
+
+**El bug es una condición de más**, en `liquidacion-detalle-dialog.component.html:66`:
+
+```html
+*ngIf="row.manual && liq.estado === 'BORRADOR'"
+```
+
+El botón de **editar** (línea 63) no tiene esa restricción — ya funciona hoy para automáticos.
+
+**Sobre los efectos cruzados:** `aplicarEfectosCruzados` se invoca **solo** desde `pagar()`, `anular()` y `sincronizarDesdeSolicitudPago()`. En `BORRADOR` ningún ítem tiene todavía efecto aplicado sobre su entidad de origen — `Vale.estado`, `PrestamoCuota.montoPagado` y los demás se tocan recién al pagar. **Borrar un automático en BORRADOR no deja nada colgado.**
+
+**Decisión: opción mínima.** Sacar `row.manual &&` y agregar un `dialogos.confirm` (hoy `onEliminarItem` no confirma).
+
+**Limitación aceptada y documentada:** `generarBorrador:129-140` preserva solo `manual=true`, así que un automático borrado **reaparece al Regenerar**. No introduzco una inconsistencia nueva: la **edición** de automáticos ya se comporta igual hoy (`editado=true` tampoco sobrevive al regenerado). La alternativa durable — campo `excluido` + preservarlo en el regenerado + saltear la recreación en los 7 tipos de ítem automático — toca la lógica central de reconstrucción y merece su propio PR con tests por tipo.
+
+**Archivos:** los dos del diálogo, en desktop. Backend intacto. Sin migración.
+
+## 7. R1 — deduplicar el armado de filas del recibo
+
+No estaba en la lista de bugs; sale de cruzar B13 con B16.
+
+`ReciboLiquidacionService` arma las filas del recibo **tres veces**, cada una recorriendo `findItems()` por su cuenta. Cualquier cambio de presentación aplicado a uno solo deja los otros dos desalineados.
+
+B13 (desglosar penalizaciones) y B16 (consolidar cuotas de crédito) son la misma operación con signo opuesto y viven ahí.
+
+**⚠️ No es una extracción mecánica. Los tres modelos de fila son distintos:**
+
+| Generador | DTO | Columnas | Cómo codifica el signo |
+|---|---|---|---|
+| `generarBase64` (PDF A4) | `ReciboLiquidacionItemDto` | 5: operación, dirección, descripción, fecha, monto | Columna explícita `ENTRADA`/`SALIDA` |
+| `generarTicketEscPos` (térmica) | `Row` | 2: concepto, monto | Paréntesis: `(monto)` |
+| `generarTicket` (58/80mm) | `FiniquitoRow` | 2: concepto, monto | Paréntesis: `(monto)` |
+
+El A4 tiene fecha y dirección y **no usa paréntesis**; los tickets no tienen ni fecha ni dirección y codifican el signo **solo** con paréntesis. Unificar exige diseñar un modelo superset y parametrizar el formato de monto por destino — no mover código. Los dos errores a evitar: filtrar los paréntesis al A4, o perder la columna de fecha en los tickets.
+
+Presupuestar esto como diseño, no como refactor de cinco minutos. Es la fase con más chance de desbordarse del lote.
+
+**De paso:** `operacion(it):181-197` no tiene case para `"CREDITO_CONVENIO_CUOTA"` ni para `"AGUINALDO"`, así que hoy imprimen "HABER"/"DESCUENTO" genérico en la columna Operación en vez de su nombre. Se corrige acá.
+
+**Archivos:** `service/rrhh/ReciboLiquidacionService.java`.
+
+**Criterio de aceptación:** las tres salidas idénticas antes y después, salvo los dos labels corregidos. Comparar el PDF A4, el ticket 58 y el ticket 80 generados con la misma liquidación. `ReciboRrhhJrxmlTest` cubre `recibo-ticket-58.jrxml` y `recibo-ticket-80.jrxml` — correrlo, aunque no ejercite este servicio (usa su propia clase `Row` dummy).
+
+## 8. F8 — backfill de `origen_tipo`
+
+**Cadena de derivación, validada contra datos reales.** El movimiento no tiene FK al pago; el link va por la tabla puente:
+
+```
+movimiento_caja_virtual (origen_tipo='PAGO_CPP')
+  → pago_solicitud_detalle.movimiento_caja_virtual_id = m.id
+  → solicitud_pago.tipo   (COMPRA | GASTO | RRHH)
+      si RRHH → desambiguar por bridge 1:1 (índice único por tabla):
+        rrhh.vale.solicitud_pago_id              → RRHH_VALE
+        rrhh.liquidacion_sueldo.solicitud_pago_id → RRHH_LIQUIDACION_SUELDO
+        rrhh.liquidacion_final.solicitud_pago_id  → RRHH_LIQUIDACION_FINAL
+        rrhh.aguinaldo.solicitud_pago_id          → RRHH_AGUINALDO
+```
+
+Replica la clasificación que ya hace el código en vivo (`PagoProveedorService.clasificar():176-191`).
+
+**Alcance real: menor de lo que parecía.** De los 17 valores del enum, solo `PAGO_CPP`, `GASTO` y los 4 `RRHH_*` están afectados — son los únicos que pasan por el motor de pago compartido. Los otros (`RETIRO_CAJA`, `VENTA_CREDITO_COBRO`, `DEVOLUCION`, `ENTRADA_VARIA`, `OPERACION_FINANCIERA`, `MALETIN`, `MANUAL`, `ANULACION`) los setea siempre su propio servicio dueño y nunca pasaron por el bug. `CHEQUE` y `ACREDITACION_POS` están declarados pero no tienen productor: 0 filas.
+
+**Medición en la base de dev:** de 16 movimientos `PAGO_CPP`, 8 quedan igual, 5 pasan a `GASTO` y 3 a `RRHH_VALE`. La mitad mal etiquetada. No es muestra representativa de prod.
+
+**Script manual, no migración Flyway.** Hay precedente de las dos formas y la diferencia es la ambigüedad: `V180.5` sí hizo un backfill de esta misma columna dentro de la migración, pero era determinístico — FK 1:1, nada que decidir. Acá hay tres clases de fila que no se pueden derivar:
+
+- eventos **MIXTO** (una línea de caja paga solicitudes de tipos distintos) — `PAGO_CPP` es la clasificación *correcta*, no un bug
+- **RRHH huérfano** (solicitud RRHH sin fila en ninguna bridge) — el código en vivo asume `VALE` por default, pero eso es una heurística para el flujo en tiempo real, no evidencia para reescribir historia
+- pagos **anteriores a `V182.5`**, sin fila en `pago_solicitud_detalle`
+
+Una migración corre ciega al bootear: no hay punto donde un humano vea los conteos antes de aplicar. Son 3 instancias (alpha/farmacia/bodega) con historiales distintos. Y si la clasificación tuviera un error, en un script se reedita y se re-corre; en una migración ya aplicada hay que escribir otra migración correctiva por algo puramente cosmético. Mismo razonamiento que sacó `backfill-acl-cajas.sql` de Flyway.
+
+La query solo actualiza cuando la clasificación es unánime y deja lo ambiguo intacto. El label de fallback de `PAGO_CPP` es "Compra", honesto para lo que efectivamente son compras.
+
+**Filial no se toca.** `financiero.movimiento_caja_virtual` no existe en su schema ni está en ninguna publicación de replicación — caja mayor es central-only. Cero riesgo de propagación.
+
+**Entregable:** `docs/manuales-implementacion/financiero/backfill-origen-tipo.sql`, con la misma estructura que el del ACL: PASO 0 de conteo, `BEGIN`, `UPDATE`, verificación, `COMMIT`/`ROLLBACK`. Idempotente (`WHERE origen_tipo = 'PAGO_CPP'` deja de matchear una vez corregido).
+
+## 9. Verificaciones de datos previas al deploy
+
+Ninguna es opcional. Las tres se corren contra la instancia destino, no contra dev.
+
+**1. B5 — cuántos funcionarios dejarían de aportar IPS**
+
+```sql
+SELECT ips_activo, count(*) FROM personas.funcionario WHERE activo GROUP BY ips_activo;
+```
+
+Si la mayoría de los activos está en `false` por el default de `V154.0` y no por decisión real, hay que corregir los datos por legajo **antes** de deployar el fix. Si no, el primer mes post-deploy sale sin IPS para media plantilla.
+
+**2. B2 — si la data sucia existe fuera de dev**
+
+```sql
+SELECT count(*) FROM personas.funcionario WHERE activo AND (sueldo < 1000 OR cargo_id IS NULL);
+```
+
+Si da 0 en prod, B2 se cierra como artefacto de la base de dev. Si no, hace falta un script de limpieza aparte — que no es parte de este PR.
+
+**3. F8 — desglose antes de aplicar el backfill**
+
+```sql
+SELECT origen_tipo, count(*) FROM financiero.movimiento_caja_virtual GROUP BY origen_tipo ORDER BY 2 DESC;
+```
+
+Más la CTE de clasificación agrupada por `nuevo_origen`, para ver el reparto antes de tocar nada.
+
+## 10. Fases y commits
+
+Sin AOT entre fases; el gate real (`npm run check` en desktop, `./mvnw clean verify` en central) corre al final.
+
+| Fase | Contenido | Commit |
+|---|---|---|
+| 1 | B1 + B3 | `fix(rrhh): ajuste de salario minimo no persistia y seleccionaba filas no visibles` |
+| 2 | B5 | `fix(rrhh): respetar el toggle de ips del funcionario en la liquidacion mensual` |
+| 3 | B9 | `fix(rrhh): leer el salario fresco en la generacion masiva de liquidaciones` |
+| 4 | R1 | `refactor(rrhh): unificar el armado de filas del recibo de liquidacion` |
+| 5 | B13 | `fix(rrhh): un item por penalizacion en la liquidacion` |
+| 6 | B6 | `fix(rrhh): permitir eliminar items automaticos del borrador` |
+| 7 | F8 + docs | `docs(financiero): script de backfill de origen_tipo historico` |
+
+**Orden no negociable:** B1 y B3 en la misma fase (§2). R1 antes de B13, porque B13 toca `fechaItem` y R1 reorganiza ese archivo.
+
+## 11. Cierre
+
+1. `./mvnw clean verify` en central — incluye los tests que rompió el PR anterior por constructores nuevos.
+2. `npm run check` en desktop (AOT). `tsc --noEmit` **no sirve** como gate: TS 4.8.4 no parsea los `.d.ts` modernos y los errores sintácticos suprimen el chequeo semántico.
+3. Dos agentes auditores de código.
+4. Tests e2e y UI con Claude in Chrome, servidor central local + desktop web.
+5. Actualizar `BUGS-TESTEO-2026-08-18.md` (marcar resueltos) y la skill `rrhh-expert` si cambia algún invariante.
+6. Commit, push, PR a `develop` en cada repo. Revisión humana.
+
+## 12. Riesgos
+
+| Riesgo | Mitigación |
+|---|---|
+| **B5 deja media plantilla sin IPS** | La consulta de §9.1 es bloqueante del deploy, no del merge |
+| **B9: el fix parece aplicado y no funciona** (self-invocation) | Worker bean aparte, no anotación. Prueba en runtime obligatoria, §4 |
+| B9: transacción por funcionario cambia el locking en lotes grandes | Medir con un lote real; el `catch` que hoy traga errores queda mejor, no peor |
+| **R1 se desborda: tres modelos de fila distintos** | Presupuestar como diseño. Si crece, sacarlo del lote y hacer B13 sin él |
+| R1 cambia los PDF sin querer | Comparar A4 + ticket 58 + ticket 80 antes/después; solo deben diferir los labels de `AGUINALDO` y `CREDITO_CONVENIO_CUOTA` |
+| B6: un automático borrado reaparece al Regenerar | Aceptado y documentado. La edición ya se comporta igual |
+| F8 mal clasifica | La query solo toca lo unánime; `BEGIN`/verificar/`COMMIT` |
+| B13 alarga el recibo | La banda iterable pagina sola. Cosmético |

--- a/docs/manuales-implementacion/rrhh/PLAN-LOTE-A-FIXES.md
+++ b/docs/manuales-implementacion/rrhh/PLAN-LOTE-A-FIXES.md
@@ -113,9 +113,11 @@ La mutation de un solo funcionario abre transacción propia y está sana. Solo l
 
 Ese es el peor tipo de fix posible: compila, pasa un review a simple vista, y el bug sigue exactamente igual.
 
-**Fix real — extraer un bean aparte.** Un `@Component LiquidacionLoteWorker` con el trabajo por funcionario anotado `@Transactional(propagation = REQUIRES_NEW)`, inyectado en `LiquidacionSueldoService`. La llamada `worker.generarBorradorNuevaTx(...)` sí atraviesa el proxy del otro bean.
+**Fix real — `TransactionTemplate` con `PROPAGATION_REQUIRES_NEW`** dentro de `generarLote`, y sacarle el `@Transactional` a `generarLote` y a `generarMes` (ninguno de los dos hace trabajo de DB propio).
 
-Alternativas descartadas: auto-inyección `@Lazy` de la clase en sí misma (funciona, pero es un ciclo que oscurece el diseño) y `TransactionTemplate` programático (funciona, pero deja la semántica transaccional escondida en el cuerpo del loop en vez de declarada).
+*Corregido durante la implementación:* el plan decía extraer un `@Component LiquidacionLoteWorker`. No es viable acá — el worker necesitaría `LiquidacionSueldoService` para llamar a `generarBorrador`, y el servicio necesitaría al worker: dependencia circular que `@AllArgsConstructor` (inyección por constructor) no resuelve. Auto-inyección `@Lazy` de la clase en sí misma tampoco: Lombok no propaga la anotación al parámetro del constructor sin configurar `lombok.copyableAnnotations`.
+
+`TransactionTemplate` no tiene ninguno de esos problemas: solo pide `PlatformTransactionManager`, que es un bean del framework.
 
 **Beneficio colateral:** hoy `:661` tiene un `catch (Exception ignored)` que se traga los fallos individuales. Con transacción propia por funcionario, el fallo de uno deja de poder tumbar a los ya commiteados — hoy sí puede, porque comparten transacción.
 
@@ -123,7 +125,7 @@ Alternativas descartadas: auto-inyección `@Lazy` de la clase en sí misma (func
 
 **Verificación de que el fix funciona:** no alcanza con leer el código. Hay que probar en runtime — cambiar el sueldo de un funcionario y generar el lote en la misma sesión, confirmando que toma el valor nuevo. Si se hubiera aplicado solo la anotación, esta prueba habría fallado y el review no.
 
-**Archivos:** `service/rrhh/LiquidacionSueldoService.java` + `service/rrhh/LiquidacionLoteWorker.java` (nuevo). Sin migración.
+**Archivos:** `service/rrhh/LiquidacionSueldoService.java`. Sin migración.
 
 ## 5. B13 — una penalización, un ítem
 

--- a/docs/manuales-implementacion/rrhh/PLAN-LOTE-A-FIXES.md
+++ b/docs/manuales-implementacion/rrhh/PLAN-LOTE-A-FIXES.md
@@ -281,6 +281,28 @@ Sin AOT entre fases; el gate real (`npm run check` en desktop, `./mvnw clean ver
 
 **Orden no negociable:** B1 y B3 en la misma fase (§2). R1 antes de B13, porque B13 toca `fechaItem` y R1 reorganiza ese archivo.
 
+## 10.5 Verificación en runtime (2026-08-20)
+
+Corrida contra el central local con la base `bodega_producto_devoluciones`, generando el lote
+completo desde el desktop web. **No alcanza con leer el código**: B9 falló dos diagnósticos
+estáticos seguidos antes de quedar bien.
+
+| Qué | Resultado |
+|---|---|
+| Lote completo | **"Borradores generados: 389"** — los 389 activos, sin fallos silenciosos |
+| `entityManager.clear()` no rompe el lote | ✅ Era el riesgo real del fix: vaciar el identity map con OSIV puede desprender entidades en uso |
+| Sueldo leído | `salario_base = 3.100.000`, el valor cambiado **directo en psql** sin pasar por la app |
+| **B5** | 389 liquidaciones, **1 solo** ítem `IPS_DESCUENTO`: el del único funcionario con `ips_activo = true` |
+| **B13** | Dos ítems separados, `QUEJA_CLIENTE: …` y `DANIO_MATERIAL: …`, con su `referencia_id`. Totales correctos |
+| **B6** | Ítems `Origen: AUTO` con botón de eliminar; confirmación con el aviso de "reaparece al regenerar"; borrado y totales recalculados (1.000.000 → 0) |
+
+**Penalizaciones con monto ≤ 0:** la base tenía una, un `TARDANZA` auto-generado en `0.00`.
+Con el filtro nuevo se saltea; antes sumaba cero y, si era la única, tampoco generaba ítem.
+Mismo total, sin regresión. Negativas no había ninguna.
+
+**Confirmado de paso:** el buscador global no encuentra "liquidacion" — hay que llegar por el
+menú. Es la issue desktop #235 en vivo.
+
 ## 11. Cierre
 
 1. `./mvnw clean verify` en central — incluye los tests que rompió el PR anterior por constructores nuevos.

--- a/docs/manuales-implementacion/rrhh/PLAN-LOTE-B-FEATS.md
+++ b/docs/manuales-implementacion/rrhh/PLAN-LOTE-B-FEATS.md
@@ -1,0 +1,303 @@
+# Plan — Lote B: features de RRHH
+
+> Rama: **`feat/rrhh-recibos-y-penalizaciones`** (central + desktop), sale de `develop`
+> **con el lote A ya mergeado**. Ver §0.3.
+> Origen: `docs/manuales-implementacion/BUGS-TESTEO-2026-08-18.md`.
+> Investigación item por item completada el 2026-08-19; cada sección cita `archivo:línea` verificado.
+
+## 0. Composición
+
+| # | Título | Veredicto de la investigación |
+|---|---|---|
+| **B12** | Select de operación en el ítem manual | La tabla catálogo **ya existe y está huérfana**. Ver §1 |
+| **B4** | CRUD de cargos en desktop | Backend completo. Hay un delete que miente, ver §2 |
+| **B7+B8** | Recibo: 2 vías, bruto en la firma, header de empresa | El `.jrxml` a tocar es el único sin test |
+| **B10** | Penalización automática por rango de fechas | Ya es idempotente. Más barato de lo estimado |
+| **B11** | Amonestaciones sin monto + contador + acta firmable | Reusar `Penalizacion`. `.jrxml` nuevo |
+| **B16** | Consolidar cuotas de venta a crédito | Solo impresión. Una línea si el lote A hizo R1 |
+
+**Salió del lote: F3** (recepción parcial de retiro de PDV). Tres razones, en §7.
+
+### 0.1 Migraciones
+
+Última aplicada: `V200.5`. Todas aditivas, sufijo `.5`.
+
+| Versión | Contenido | Item |
+|---|---|---|
+| `V201.5` | `configuracion_rrhh`: claves `EMPRESA_DIRECCION`, `EMPRESA_TELEFONO` | B7/B8 |
+| `V202.5` | `penalizacion`: `numero_advertencia`, `firmada`, `fecha_hecho` | B11 |
+| `V203.5` | `liquidacion_concepto`: completar el seed | B12 |
+| `V204.5` | `configuracion_rrhh`: flag de consolidación | B16 |
+
+**Las cuatro son central-only.** Verificado: de las 63 tablas en `central_pub`, **ninguna** es del schema `rrhh`. `V155.0` lo dice en su header: *"Ninguna tabla se replica a filiales (gestion central-only)"*.
+
+> ⚠️ **La primera versión de este plan ponía `direccion`/`telefono` en `empresarial.configuracion_general` con un `ALTER TABLE`. Eso rompía las filiales.** Esa tabla **sí** está publicada:
+>
+> ```
+> V0__initial_schema.sql:14081
+> ALTER PUBLICATION central_pub ADD TABLE ONLY empresarial.configuracion_general;
+> ```
+>
+> Sin lista de columnas (sintaxis pre-PG15), así que replica todas las que existan en central. Agregar columnas ahí sin agregarlas también en filial hace que el apply worker de la suscripción falle en cuanto central escriba esa fila — y el plan preveía justamente que un operador cargue los datos poco después del deploy. Es el mismo accidente que `V154.1`/`V84.1` documentan, y el repo ya tuvo que alinear esta tabla una vez: `filial/V88.3` existe para emparejar las columnas que central agregó en `V178.5` y `V184.5`.
+>
+> **Por qué mover a `configuracion_rrhh` y no escribir la migración compañera en filial:** además de eliminar el riesgo y la coordinación de deploy entre repos, la pantalla de configuración de RRHH **ya sabe editar claves de esa tabla**. Con `configuracion_general` habría que construir UI nueva para dos campos; con `configuracion_rrhh` el operador los carga desde donde ya carga los otros ~20 parámetros. Sale más barato y más seguro.
+
+### 0.2 Supuestos tomados
+
+Ninguno de estos bloquea el trabajo, pero todos son revertibles y conviene confirmarlos en el review:
+
+| # | Supuesto | Por qué |
+|---|---|---|
+| S1 | El header del recibo lleva razón social, RUC, dirección y teléfono. **Sin logo** | El pedido dice "los datos de la empresa"; el logo no se mencionó |
+| S2 | El header va **una sola vez** arriba; la frase "Recibí de…" va en **ambas** vías | Cada vía tiene que sostenerse sola como comprobante firmado |
+| S3 | Las advertencias no tienen niveles de gravedad | No se pidieron; agregar un nivel después es aditivo |
+| S4 | El contador de advertencias es acumulado histórico, filtrable por año en la UI | Es el dato crudo; el reset es política que se puede aplicar en la vista |
+| S5 | N advertencias no disparan nada automático | Automatizar consecuencias disciplinarias sin pedido explícito es de más |
+| S6 | El acta de advertencia es **solo PDF A4** | Dos firmas no entran legibles en 32/48 columnas de térmica |
+| S7 | El rango de penalizaciones se topa en 62 días | Evita recorrer meses de jornadas por un error de tipeo |
+| S8 | B16 aplica a la liquidación **mensual**, no al finiquito | El pedido habla de la hoja de liquidación mensual. **Ver la nota de abajo** |
+| S9 | B16 consolida en el recibo, **no** en la grilla de edición del borrador | Si la grilla agrupara, no se podría editar ni borrar una cuota puntual |
+
+> **S8 deja un hueco conocido.** `LiquidacionFinalService` (líneas ~352-380) **también** arma ítems `CREDITO_CONVENIO_CUOTA`, y por diseño toma **todas** las cuotas impagas — no solo las vencidas, como sí hace la mensual (`LiquidacionSueldoService:306`). O sea el finiquito puede tener *más* filas de crédito que la liquidación mensual, y el motivo que justifica B16 ("la hoja es muy extensa") aplica igual o peor ahí.
+>
+> No es un defecto funcional: las filas sin consolidar siguen siendo correctas. Pero el pedido habla de la liquidación mensual y extender el flag al finiquito sin pedirlo sería decidir por el usuario. Queda anotado para confirmarlo, no asumido.
+
+### 0.3 Por qué B va después de A, no en paralelo
+
+Tres archivos se tocan en los dos lotes:
+
+- `LiquidacionSueldoService` — B13 (A) y B12 (B) tocan la construcción de ítems
+- `ReciboLiquidacionService` — R1 y B13 (A), B12 y B16 (B)
+- `recibo-liquidacion.jrxml` — B7/B8 (B) sobre lo que R1 (A) reorganizó
+
+Con A mergeado el rebase es trivial. En paralelo es conflicto garantizado en el archivo más delicado del módulo.
+
+## 1. B12 — select de operación
+
+**El hallazgo:** `rrhh.liquidacion_concepto` existe desde la migración fundacional **`V154.0:61-92`**, con backend completo — entidad `LiquidacionConcepto`, repositorio, servicio con `findByCodigo`, resolver GraphQL con save/delete/paginado, y schema en `configuracion-rrhh.graphqls:30-95`.
+
+**Y está completamente huérfana.** No la referencia ningún servicio (`LiquidacionSueldoService`, `ReciboLiquidacionService`, `LiquidacionFinalService`) ni un solo archivo del desktop. Es scaffolding de Fase 0 que nunca se cableó.
+
+```sql
+CREATE TABLE rrhh.liquidacion_concepto (
+    id BIGSERIAL PRIMARY KEY,
+    codigo VARCHAR(50) NOT NULL UNIQUE,
+    descripcion VARCHAR(255),
+    es_haber BOOLEAN NOT NULL DEFAULT TRUE,
+    es_calculado_auto BOOLEAN NOT NULL DEFAULT FALSE,
+    activo BOOLEAN NOT NULL DEFAULT TRUE, ...);
+```
+
+`es_haber` es literalmente lo que pide el usuario: que la operación elegida determine sola si es haber o descuento. **B12 no es crear un catálogo — es terminar de conectar el que ya está.**
+
+**De dónde sale realmente "AJUSTE".** No es un `codigo` que exista en ningún lado. Nace en `ReciboLiquidacionService.operacion():180-196`, un `switch` hardcodeado sobre `codigo`. Los ítems manuales llevan `HABER_MANUAL`/`DESCUENTO_MANUAL`, caen al `default`, y con `manual == true` devuelven `"AJUSTE"`.
+
+Ese switch es una **segunda copia del catálogo**, ya desincronizada: no tiene case para `AGUINALDO` ni `CREDITO_CONVENIO_CUOTA`, así que esos dos ya imprimen "HABER"/"DESCUENTO" genérico. Reemplazarlo por un lookup a la tabla arregla B12 y ese defecto de paso.
+
+**El `.jrxml` imprime las dos columnas** — `operacion` (la categoría) y `observacion` (`it.getDescripcion()`, el texto libre). O sea el texto del usuario ya se imprime bien; lo que falla es la categoría. El select tiene que llenar el `codigo`; la descripción puede seguir siendo libre, o autocompletarse con el nombre del catálogo si el usuario no escribe nada.
+
+**El backend debe forzar el signo.** Hoy `agregarItemManual:373-381` confía ciegamente en el `tipo` que manda el frontend. Con catálogo, `tipo` se deriva de `esHaber` y se ignora lo que llegue del cliente — así una llamada GraphQL directa o un bug de UI no pueden crear un ítem con el signo invertido.
+
+**Ítems ya existentes:** no se toca el `codigo` de nada persistido. Se agregan `AJUSTE_HABER`/`AJUSTE_DESCUENTO` al catálogo como entrada genérica, y el `default` del lookup mantiene el comportamiento actual para los códigos legacy. Los recibos de liquidaciones ya pagadas siguen imprimiendo lo mismo que hoy.
+
+**Seed a completar (`V203.5`):** faltan en la tabla `JUSTIFICATIVO_DESCUENTO`, `CREDITO_CONVENIO_CUOTA`, `HABER_MANUAL`, `DESCUENTO_MANUAL` y las dos entradas de ajuste. `INSERT ... ON CONFLICT (codigo) DO NOTHING`. `COMISION` está seedeado y sin uso — se deja, no molesta.
+
+**Archivos:** `LiquidacionSueldoService` (`agregarItemManual`), `ReciboLiquidacionService` (`operacion`), `liquidacion-sueldo.graphqls`, migración; en desktop, el `mat-select` del diálogo de detalle + query nueva.
+
+## 2. B4 — CRUD de cargos
+
+**Backend listo.** `Cargo` vive en `empresarial` (no en `rrhh`): `id`, `nombre`, `descripcion`, `supervisadoPor` (autorreferencia), `sueldoBase`, `usuario`, `subcargoList`. `CargoGraphQL` ya expone `cargo(id)`, `cargos(page,size)`, `cargosSearch(texto)`, `countCargo()`, `saveCargo`, `deleteCargo`. La tabla existe desde `v26`. **Sin migración.**
+
+**Desktop tiene solo lectura:** `cargo.model.ts` sin `toInput()`, `cargo.service.ts` con `onGetAll`/`onSearch`, sin `saveCargo`/`deleteCargo`, sin componentes.
+
+**Plantilla a copiar:** `rrhh/motivo-vale/` (lista + diálogo de edición + queries + servicio). Es el CRUD más reciente y ya usa las convenciones actuales.
+
+**El delete miente, y hay que arreglarlo.** `CrudService.deleteById:62-70` (central, Java) envuelve el borrado en try/catch y **devuelve `false` ante cualquier excepción**, incluida la violación de FK de un cargo en uso. Del otro lado, `GenericCrudService.onDelete:588-591` (desktop, TypeScript — no hay una clase `CrudService` en desktop) toma como éxito cualquier respuesta sin `errors`. Resultado: borrar un cargo asignado a un funcionario no borra nada y la UI dice **"Eliminado con éxito"**.
+
+`Cargo` no tiene campo `activo`, así que tampoco hay baja lógica — solo borrado físico.
+
+**El fix es en el backend, no en el frontend.** Chequear el booleano de retorno no alcanza: un `Boolean` no distingue "está en uso" de "no existía" de "se cayó la DB" — solo dice "algo falló", sin poder explicárselo al usuario.
+
+El repo ya tiene el patrón correcto, en `ProveedorServicioGraphQL.java:82-93`, con un comentario que describe este mismo bug:
+
+```java
+/**
+ * CrudService.deleteById se traga la excepcion y devuelve false, asi que la violacion
+ * de FK llegaria al desktop como un "eliminado con exito" mentiroso. Chequeamos antes.
+ */
+public Boolean deleteProveedorServicio(Long id) throws GraphQLException {
+    Long terminales = terminalPosService.countByProveedorServicioId(id);
+    if (terminales != null && terminales > 0) {
+        throw new GraphQLException("No se puede eliminar: hay " + terminales + " terminal(es) POS vinculada(s)...");
+    }
+    return service.deleteById(id);
+}
+```
+
+Portar eso a `CargoGraphQL.deleteCargo`, contando las tres referencias que bloquean el borrado: `Funcionario.cargo`, `FuncionarioCargoHistorico.cargo` y `Cargo.supervisadoPor` (subcargos). El mensaje llega solo al desktop por `res.errors[0].message` — **sin tocar el frontend**.
+
+**Otros cuidados:** no hay validación de ciclos en `supervisadoPor` — al editar, excluir el propio cargo de las opciones. Y `CambioCargoDialogComponent` (legajo) usa el mismo `CargoService`: ampliar el modelo sin romperlo.
+
+**Registro:** entrada en el menú (`side-mini-variant.component.ts`, grupo *R.R.H.H. → Configuración*, con el `case` en `onItemClick()`) **y** en el buscador global (`search-bar.service.ts`, array `componenteList`). Los catálogos de `empresarial` hoy solo están en el buscador y los de RRHH solo en el menú; `Cargo` es de `empresarial` pero lo consume RRHH, así que va en los dos — y es justo lo que pide la issue desktop #235.
+
+## 3. B7 + B8 — el recibo de liquidación
+
+### 3.1 El test va primero
+
+`recibo-liquidacion.jrxml` es **el único de los tres recibos de RRHH sin test**. `ReciboFiniquitoJrxmlTest` y `ReciboRrhhJrxmlTest` existen; este no.
+
+Los `.jrxml` compilan en runtime. Un UUID duplicado al copiar el bloque de la segunda vía, o un paréntesis desbalanceado en una expresión, **no revienta en el build ni en CI: revienta al generar el PDF en producción**. Crear `ReciboLiquidacionJrxmlTest` calcado del de finiquito (compile + `fillReport` con params dummy + export) **antes** de tocar la plantilla.
+
+### 3.2 Lo que ya está resuelto
+
+- El parámetro `totalRecibido` que se pasa al jrxml **ya es** `liq.getTotalHaberes()`. Verificado que `totalHaberes` es el bruto real: `LiquidacionCalculator:35-49` suma todos los ítems `HABER` sin restar nada.
+- `recibo-finiquito.jrxml:166` **ya tiene** casi literal la frase de B8:
+
+  ```
+  "Recibi de la empresa " + $P{empresa} + " la suma de " + $P{totalEnLetras}
+  + " (Gs. " + $P{total} + ") en concepto de liquidacion final de haberes laborales."
+  ```
+
+  Se adapta, no se inventa.
+- `NumeroALetrasService` ya está inyectado y se usa en el helper `enLetras()`.
+
+### 3.3 Los cambios
+
+**B7.1 — bruto en la firma.** `ReciboLiquidacionService:116`: `enLetras(liq.getTotalNeto())` → `enLetras(liq.getTotalHaberes())`. En el `.jrxml`, la ocurrencia de `$P{totalNeto}` de la **línea 171** (el párrafo de firma) → `$P{totalRecibido}`.
+
+> **No tocar la de la línea 166.** Esa es el cuadro "Total a cobrar" del summary y tiene que seguir siendo el neto — es lo que el funcionario efectivamente cobra. Lo que cambia es solo la frase de recepción, que debe decir el bruto.
+
+**B7.2 — dos vías.** Duplicar el bloque dentro de la banda `<summary>` con offset en Y, **con UUIDs nuevos** (Jasper los exige únicos; copiar y pegar literal rompe). La banda pasa de `height=210` a ~440.
+
+**B7.3 — corte punteado.** Un `<line>` con `<pen lineStyle="Dotted"/>` de ancho completo (555pt) entre las dos vías.
+
+**B8.1 — header de empresa.** `ConfiguracionGeneral` tiene `razonSocial` y `ruc`, pero **no tiene dirección ni teléfono**. `Sucursal` tiene dirección y no teléfono. `Timbrado` los tiene todos pero es un objeto fiscal de SIFEN — traerlo obligaría a resolver el timbrado activo por sucursal para un recibo interno que no es documento tributario.
+
+Razón social y RUC se siguen leyendo de `ConfiguracionGeneral` (es lo que ya hace `razonSocial()`). Dirección y teléfono van como claves nuevas de `rrhh.configuracion_rrhh` en `V201.5` — ver el recuadro de §0.1 para por qué no en `configuracion_general`.
+
+```sql
+INSERT INTO rrhh.configuracion_rrhh (clave, valor, tipo, descripcion, creado_en)
+SELECT v.clave, v.valor, v.tipo, v.descripcion, now()
+FROM (VALUES
+    ('EMPRESA_DIRECCION', '', 'STRING', 'Direccion de la empresa, para el encabezado de los recibos'),
+    ('EMPRESA_TELEFONO',  '', 'STRING', 'Telefono de la empresa, para el encabezado de los recibos')
+) AS v(clave, valor, tipo, descripcion)
+WHERE NOT EXISTS (SELECT 1 FROM rrhh.configuracion_rrhh c WHERE c.clave = v.clave);
+```
+
+> **Alguien tiene que cargar esos dos valores** en cada instancia después del deploy, desde la pantalla de configuración de RRHH. Hasta entonces el header sale con razón social y RUC, y las dos líneas nuevas vacías.
+
+**B8.2 — la frase.** Reemplazar el bloque en mayúsculas actual por la redacción de §3.2, usando `$P{montoRecibido}` y `$P{montoEnLetras}` ya corregidos al bruto.
+
+### 3.4 El espacio
+
+A4 deja 802pt útiles (`pageHeight=842` menos márgenes 20+20). Lo fijo es header ampliado (~126) + `columnHeader` (18) + summary duplicado (~440) = **584pt**. A 15pt por fila de detalle, el techo real es **~14 ítems por página**.
+
+**Ese número es más ajustado de lo que parece**, porque B13 del lote A convierte el ítem único de "PENALIZACIONES" en uno por penalización. Un funcionario con vale + cuota de préstamo + bono + horas extra + tres penalizaciones desglosadas ya está en el límite. Jasper no parte la banda: si no entra, manda las dos vías enteras a una hoja nueva, que es exactamente lo contrario de lo pedido.
+
+Hay que **probarlo con una liquidación real cargada**, no con el datasource dummy del test, y con el peor caso que exista en la base. Si desborda: reducir la altura de fila del detalle, o compactar el bloque de firma.
+
+**Fuentes:** el jrxml usa solo `SansSerif`. Todo `<font>` nuevo lo mantiene explícito. No introducir ninguna fuente.
+
+## 4. B10 — penalizaciones por rango
+
+**Mejor de lo estimado: ya es idempotente**, y la guarda es más fina que "esta fecha ya corrió". `PenalizacionService.generarPenalizacionesAuto:92-155` chequea **por jornada individual** (`findByJornadaIdAndSucursalIdAndAutoGeneradaTrueAndAnuladaFalse`). Correr 1–5 y después 3–7 no duplica los días 3–5: cada jornada del solape ya tiene su penalización y se saltea.
+
+**Limitación:** la guarda es SELECT-then-INSERT a nivel aplicación, sin `UNIQUE` en DB. Dos corridas concurrentes sobre la misma jornada podrían colar un duplicado. Con un botón manual y un cron diario el riesgo es marginal; se anota, no se blinda en este PR.
+
+**El cambio:** un método de rango que **itere día por día llamando al existente**. Reusa toda la lógica (feriados, justificativos con `evitaPenalizacion`, tolerancia) y la idempotencia intacta, y cada día lleva su propia transacción — un rango largo no queda en una transacción única, y si un día falla los otros ya commitearon. El método de un solo día se conserva: lo usa `PenalizacionScheduler`.
+
+Mutation nueva `generarPenalizacionesAutoRango(desde, hasta)`, con el mismo gate `seg.requireAnyRole(seg.GESTIONAR)`. Tope de 62 días (S7).
+
+**Desktop:** el diálogo pasa de un `matDatepicker` a `mat-date-range-input`, validando `desde <= hasta` y el tope.
+
+## 5. B11 — amonestaciones
+
+**Reusar `Penalizacion`** con `tipo = ADVERTENCIA` (valor nuevo del enum) y `monto = 0`. `PenalizacionTipo` es un enum Java, así que agregar el valor requiere deploy — aceptable para un valor sin lógica condicional, y no justifica migrar a tabla solo por esto.
+
+Reusar evita duplicar repositorio, paginado con filtro por tipo, resolver, gating y generación de recibos, y mantiene la vista unificada del legajo.
+
+**Que no ensucie la liquidación.** Con `monto = 0` es inocuo en los dos builders de ítems: suman montos y emiten el ítem solo `if (pen.signum() > 0)`. Pero eso es una invariante implícita que depende de que nadie cargue un monto por accidente — nada en la entidad ni en la DB lo impide. Va el filtro explícito por tipo en `LiquidacionSueldoService:225` y `LiquidacionFinalService:356`.
+
+**Hay un tercer lugar, y es el que sí se rompe.** `DashboardRrhhService:144-149` también suma penalizaciones, **sin filtro de tipo y sin guarda de cero**:
+
+```java
+for (Penalizacion p : penalizacionRepository.findByFechaBetweenAndAnuladaFalse(desde, hasta)) {
+    penCant++;
+    if (p.getMonto() != null) penMonto = penMonto.add(p.getMonto());
+}
+```
+
+Alimenta los KPIs `penalizacionesMesCantidad` y `penalizacionesMesMonto` (`dashboard-rrhh.graphqls:10-11`). A diferencia de los otros dos, acá el monto 0 **no salva nada**: `penCant++` corre igual. Toda advertencia inflaría el contador de penalizaciones del mes. El filtro por tipo va también acá — es el único de los tres donde es obligatorio, no defensivo.
+
+**Contador: sale gratis.** `penalizacionesPage(page, size, funcionarioId, desde, hasta, tipo)` ya filtra por `tipo`, así que `totalElements` con `tipo: ADVERTENCIA` da el número sin tocar backend. Se muestra como un cuarto `dash-stat-chip` en el legajo, junto a los tres que ya están.
+
+**Campos nuevos (`V202.5`):** `numero_advertencia` (int), `firmada` (boolean), `fecha_hecho` (date, cuando el hecho no es el día del registro). Los tres nullable.
+
+**El acta.** `recibo-rrhh.jrxml` es la plantilla más cercana, pero tiene **una sola firma** y el acta necesita dos (funcionario y empresa). Va `.jrxml` nuevo — `reports/acta-advertencia.jrxml` — copiando su estructura de bandas y `SansSerif`, con parámetros `numeroAdvertencia`, `motivo`, `fechaHecho` y el bloque de firma duplicado en dos columnas. Más `ActaAdvertenciaJrxmlTest`, calcado de `ReciboRrhhJrxmlTest`.
+
+Método `actaAdvertenciaBase64(Long, Integer, boolean)` en `ReporteRrhhService`, con la misma firma que los otros cinco. Solo PDF A4 (S6).
+
+**Nota de orden:** el acta usa `razonSocialEmpresa():193-201`, que hoy devuelve solo el nombre. Si B7/B8 se hace antes en el mismo PR, el acta nace ya con RUC y dirección — vale la pena hacer B7/B8 primero para no tocar el jrxml nuevo dos veces.
+
+## 6. B16 — consolidar cuotas de venta a crédito
+
+**Se pueden distinguir de las de préstamo, sin ambigüedad.** Las de venta a crédito llevan `referenciaTipo = "CREDITO_CONVENIO_CUOTA"` (`LiquidacionSueldoService:317-318`), las de préstamo `"CPP_CUOTA"` (`:283-284`). Constantes distintas asignadas explícitamente, y ya usadas como discriminador en `aplicarEfectosCruzados`.
+
+**Consolidar solo en la impresión.** Este es el punto que decide el diseño: si se consolidara en el modelo, el ítem único perdería el `referenciaId` por cuota y `aplicarEfectosCruzados:617-624` no podría llamar `reconciliarPorCuota`. **Las cuotas nunca quedarían saldadas: plata descontada del sueldo y la deuda viva.** Eso descarta tanto el ítem consolidado con tabla puente como el de ids serializados — no por costo, por corrección.
+
+Y el motivo del pedido es explícito: *"la hoja de liquidación es muy extensa"*. Es un problema de presentación.
+
+**Con R1 hecho en el lote A**, el cambio es agrupar los ítems `CREDITO_CONVENIO_CUOTA` en una fila sumada dentro del armado común, cuando `getBoolean("LIQUIDACION_CONSOLIDAR_CUOTAS_CREDITO", false)` sea true.
+
+**Contingencia si R1 no está.** El lote A marca R1 como la fase con más chance de desbordarse (tres modelos de fila distintos, no una extracción mecánica). Antes de arrancar la fase 7 hay que **verificar la forma real con la que R1 quedó**, no asumir la planeada. Si R1 se sacó del lote A o salió con otra firma, B16 no queda bloqueado: se implementa replicando la agrupación en los tres generadores. Cuesta más y hay que verificar los tres formatos a mano, pero es viable. Lo que no es aceptable es tocar uno solo y dejar el ticket térmico desalineado del PDF.
+
+**La config es key/value** (`rrhh.configuracion_rrhh`), así que `V204.5` es un `INSERT` idempotente, no un `ALTER TABLE`. En desktop, un `toggle` en `configuracion-rrhh-catalogo.ts` — el widget ya existe (`PENALIZACION_AUTO_TARDANZA` lo usa).
+
+**El flag es global**, no por sucursal ni por funcionario. Si mañana se quiere consolidar en farmacia y no en bodega, no hay dónde colgar ese scope sin migrar la tabla.
+
+## 7. F3 — por qué sale del lote
+
+**1. Tiene una pregunta de negocio bloqueante.** Cuando tesorería recibe menos de lo declarado, no se puede deducir del código qué pasa con la diferencia. Tres modelos, tres diseños distintos: el retiro queda abierto con saldo pendiente; se cierra y la diferencia va como faltante de caja (ya existe el mecanismo — `OperacionFinanciera.diferencia` + `DiferenciaDestinoTipo`, que postea un `AJUSTE` rotulado sin crear Gasto/Vale real); o se le carga a `Retiro.responsable`. Elegir uno por cuenta propia es inventar política contable.
+
+**2. Toca filial, con riesgo de cortar la replicación.** `financiero.retiro` replica **central→filial** (`V155.1`), y el repo ya documenta el accidente en `V154.1`/`V84.1`: el apply worker de la suscripción falla si el enum local no conoce la etiqueta. Un `PARCIAL` nuevo en `estado_retiro` tiene que existir en **todas** las filiales antes de que central escriba una sola fila con ese valor — y las filiales se autoactualizan cada 15 minutos, así que hay ventana real para que una se quede atrás.
+
+**3. Es cross-repo** (central + filial + desktop) con deploy ordenado. No entra de colado en un lote de RRHH.
+
+**Lo que sí quedó resuelto:** "seleccionar qué monedas" son **divisas** (Gs/R$/US$), no denominaciones. `RetiroDetalle` es `(retiro, moneda, cantidad)` sin FK a `MonedaBilletes`; el PDV nunca registra billetes al retirar. Y hay patrón hermano listo para copiar: `MaletinTesoreriaService.ingresarMaletinCierre` ya recibe `List<Long> monedaIds`. Esa mitad es barata; la de recepción parcial es la cara.
+
+## 8. Fases y commits
+
+| Fase | Contenido | Commit |
+|---|---|---|
+| 1 | Test del recibo (§3.1) | `test(rrhh): cubrir la compilacion del recibo de liquidacion` |
+| 2 | `V201.5` + B7 + B8 | `feat(rrhh): recibo de liquidacion con datos de empresa y dos vias` |
+| 3 | `V203.5` + B12 | `feat(rrhh): catalogo de conceptos en el item manual de liquidacion` |
+| 4 | B4 | `feat(empresarial): abm de cargos` |
+| 5 | B10 | `feat(rrhh): generar penalizaciones automaticas por rango de fechas` |
+| 6 | `V202.5` + B11 | `feat(rrhh): amonestaciones con contador y acta firmable` |
+| 7 | `V204.5` + B16 | `feat(rrhh): consolidar cuotas de venta a credito en el recibo` |
+
+**Orden no negociable:** la fase 1 antes que la 2 (§3.1). B7/B8 antes que B11, para que el acta nazca con el header completo (§5).
+
+## 9. Cierre
+
+Igual que el lote A: `./mvnw clean verify`, `npm run check`, dos auditores de código, tests e2e/UI con Claude in Chrome, actualizar `BUGS-TESTEO-2026-08-18.md` y la skill `rrhh-expert`, commit, push, PR por repo, revisión humana.
+
+**Verificación específica de este lote:** generar el recibo con una liquidación real de muchos ítems y confirmar que las dos vías entran en una hoja (§3.4).
+
+## 10. Riesgos
+
+| Riesgo | Mitigación |
+|---|---|
+| **El `.jrxml` revienta recién en producción** | El test de la fase 1 es bloqueante, no opcional |
+| **Una migración corta la replicación a filiales** | Ninguna de las 4 toca una tabla publicada. Verificado, §0.1. Volver a verificarlo si se agrega una migración al lote |
+| Las dos vías desbordan a una segunda hoja | Techo real ~14 ítems. Probar con el peor caso real; compactar detalle o firma si pasa |
+| Nadie carga dirección/teléfono de la empresa | El header degrada a razón social + RUC. Avisar en el PR |
+| **B16 depende de la forma real de R1** | Verificar cómo quedó R1 antes de la fase 7. Camino alternativo en §6 |
+| B12 rompe recibos históricos | No se toca el `codigo` de nada persistido; el `default` mantiene el comportamiento |
+| B4: se borra un cargo en uso y la UI dice que salió bien | Pre-check + `GraphQLException` en el backend, patrón de `ProveedorServicioGraphQL` |
+| B11: una advertencia infla los KPIs del dashboard | Filtro por tipo en los **tres** lugares. En el dashboard el monto 0 no salva: cuenta filas |
+| B10: duplicado por concurrencia | Anotado. Sin `UNIQUE` en DB; riesgo marginal con un botón y un cron |
+| B16: el flag es global | Anotado. No hay scope por sucursal sin migrar la tabla |
+| B16: el finiquito queda sin consolidar | Anotado en §0.2. A confirmar, no asumido |

--- a/src/main/java/com/franco/dev/graphql/rrhh/ConfiguracionRrhhGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/rrhh/ConfiguracionRrhhGraphQL.java
@@ -87,11 +87,17 @@ public class ConfiguracionRrhhGraphQL implements GraphQLQueryResolver, GraphQLMu
      * Sube al minimo los sueldos elegidos por el usuario. Nunca se dispara solo:
      * el desktop muestra la lista y el usuario tilda a quienes ajustar.
      */
-    public Integer ajustarSalariosAlMinimo(List<Long> funcionarioIds, java.math.BigDecimal minimo,
+    public Integer ajustarSalariosAlMinimo(List<Integer> funcionarioIds, java.math.BigDecimal minimo,
                                            Long usuarioId) {
         seg.requireAnyRole(seg.CONFIG);
+        // [Int] de GraphQL llega como List<Integer>; kickstart no convierte los elementos.
+        // Declarar List<Long> aca no sirve: el borrado de tipos deja pasar los Integer y el
+        // unboxing del for-each en ajustarAlMinimo tira ClassCastException. Mismo patron que
+        // LiquidacionSueldoGraphQL.generarLiquidacionesLote.
+        List<Long> ids = funcionarioIds == null ? null
+                : funcionarioIds.stream().map(Integer::longValue).collect(java.util.stream.Collectors.toList());
         Usuario u = usuarioId != null ? usuarioService.findById(usuarioId).orElse(null) : null;
-        return ajusteSalarioMinimoService.ajustarAlMinimo(funcionarioIds, minimo, u);
+        return ajusteSalarioMinimoService.ajustarAlMinimo(ids, minimo, u);
     }
 
     public ConfiguracionRrhh saveConfiguracionRrhh(ConfiguracionRrhhInput input) {

--- a/src/main/java/com/franco/dev/graphql/rrhh/ConfiguracionRrhhGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/rrhh/ConfiguracionRrhhGraphQL.java
@@ -95,7 +95,8 @@ public class ConfiguracionRrhhGraphQL implements GraphQLQueryResolver, GraphQLMu
         // unboxing del for-each en ajustarAlMinimo tira ClassCastException. Mismo patron que
         // LiquidacionSueldoGraphQL.generarLiquidacionesLote.
         List<Long> ids = funcionarioIds == null ? null
-                : funcionarioIds.stream().map(Integer::longValue).collect(java.util.stream.Collectors.toList());
+                : funcionarioIds.stream().filter(java.util.Objects::nonNull)
+                        .map(Integer::longValue).collect(java.util.stream.Collectors.toList());
         Usuario u = usuarioId != null ? usuarioService.findById(usuarioId).orElse(null) : null;
         return ajusteSalarioMinimoService.ajustarAlMinimo(ids, minimo, u);
     }

--- a/src/main/java/com/franco/dev/graphql/rrhh/PenalizacionGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/rrhh/PenalizacionGraphQL.java
@@ -78,6 +78,15 @@ public class PenalizacionGraphQL implements GraphQLQueryResolver, GraphQLMutatio
 
     public Penalizacion savePenalizacion(PenalizacionInput input) {
         seg.requireAnyRole(seg.GESTIONAR);
+        // Una penalizacion es siempre un descuento positivo. Un monto negativo cargado como
+        // "correccion" de otra penalizacion genera su propio item de DESCUENTO en la
+        // liquidacion, donde no se compensa con nada: el funcionario termina cobrando de
+        // menos y en el recibo no se ve por que. Para corregir hay que anular y volver a
+        // cargar, que es lo que deja rastro.
+        if (input.getMonto() != null && input.getMonto().signum() < 0) {
+            throw new graphql.GraphQLException(
+                    "El monto de una penalizacion no puede ser negativo. Para corregir una penalizacion, anulala y carga la nueva.");
+        }
         Penalizacion e = input.getId() != null
                 ? service.findById(input.getId()).orElse(new Penalizacion())
                 : new Penalizacion();

--- a/src/main/java/com/franco/dev/service/rrhh/LiquidacionSueldoService.java
+++ b/src/main/java/com/franco/dev/service/rrhh/LiquidacionSueldoService.java
@@ -208,10 +208,14 @@ public class LiquidacionSueldoService extends CrudService<LiquidacionSueldo, Liq
         // SALARIO_BASE (HABER)
         items.add(item(liq, "SALARIO_BASE", "SALARIO BASE", salarioBase, LiquidacionItemTipo.HABER, null, null));
 
-        // IPS_DESCUENTO (DESC)
-        BigDecimal ipsPct = configuracionRrhhService.getNumber("IPS_PORCENTAJE_FUNCIONARIO", new BigDecimal("9"));
-        BigDecimal ips = salarioBase.multiply(ipsPct).divide(new BigDecimal("100"), 2, RoundingMode.HALF_UP);
-        if (ips.signum() > 0) items.add(item(liq, "IPS_DESCUENTO", "DESCUENTO IPS", ips, LiquidacionItemTipo.DESCUENTO, null, null));
+        // IPS_DESCUENTO (DESC) — solo si el funcionario aporta. El null se trata como
+        // activo (mismo criterio que LiquidacionFinalService): solo un false explicito
+        // en el legajo desactiva el descuento.
+        if (!Boolean.FALSE.equals(f.getIpsActivo())) {
+            BigDecimal ipsPct = configuracionRrhhService.getNumber("IPS_PORCENTAJE_FUNCIONARIO", new BigDecimal("9"));
+            BigDecimal ips = salarioBase.multiply(ipsPct).divide(new BigDecimal("100"), 2, RoundingMode.HALF_UP);
+            if (ips.signum() > 0) items.add(item(liq, "IPS_DESCUENTO", "DESCUENTO IPS", ips, LiquidacionItemTipo.DESCUENTO, null, null));
+        }
 
         // HORA_EXTRA (HABER)
         BigDecimal he = BigDecimal.ZERO;

--- a/src/main/java/com/franco/dev/service/rrhh/LiquidacionSueldoService.java
+++ b/src/main/java/com/franco/dev/service/rrhh/LiquidacionSueldoService.java
@@ -79,6 +79,14 @@ public class LiquidacionSueldoService extends CrudService<LiquidacionSueldo, Liq
     private final CreditoConvenioService creditoConvenioService;
     private final PlatformTransactionManager transactionManager;
 
+    /**
+     * Inyectado por campo a proposito: @AllArgsConstructor solo toma los final, y este no
+     * puede serlo. Se usa en generarLote para vaciar el cache de primer nivel entre
+     * funcionarios — ver el comentario ahi.
+     */
+    @javax.persistence.PersistenceContext
+    private javax.persistence.EntityManager entityManager;
+
     @Override
     public LiquidacionSueldoRepository getRepository() {
         return repository;
@@ -111,6 +119,9 @@ public class LiquidacionSueldoService extends CrudService<LiquidacionSueldo, Liq
      * un periodo 'YYYY-MM'. Preserva los items manuales; recalcula los
      * automaticos. Espejo del algoritmo de FRC Gourmet.
      */
+    // OJO: esta anotacion solo aplica cuando el metodo se invoca desde afuera (por el
+    // proxy de Spring). generarLote lo llama desde la misma clase, asi que ahi no rige:
+    // el aislamiento por funcionario lo pone el TransactionTemplate de aquel metodo.
     @Transactional
     public LiquidacionSueldo generarBorrador(Long funcionarioId, String periodo, Long monedaId) {
         Funcionario f = funcionarioService.findById(funcionarioId).orElse(null);
@@ -665,14 +676,10 @@ public class LiquidacionSueldoService extends CrudService<LiquidacionSueldo, Liq
             }
         }
 
-        // Una transaccion por funcionario, no una sola para el lote entero. Dos razones:
-        //
-        // 1. Con transaccion compartida, generarBorrador recibe del identity map de
-        //    Hibernate el Funcionario que este metodo ya cargo arriba, no la fila fresca:
-        //    si el sueldo cambio despues de esa lectura, la liquidacion sale con el viejo.
-        // 2. El catch de abajo se traga el fallo de un funcionario para seguir con los
-        //    demas, pero compartiendo transaccion ese fallo puede marcar rollback-only y
-        //    tumbar tambien a los que ya se procesaron bien.
+        // Una transaccion por funcionario, no una sola para el lote entero: el catch de
+        // abajo se traga el fallo de un funcionario para seguir con los demas, y
+        // compartiendo transaccion ese fallo puede marcar rollback-only y tumbar tambien a
+        // los que ya se procesaron bien.
         //
         // Va con TransactionTemplate y no con @Transactional(REQUIRES_NEW) sobre
         // generarBorrador: la llamada de abajo es self-invocation (mismo bean), no pasa
@@ -683,7 +690,18 @@ public class LiquidacionSueldoService extends CrudService<LiquidacionSueldo, Liq
         int n = 0;
         for (Long id : objetivo) {
             try {
-                tx.execute(status -> generarBorrador(id, periodo, monedaId));
+                tx.execute(status -> {
+                    // Vaciar el cache de primer nivel ANTES de cada funcionario. La
+                    // transaccion nueva no alcanza: la app corre con
+                    // OpenEntityManagerInViewFilter (FrancoSystemsApplication.OpenFilter) y
+                    // sin spring.jpa.open-in-view=false, asi que hay un EntityManager atado
+                    // al hilo para toda la request. JpaTransactionManager.doBegin lo
+                    // reutiliza en vez de crear uno nuevo, y sin este clear el findById de
+                    // generarBorrador devolveria el Funcionario que el loop de arriba ya
+                    // cargo — con el sueldo viejo si cambio despues de esa lectura.
+                    entityManager.clear();
+                    return generarBorrador(id, periodo, monedaId);
+                });
                 n++;
             } catch (Exception ignored) {
             }

--- a/src/main/java/com/franco/dev/service/rrhh/LiquidacionSueldoService.java
+++ b/src/main/java/com/franco/dev/service/rrhh/LiquidacionSueldoService.java
@@ -21,7 +21,10 @@ import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -74,6 +77,7 @@ public class LiquidacionSueldoService extends CrudService<LiquidacionSueldo, Liq
     private final com.franco.dev.repository.financiero.PagoSolicitudDetalleRepository pagoSolicitudDetalleRepository;
     private final com.franco.dev.service.administrativo.JornadaService jornadaService;
     private final CreditoConvenioService creditoConvenioService;
+    private final PlatformTransactionManager transactionManager;
 
     @Override
     public LiquidacionSueldoRepository getRepository() {
@@ -633,7 +637,6 @@ public class LiquidacionSueldoService extends CrudService<LiquidacionSueldo, Liq
     }
 
     /** Genera borradores para todos los funcionarios activos en un periodo. */
-    @Transactional
     public int generarMes(String periodo, Long monedaId) {
         return generarLote(null, periodo, monedaId);
     }
@@ -643,24 +646,37 @@ public class LiquidacionSueldoService extends CrudService<LiquidacionSueldo, Liq
      * corre para todos los activos; si no, solo para los indicados. Los que ya estan
      * APROBADA/PAGADA se saltean en silencio (generarBorrador tira, se ignora).
      */
-    @Transactional
     public int generarLote(List<Long> funcionarioIds, String periodo, Long monedaId) {
-        List<Funcionario> objetivo;
+        List<Long> objetivo = new ArrayList<>();
         if (funcionarioIds == null || funcionarioIds.isEmpty()) {
-            objetivo = new ArrayList<>();
             for (Funcionario f : funcionarioService.findAll2()) {
-                if (Boolean.TRUE.equals(f.getActivo())) objetivo.add(f);
+                if (Boolean.TRUE.equals(f.getActivo())) objetivo.add(f.getId());
             }
         } else {
-            objetivo = new ArrayList<>();
             for (Long id : funcionarioIds) {
-                funcionarioService.findById(id).ifPresent(objetivo::add);
+                funcionarioService.findById(id).ifPresent(f -> objetivo.add(f.getId()));
             }
         }
+
+        // Una transaccion por funcionario, no una sola para el lote entero. Dos razones:
+        //
+        // 1. Con transaccion compartida, generarBorrador recibe del identity map de
+        //    Hibernate el Funcionario que este metodo ya cargo arriba, no la fila fresca:
+        //    si el sueldo cambio despues de esa lectura, la liquidacion sale con el viejo.
+        // 2. El catch de abajo se traga el fallo de un funcionario para seguir con los
+        //    demas, pero compartiendo transaccion ese fallo puede marcar rollback-only y
+        //    tumbar tambien a los que ya se procesaron bien.
+        //
+        // Va con TransactionTemplate y no con @Transactional(REQUIRES_NEW) sobre
+        // generarBorrador: la llamada de abajo es self-invocation (mismo bean), no pasa
+        // por el proxy de Spring y la anotacion se ignoraria en silencio.
+        TransactionTemplate tx = new TransactionTemplate(transactionManager);
+        tx.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+
         int n = 0;
-        for (Funcionario f : objetivo) {
+        for (Long id : objetivo) {
             try {
-                generarBorrador(f.getId(), periodo, monedaId);
+                tx.execute(status -> generarBorrador(id, periodo, monedaId));
                 n++;
             } catch (Exception ignored) {
             }

--- a/src/main/java/com/franco/dev/service/rrhh/LiquidacionSueldoService.java
+++ b/src/main/java/com/franco/dev/service/rrhh/LiquidacionSueldoService.java
@@ -228,12 +228,19 @@ public class LiquidacionSueldoService extends CrudService<LiquidacionSueldo, Liq
         }
         if (he.signum() > 0) items.add(item(liq, "HORA_EXTRA", "HORAS EXTRA", he, LiquidacionItemTipo.HABER, null, null));
 
-        // PENALIZACION (DESC)
-        BigDecimal pen = BigDecimal.ZERO;
+        // PENALIZACION (DESC) — un item por penalizacion, no uno consolidado. Con un solo
+        // item de "PENALIZACIONES" el funcionario recibe un monto sin poder saber de que
+        // se le descuenta, y sin referenciaId el item no se puede rastrear hasta su origen.
+        // La descripcion lleva "TIPO: descripcion" para que el recibo lo explique solo.
         for (Penalizacion p : penalizacionRepository.findByFuncionarioIdAndFechaBetweenAndAnuladaFalse(fid, inicio, fin)) {
-            if (p.getMonto() != null) pen = pen.add(p.getMonto());
+            if (p.getMonto() == null || p.getMonto().signum() <= 0) continue;
+            String desc = p.getTipo() != null ? p.getTipo().name() : "PENALIZACION";
+            if (p.getDescripcion() != null && !p.getDescripcion().trim().isEmpty()) {
+                desc = desc + ": " + p.getDescripcion().trim();
+            }
+            items.add(item(liq, "PENALIZACION", desc, p.getMonto(),
+                    LiquidacionItemTipo.DESCUENTO, p.getId(), "PENALIZACION"));
         }
-        if (pen.signum() > 0) items.add(item(liq, "PENALIZACION", "PENALIZACIONES", pen, LiquidacionItemTipo.DESCUENTO, null, null));
 
         // JUSTIFICATIVO_DESCUENTO (DESC) — dias justificados cuyo TIPO descuenta salario.
         // Cuanto descuenta cada tipo lo define el catalogo (MEDIO_DIA / DIA_COMPLETO),

--- a/src/main/java/com/franco/dev/service/rrhh/ReciboLiquidacionService.java
+++ b/src/main/java/com/franco/dev/service/rrhh/ReciboLiquidacionService.java
@@ -6,6 +6,7 @@ import com.franco.dev.domain.rrhh.LiquidacionItem;
 import com.franco.dev.domain.rrhh.LiquidacionSueldo;
 import com.franco.dev.domain.rrhh.enums.LiquidacionItemTipo;
 import com.franco.dev.repository.rrhh.BonoRepository;
+import com.franco.dev.repository.rrhh.PenalizacionRepository;
 import com.franco.dev.repository.rrhh.PrestamoCuotaRepository;
 import com.franco.dev.repository.rrhh.VacacionVentaRepository;
 import com.franco.dev.repository.rrhh.ValeRepository;
@@ -52,6 +53,7 @@ public class ReciboLiquidacionService {
     private final BonoRepository bonoRepository;
     private final VacacionVentaRepository vacacionVentaRepository;
     private final PrestamoCuotaRepository prestamoCuotaRepository;
+    private final PenalizacionRepository penalizacionRepository;
     private final DecimalFormat formato = new DecimalFormat("#,##0.##");
     private final DecimalFormat formatoGs = new DecimalFormat("#,##0");   // guaraníes sin decimales (ticket)
 
@@ -61,7 +63,8 @@ public class ReciboLiquidacionService {
                                     ValeRepository valeRepository,
                                     BonoRepository bonoRepository,
                                     VacacionVentaRepository vacacionVentaRepository,
-                                    PrestamoCuotaRepository prestamoCuotaRepository) {
+                                    PrestamoCuotaRepository prestamoCuotaRepository,
+                                    PenalizacionRepository penalizacionRepository) {
         this.liquidacionSueldoService = liquidacionSueldoService;
         this.configuracionGeneralService = configuracionGeneralService;
         this.numeroALetrasService = numeroALetrasService;
@@ -69,6 +72,7 @@ public class ReciboLiquidacionService {
         this.bonoRepository = bonoRepository;
         this.vacacionVentaRepository = vacacionVentaRepository;
         this.prestamoCuotaRepository = prestamoCuotaRepository;
+        this.penalizacionRepository = penalizacionRepository;
     }
 
     @Transactional(readOnly = true)
@@ -242,6 +246,9 @@ public class ReciboLiquidacionService {
                     break;
                 case "CPP_CUOTA":
                     f = prestamoCuotaRepository.findById(ref).map(c -> c.getFechaVencimiento()).orElse(null);
+                    break;
+                case "PENALIZACION":
+                    f = penalizacionRepository.findById(ref).map(p -> p.getFecha()).orElse(null);
                     break;
                 default:
                     break;

--- a/src/main/java/com/franco/dev/service/rrhh/ReciboLiquidacionService.java
+++ b/src/main/java/com/franco/dev/service/rrhh/ReciboLiquidacionService.java
@@ -86,7 +86,7 @@ public class ReciboLiquidacionService {
         }
 
         List<ReciboLiquidacionItemDto> filas = new ArrayList<>();
-        for (LiquidacionItem it : liquidacionSueldoService.findItems(liquidacionId)) {
+        for (LiquidacionItem it : itemsParaImpresion(liquidacionId)) {
             filas.add(new ReciboLiquidacionItemDto(
                     operacion(it),
                     it.getTipo() == LiquidacionItemTipo.HABER ? "ENTRADA" : "SALIDA",
@@ -129,11 +129,9 @@ public class ReciboLiquidacionService {
     /** Recibo de sueldo en ESC/POS (base64) para impresión térmica local del cliente. */
     private String generarTicketEscPos(LiquidacionSueldo liq, Integer anchoMm) {
         List<com.franco.dev.utilitarios.print.ReciboTicketEscPos.Row> rows = new ArrayList<>();
-        for (LiquidacionItem it : liquidacionSueldoService.findItems(liq.getId())) {
-            String monto = formatoGs.format(it.getMonto() != null ? it.getMonto() : BigDecimal.ZERO);
-            if (it.getTipo() == LiquidacionItemTipo.DESCUENTO) monto = "(" + monto + ")";
-            String concepto = it.getDescripcion() != null ? it.getDescripcion() : operacion(it);
-            rows.add(new com.franco.dev.utilitarios.print.ReciboTicketEscPos.Row(concepto, monto));
+        for (LiquidacionItem it : itemsParaImpresion(liq.getId())) {
+            rows.add(new com.franco.dev.utilitarios.print.ReciboTicketEscPos.Row(
+                    conceptoTicket(it), montoTicket(it)));
         }
         BigDecimal neto = liq.getTotalNeto() != null ? liq.getTotalNeto() : BigDecimal.ZERO;
         return com.franco.dev.utilitarios.print.ReciboTicketEscPos.build(
@@ -146,11 +144,8 @@ public class ReciboLiquidacionService {
     /** Recibo de sueldo en formato ticket (58/80mm), plantilla genérica concepto/monto. */
     private String generarTicket(LiquidacionSueldo liq, Integer anchoMm) {
         List<ReporteRrhhService.FiniquitoRow> filas = new ArrayList<>();
-        for (LiquidacionItem it : liquidacionSueldoService.findItems(liq.getId())) {
-            String monto = formatoGs.format(it.getMonto() != null ? it.getMonto() : BigDecimal.ZERO);
-            if (it.getTipo() == LiquidacionItemTipo.DESCUENTO) monto = "(" + monto + ")";
-            String concepto = it.getDescripcion() != null ? it.getDescripcion() : operacion(it);
-            filas.add(new ReporteRrhhService.FiniquitoRow(concepto, monto));
+        for (LiquidacionItem it : itemsParaImpresion(liq.getId())) {
+            filas.add(new ReporteRrhhService.FiniquitoRow(conceptoTicket(it), montoTicket(it)));
         }
         if (filas.isEmpty()) filas.add(new ReporteRrhhService.FiniquitoRow("SIN ITEMS", "0"));
 
@@ -177,6 +172,33 @@ public class ReciboLiquidacionService {
         }
     }
 
+    /**
+     * Items tal como se imprimen, para los tres formatos (PDF A4, ticket PDF y ESC/POS).
+     *
+     * <p>Punto unico donde se aplica cualquier politica de presentacion: agrupar varios
+     * items en una linea o desglosar uno en varias. Hoy devuelve los items tal cual.</p>
+     *
+     * <p>Existe porque los tres generadores construyen sus filas por separado y con
+     * modelos distintos — el A4 tiene 5 columnas y marca el signo con ENTRADA/SALIDA, los
+     * tickets tienen 2 y lo marcan con parentesis. Sin este punto en comun, cada cambio de
+     * presentacion hay que escribirlo tres veces y alcanza con olvidarse de uno para que
+     * el ticket termico y el PDF muestren cosas distintas de la misma liquidacion.</p>
+     */
+    private List<LiquidacionItem> itemsParaImpresion(Long liquidacionId) {
+        return liquidacionSueldoService.findItems(liquidacionId);
+    }
+
+    /** Concepto de una fila de ticket: la descripcion del item, o su categoria si no tiene. */
+    private String conceptoTicket(LiquidacionItem it) {
+        return it.getDescripcion() != null ? it.getDescripcion() : operacion(it);
+    }
+
+    /** Monto de una fila de ticket. Los descuentos van entre parentesis (no hay columna de signo). */
+    private String montoTicket(LiquidacionItem it) {
+        String monto = formatoGs.format(it.getMonto() != null ? it.getMonto() : BigDecimal.ZERO);
+        return it.getTipo() == LiquidacionItemTipo.DESCUENTO ? "(" + monto + ")" : monto;
+    }
+
     /** Categoria del movimiento a partir del codigo del item, como en el recibo modelo. */
     private String operacion(LiquidacionItem it) {
         String c = it.getCodigo() != null ? it.getCodigo() : "";
@@ -189,6 +211,8 @@ public class ReciboLiquidacionService {
             case "ADELANTO_DESCUENTO": return "ANTICIPOS";
             case "PRESTAMO_CUOTA": return "PRESTAMO";
             case "VACACION_VENTA": return "VACACIONES";
+            case "AGUINALDO": return "AGUINALDO";
+            case "CREDITO_CONVENIO_CUOTA": return "CREDITO";
             case "PENALIZACION":
             case "JUSTIFICATIVO_DESCUENTO": return "DESCUENTOS";
             default: return Boolean.TRUE.equals(it.getManual()) ? "AJUSTE"


### PR DESCRIPTION
Lote A de la lista de hallazgos de `BUGS-TESTEO-2026-08-18.md`. Siete arreglos y un refactor habilitador, todos investigados item por item y auditados por dos revisiones independientes antes y después de escribir el código.

Plan completo: `docs/manuales-implementacion/rrhh/PLAN-LOTE-A-FIXES.md`.

## Qué resuelve

| # | Problema | Causa raíz |
|---|---|---|
| **B1** | El ajuste de salario mínimo no persistía nada | El schema declara `[Int]` y el resolver recibía `List<Long>`. Kickstart puebla la lista con `Integer` sin mirar el genérico; el unboxing del for-each tiraba `ClassCastException` en el primer elemento, y como el método es `@Transactional`, no se guardaba ni un ajuste |
| **B5** | El toggle de IPS del legajo se ignoraba | `construirItemsAutomaticos` armaba el descuento incondicional. `ipsActivo` no aparecía ni una vez en el servicio |
| **B9** | La generación masiva tomaba el salario viejo | Dos causas: consecuencia de B1, y el caché de primer nivel de Hibernate compartido en el lote |
| **B13** | Penalizaciones consolidadas en un ítem sin detalle | Se emitían sumadas, con `referenciaId` en `null` |
| **F8** | Los movimientos históricos siguen diciendo "Compra" | El motor de pago grababa siempre `PAGO_CPP` antes del fix de F4 |
| **R1** | *(refactor)* Tres generadores del recibo desalineables | `generarBase64`, `generarTicket` y `generarTicketEscPos` recorrían `findItems()` por separado |

## Dos trampas que costaron un diagnóstico cada una

**Self-invocation.** `generarLote` llama `generarBorrador(...)` sin calificar, dentro de la misma clase. Con proxies de Spring eso no pasa por el proxy, así que anotar `@Transactional(REQUIRES_NEW)` se ignora en silencio: compila, pasa review, y el bug queda igual. Va con `TransactionTemplate`.

**OSIV.** `FrancoSystemsApplication.OpenFilter()` registra `OpenEntityManagerInViewFilter` sin restricción de URL y no hay `spring.jpa.open-in-view=false` en ningún properties. `JpaTransactionManager.doBegin` reutiliza el `EntityManager` atado al hilo en vez de crear uno: transacción JDBC nueva sí, persistence context nuevo no. Hace falta `entityManager.clear()` explícito.

> Esto vale para todo el repo, no solo RRHH: **abrir una transacción nueva no da un identity map limpio**.

## Guarda nueva: penalizaciones negativas

`savePenalizacion` ahora rechaza montos negativos. Con un ítem por penalización, un negativo cargado como "corrección" genera su propio ítem de DESCUENTO que no se compensa con nada — el funcionario cobra de menos y el recibo no explica por qué. Para corregir hay que anular y volver a cargar.

## Cómo probarlo

1. **B1 + B9** — cambiá el sueldo de un funcionario y generá el lote del período. El `salario_base` tiene que salir con el valor nuevo.
2. **B5** — poné el toggle de IPS en `false` en el legajo y generá. No debe aparecer el ítem `IPS_DESCUENTO`.
3. **B13** — cargá dos penalizaciones de tipos distintos en el período y generá. Tienen que salir dos ítems separados, con `TIPO: descripción` y su `referenciaId`.
4. **R1** — generá el recibo en PDF A4, ticket 58 y ticket 80 de la misma liquidación. Salvo las categorías nuevas de `AGUINALDO` y `CREDITO_CONVENIO_CUOTA`, tienen que salir idénticos a antes.

### Ya verificado en runtime

Contra el central local, generando el lote completo desde el desktop web: **389 borradores, sin fallos silenciosos**. `salario_base` leyó un sueldo cambiado directo en psql. De las 389 liquidaciones, **un solo** ítem de IPS — el del único funcionario con `ips_activo = true`. Penalizaciones desglosadas con su referencia. Totales correctos.

`./mvnw clean verify`: **318 tests, 0 fallos.**

## Impacto en DB

**Ninguna migración.** El único cambio de datos es `docs/manuales-implementacion/financiero/backfill-origen-tipo.sql`, que es un **script manual** y no corre solo.

Va fuera de Flyway porque hay tres clases de fila que no se pueden derivar (eventos mixtos, RRHH sin tabla puente, y pagos anteriores a `V182.5`), y una migración corre ciega al bootear sin que nadie vea los conteos. Son tres instancias con historiales distintos. La query solo reclasifica cuando el tipo de solicitud es unánime y deja lo ambiguo en `PAGO_CPP`, cuyo label es "Compra". Es idempotente.

**Filial no se toca**: `movimiento_caja_virtual` no existe en su schema ni está en ninguna publicación de replicación.

## Antes de deployar

```sql
select ips_activo, count(*) from personas.funcionario where activo group by ips_activo;
```

`V154.0:23` creó la columna con `DEFAULT false`, así que Postgres persistió `false` en todas las filas que ya existían — en dev son **388 de 389**. Si prod se parece, respetar el flag deja a casi toda la nómina sin aporte el primer mes. Hay que mirar el reparto real por instancia antes de subir esto.

## Rollback

Todo es código, sin schema. Volver a la versión anterior alcanza. El backfill de F8 no se revierte solo — pero solo cambia una etiqueta de presentación, no plata.

**Riesgo: medio.** B5 y B13 cambian montos y estructura de liquidaciones nuevas; ninguna liquidación ya `APROBADA`/`PAGADA` se recalcula.

## Se decidió dejar afuera

- **B2** — no hay código que arreglar: la cadena schema → repository → query → template está correcta. Es data sucia (75 funcionarios con `sueldo` entre 1 y 30). Queda como verificación, no como fix.
- **B15** — no es un fix. "Vacaciones proporcionales" no existe en el código, y quedan ~8 preguntas de negocio abiertas. Va con B14.

PR hermano en desktop: GabFrank/frc-sistemas-integrados-angular

🤖 Generated with [Claude Code](https://claude.com/claude-code)
