### PR TITLE
feat(rrhh): base remunerativa unica para aguinaldo, indemnizacion e IPS del finiquito

### DIFF
--- a/docs/manuales-implementacion/BUGS-TESTEO-2026-08-18.md
+++ b/docs/manuales-implementacion/BUGS-TESTEO-2026-08-18.md
@@ -3,7 +3,25 @@
 Registro de errores encontrados probando el módulo RRHH en desktop (rama `develop`)
 contra central local. **Sin investigar todavía** — solo captura del síntoma.
 
-Estados: 🔴 abierto · 🟡 en análisis · 🟢 corregido
+Estados: 🔴 abierto · 🟡 en análisis · 🟢 corregido · ✅ cerrado en un PR
+
+**Al 2026-08-21 — 19 de 24 cerrados.**
+
+| Lote | Rama | PRs |
+|---|---|---|
+| A — fixes (B1, B3, B5, B6, B9, B13, F8) | `fix/rrhh-calculos-y-trazabilidad` | central #230 · desktop #239 |
+| B — feats (B4, B7, B8, B10, B11, B12, B16) | `feat/rrhh-recibos-y-penalizaciones` | central #231 · desktop #241 |
+| Tipo del sueldo | `refactor/funcionario-sueldo-bigdecimal` | central #233 |
+| B14 + B15 | `feat/rrhh-base-remunerativa` | central #234 |
+
+**Orden de merge:** A → B, y #233 → #234. Cada uno sale del anterior.
+
+Siguen abiertos: **B2** (no es código, es data sucia), **F3** (cross-repo, toca el enum que
+replica a filiales) y **F5** (bloqueado por el hub de pagos).
+
+**Follow-up que dejó abierto #234:** no existe ABM de conceptos de liquidación en el desktop, así
+que `es_remunerativo` solo se edita por SQL y el `DEFAULT TRUE` deja pasar conceptos nuevos sin que
+nadie lo decida.
 
 ## Índice
 
@@ -22,8 +40,8 @@ Estados: 🔴 abierto · 🟡 en análisis · 🟢 corregido
 | B11 | Amonestaciones/advertencias sin monto + contador + acta firmable | 🟠 |
 | B12 | Ítem manual: select de operación (hoy todo sale "AJUSTE") | 🟠 |
 | B13 | Penalizaciones consolidadas en un ítem, sin detalle | 🔴 |
-| B14 | Aguinaldo sobre último sueldo, no sobre promedio percibido (INVESTIGADO) | 🔴 |
-| B15 | IPS del finiquito: sin prorrateo por días ni vacaciones en la base | 🔴 |
+| B14 | Aguinaldo sobre último sueldo, no sobre promedio percibido | ✅ PR #234 |
+| B15 | IPS del finiquito: sin prorrateo por días ni vacaciones en la base | ✅ PR #234 |
 | F1 | Ajuste de saldo en cuentas bancarias (solo existe en caja) | ✅ **hecho** |
 | F2 | Pagar liquidación/finiquito desde el hub de egreso de Caja Mayor | ✅ **hecho** |
 | F3 | Retiro de PDV: recepción parcial + selección de monedas | 🟠 |

--- a/docs/manuales-implementacion/rrhh/PLAN-B14-B15-BASE-REMUNERATIVA.md
+++ b/docs/manuales-implementacion/rrhh/PLAN-B14-B15-BASE-REMUNERATIVA.md
@@ -30,7 +30,7 @@ Asumido, decir si se quiere distinto:
   comportamiento de `AguinaldoService:89-91`.
 - Solo se recalcula el **año en curso**, no años anteriores.
 - `VACACION_VENTA` arranca como **remunerativo** (es plata que el funcionario percibió). Se corrige
-  desde el ABM sin deploy.
+  con un `UPDATE` al catálogo, sin deploy — pero por ahora a mano, porque no hay ABM.
 
 ---
 
@@ -116,11 +116,14 @@ WHERE NOT EXISTS (SELECT 1 FROM rrhh.liquidacion_concepto WHERE codigo = 'COMISI
 
 Aditiva y reversible a mano sin pérdida de datos.
 
-> **Riesgo reintroducido, y hay que mitigarlo.** El default `TRUE` significa que un concepto nuevo
-> que alguien cargue sin marcar `es_remunerativo = false` entra a la base del aguinaldo y del IPS
-> **sin que nadie lo note** — exactamente el patrón de falla silenciosa que motivó este plan.
-> Mitigación: en el ABM de conceptos la columna va **visible y obligatoria en el alta**, no
-> escondida detrás de un default.
+> **Riesgo reintroducido, y la mitigación que yo planeé no existe.** El default `TRUE` significa
+> que un concepto nuevo cargado sin marcar `es_remunerativo = false` entra a la base del aguinaldo
+> y del IPS **sin que nadie lo note** — el mismo patrón de falla silenciosa que motivó este plan.
+>
+> Yo había escrito que el ABM de conceptos lo pediría en el alta. **Ese ABM no existe**: el lote B
+> agregó una query de lectura (`ConceptosParaItemManual.ts`) y nada más. Hoy el catálogo solo se
+> edita por SQL. Queda como **follow-up obligatorio antes de que alguien agregue conceptos nuevos**,
+> y mientras tanto el que agregue uno tiene que correr el `UPDATE` a mano.
 
 ### D2 — Un único punto que responde "cuánto percibió"
 
@@ -253,13 +256,18 @@ Queda declarado como cabo suelto conocido, no como olvido.
 
 | # | Qué | Gate |
 |---|---|---|
-| 1 | `V205.5` + `es_remunerativo` en entidad/schema/ABM (visible y obligatorio en el alta) | migración en dev |
+| 1 | `V205.5` + `es_remunerativo` en entidad y schema GraphQL | migración en dev |
 | 2 | `V206.5` + los 4 campos de trazabilidad en `Aguinaldo` | migración en dev |
 | 3 | `BaseRemunerativa` + query agregada + tests puros | tests |
 | 4 | `AguinaldoService`: calculado **y** proyectado desde la misma fuente, con snapshot | recálculo en dev |
 | 5 | `LiquidacionFinalService`: aguinaldo proporcional + `calcularSalarioPromedio` (indemnización) | tests |
 | 6 | B15: base compuesta del IPS + monto de vacaciones en `previewDefaults` | tests |
-| 7 | Desktop: columna del catálogo, aviso de huecos, base del IPS en el diálogo | AOT |
+| 7 | Desktop: aviso de huecos y base del IPS en el diálogo | AOT |
+
+**Fuera de este PR, y hay que hacerlo:** el **ABM de conceptos de liquidación** no existe en el
+desktop. Sin él, `es_remunerativo` solo se edita por SQL y el default `TRUE` deja pasar conceptos
+nuevos sin que nadie lo decida. Es un PR propio, del tamaño del ABM de cargos del lote B, y depende
+de que el lote B esté mergeado.
 
 Commit + push por fase. **El gate real del backend es `gh pr checks`, no `mvnw verify` local** — los
 tests de Jasper tardan de 2 a 10 minutos acá y `ActaAdvertenciaJrxmlTest` mata la VM forked por

--- a/src/main/java/com/franco/dev/domain/rrhh/Aguinaldo.java
+++ b/src/main/java/com/franco/dev/domain/rrhh/Aguinaldo.java
@@ -84,4 +84,28 @@ public class Aguinaldo implements Identifiable<Long> {
     @CreationTimestamp
     @Column(name = "creado_en")
     private LocalDateTime creadoEn;
+
+    /**
+     * De donde salio el monto: {@code PERCIBIDO} (suma de las liquidaciones del anio) o
+     * {@code SUELDO_ACTUAL} (fallback cuando el funcionario no tiene ninguna). NULL en las
+     * filas calculadas antes de que esto existiera.
+     */
+    @Column(name = "origen_base")
+    private String origenBase;
+
+    /** Sobre cuantos meses se calculo. Menos meses que los devengados y con un hueco en el medio = falta cargar una liquidacion. */
+    @Column(name = "meses_con_liquidacion")
+    private Integer mesesConLiquidacion;
+
+    /**
+     * El {@code montoCalculado} que habia antes del ultimo recalculo.
+     *
+     * <p>Recalcular pisa el monto, y el rollback del JAR no devuelve un dato ya escrito.
+     * Sin este campo, un recalculo con una formula equivocada no se puede deshacer.</p>
+     */
+    @Column(name = "monto_anterior")
+    private BigDecimal montoAnterior;
+
+    @Column(name = "recalculado_en")
+    private LocalDateTime recalculadoEn;
 }

--- a/src/main/java/com/franco/dev/domain/rrhh/LiquidacionConcepto.java
+++ b/src/main/java/com/franco/dev/domain/rrhh/LiquidacionConcepto.java
@@ -41,6 +41,14 @@ public class LiquidacionConcepto implements Identifiable<Long> {
     @Column(name = "es_calculado_auto")
     private Boolean esCalculadoAuto;
 
+    /**
+     * Si el concepto suma a la base remunerativa: aguinaldo, IPS del finiquito e
+     * indemnizacion. Falso para AGUINALDO (no entra a su propia base), VIATICO y
+     * REINTEGRO (compensan un gasto, no retribuyen trabajo).
+     */
+    @Column(name = "es_remunerativo")
+    private Boolean esRemunerativo;
+
     private Boolean activo;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/franco/dev/graphql/rrhh/input/LiquidacionConceptoInput.java
+++ b/src/main/java/com/franco/dev/graphql/rrhh/input/LiquidacionConceptoInput.java
@@ -11,6 +11,7 @@ public class LiquidacionConceptoInput {
     private String descripcion;
     private Boolean esHaber;
     private Boolean esCalculadoAuto;
+    private Boolean esRemunerativo;
     private Boolean activo;
     private LocalDateTime creadoEn;
     private Long usuarioId;

--- a/src/main/java/com/franco/dev/repository/rrhh/LiquidacionItemRepository.java
+++ b/src/main/java/com/franco/dev/repository/rrhh/LiquidacionItemRepository.java
@@ -30,4 +30,31 @@ public interface LiquidacionItemRepository extends HelperRepository<LiquidacionI
     BigDecimal sumConvenioCobrado(@Param("cuotaId") Long cuotaId,
                                   @Param("sucId") Long sucId,
                                   @Param("excludeLiqId") Long excludeLiqId);
+
+    /**
+     * Lo percibido por el funcionario en el anio, agregado por periodo, contando solo los
+     * items HABER cuyo concepto es remunerativo.
+     *
+     * <p>Devuelve {@code [periodo, monto]} por mes. Una sola query: la version por item
+     * haria un SELECT al catalogo por fila, que es el N+1 que ya se corrigio en el
+     * recibo.</p>
+     *
+     * <p>El join al catalogo es por codigo (es un String, no una FK) y va por izquierda a
+     * proposito: un item con un codigo que no esta en el catalogo cuenta como
+     * remunerativo, igual que el DEFAULT TRUE de la columna. Asi los items historicos no
+     * desaparecen de la base por no estar seedeados.</p>
+     */
+    @Query("select l.periodo, coalesce(sum(i.monto), 0) " +
+            "from LiquidacionItem i " +
+            "join i.liquidacion l " +
+            "left join com.franco.dev.domain.rrhh.LiquidacionConcepto c on c.codigo = i.codigo " +
+            "where l.funcionario.id = :funcionarioId " +
+            "and l.periodo like concat(cast(:anio as string), '-%') " +
+            "and (l.estado = com.franco.dev.domain.rrhh.enums.LiquidacionSueldoEstado.APROBADA " +
+            "  or l.estado = com.franco.dev.domain.rrhh.enums.LiquidacionSueldoEstado.PAGADA) " +
+            "and i.tipo = com.franco.dev.domain.rrhh.enums.LiquidacionItemTipo.HABER " +
+            "and (c.id is null or c.esRemunerativo is null or c.esRemunerativo = true) " +
+            "group by l.periodo order by l.periodo")
+    List<Object[]> percibidoPorPeriodo(@Param("funcionarioId") Long funcionarioId,
+                                       @Param("anio") Integer anio);
 }

--- a/src/main/java/com/franco/dev/repository/rrhh/LiquidacionItemRepository.java
+++ b/src/main/java/com/franco/dev/repository/rrhh/LiquidacionItemRepository.java
@@ -57,4 +57,21 @@ public interface LiquidacionItemRepository extends HelperRepository<LiquidacionI
             "group by l.periodo order by l.periodo")
     List<Object[]> percibidoPorPeriodo(@Param("funcionarioId") Long funcionarioId,
                                        @Param("anio") Integer anio);
+
+    /**
+     * Lo mismo que {@link #percibidoPorPeriodo}, pero sin filtro de anio y del mas
+     * reciente al mas viejo. Lo usa el salario promedio del finiquito, que mira los
+     * ultimos N meses aunque crucen el fin de anio.
+     */
+    @Query("select l.periodo, coalesce(sum(i.monto), 0) " +
+            "from LiquidacionItem i " +
+            "join i.liquidacion l " +
+            "left join com.franco.dev.domain.rrhh.LiquidacionConcepto c on c.codigo = i.codigo " +
+            "where l.funcionario.id = :funcionarioId " +
+            "and (l.estado = com.franco.dev.domain.rrhh.enums.LiquidacionSueldoEstado.APROBADA " +
+            "  or l.estado = com.franco.dev.domain.rrhh.enums.LiquidacionSueldoEstado.PAGADA) " +
+            "and i.tipo = com.franco.dev.domain.rrhh.enums.LiquidacionItemTipo.HABER " +
+            "and (c.id is null or c.esRemunerativo is null or c.esRemunerativo = true) " +
+            "group by l.periodo order by l.periodo desc")
+    List<Object[]> percibidoPorPeriodoDesc(@Param("funcionarioId") Long funcionarioId);
 }

--- a/src/main/java/com/franco/dev/service/rrhh/AguinaldoService.java
+++ b/src/main/java/com/franco/dev/service/rrhh/AguinaldoService.java
@@ -41,6 +41,11 @@ public class AguinaldoService extends CrudService<Aguinaldo, AguinaldoRepository
     private final CajaVirtualService cajaVirtualService;
     private final MovimientoCajaVirtualService movimientoCajaVirtualService;
     private final MonedaService monedaService;
+    private final BaseRemunerativaService baseRemunerativaService;
+
+    /** Valores de {@code Aguinaldo.origenBase}. */
+    public static final String ORIGEN_PERCIBIDO = "PERCIBIDO";
+    public static final String ORIGEN_SUELDO_ACTUAL = "SUELDO_ACTUAL";
 
     @Override
     public AguinaldoRepository getRepository() {
@@ -61,16 +66,28 @@ public class AguinaldoService extends CrudService<Aguinaldo, AguinaldoRepository
 
     /**
      * Calcula el aguinaldo del anio para todos los funcionarios activos.
-     * aguinaldo = (sueldo x meses_trabajados) / 12. Idempotente por
-     * (funcionario, anio): si ya existe CALCULADO lo actualiza; no toca los
-     * APROBADO/PAGADO. Devuelve la cantidad procesada.
+     *
+     * <p><b>aguinaldo = lo percibido en el anio / 12.</b> Percibido es la suma de los
+     * items HABER remunerativos de las liquidaciones APROBADA o PAGADA -- no el sueldo
+     * actual multiplicado por meses, que era lo que se hacia antes y no miraba ni el
+     * historial salarial ni las horas extra, bonos o comisiones.</p>
+     *
+     * <p>La formula no es nueva en el sistema: es la que
+     * {@code LiquidacionFinalService.calcularAguinaldoProporcional()} ya usaba para el
+     * finiquito. Lo que se corrige aca es que convivieran dos, y que el mismo funcionario
+     * cobrara distinto segun si se quedaba o si se iba.</p>
+     *
+     * <p>Idempotente por (funcionario, anio): si ya existe CALCULADO lo actualiza y guarda
+     * el monto anterior; no toca los APROBADO/PAGADO. Devuelve la cantidad procesada.</p>
      */
     @Transactional
     public int calcularAguinaldosAnio(Integer anio) {
         int n = 0;
         for (Funcionario f : funcionarioService.findAll2()) {
             if (!Boolean.TRUE.equals(f.getActivo())) continue;
-            if (f.getSueldo() == null || f.getFechaIngreso() == null) continue;
+            // El sueldo ya no es requisito: quien tenga liquidaciones cargadas se calcula
+            // desde lo percibido. Solo hace falta para el fallback, y ahi se valida.
+            if (f.getFechaIngreso() == null) continue;
 
             if (f.getFechaIngreso().getYear() > anio) {
                 continue;

--- a/src/main/java/com/franco/dev/service/rrhh/BaseRemunerativaService.java
+++ b/src/main/java/com/franco/dev/service/rrhh/BaseRemunerativaService.java
@@ -1,0 +1,46 @@
+package com.franco.dev.service.rrhh;
+
+import com.franco.dev.repository.rrhh.LiquidacionItemRepository;
+import com.franco.dev.service.rrhh.builder.BaseRemunerativa;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Responde "cuanto percibio este funcionario en este anio", una sola vez y para todos.
+ *
+ * <p>Lo consumen el aguinaldo anual, el aguinaldo proporcional del finiquito, la base del
+ * IPS del finiquito y la base de la indemnizacion. Antes cada uno resolvia lo mismo por su
+ * cuenta y con formulas distintas.</p>
+ */
+@Service
+public class BaseRemunerativaService {
+
+    @Autowired
+    private LiquidacionItemRepository liquidacionItemRepository;
+
+    /**
+     * Percibido del anio, mes por mes. Cuentan las liquidaciones APROBADA y PAGADA; un
+     * BORRADOR no, porque todavia puede cambiar.
+     */
+    public BaseRemunerativa.Resultado percibidoAnual(Long funcionarioId, int anio) {
+        if (funcionarioId == null) return BaseRemunerativa.de(null);
+        List<Object[]> filas = liquidacionItemRepository.percibidoPorPeriodo(funcionarioId, anio);
+        List<BaseRemunerativa.Mes> meses = new ArrayList<>();
+        if (filas != null) {
+            for (Object[] f : filas) {
+                if (f == null || f.length < 2) continue;
+                int mes = BaseRemunerativa.mesDePeriodo(f[0] != null ? f[0].toString() : null);
+                if (mes == 0) continue;
+                BigDecimal monto = f[1] instanceof BigDecimal
+                        ? (BigDecimal) f[1]
+                        : new BigDecimal(String.valueOf(f[1] != null ? f[1] : "0"));
+                meses.add(new BaseRemunerativa.Mes(mes, monto));
+            }
+        }
+        return BaseRemunerativa.de(meses);
+    }
+}

--- a/src/main/java/com/franco/dev/service/rrhh/BaseRemunerativaService.java
+++ b/src/main/java/com/franco/dev/service/rrhh/BaseRemunerativaService.java
@@ -43,4 +43,29 @@ public class BaseRemunerativaService {
         }
         return BaseRemunerativa.de(meses);
     }
+
+    /**
+     * Promedio de lo percibido en los ultimos {@code meses} meses liquidados, sin
+     * importar el anio. Es la base del salario promedio del finiquito (indemnizacion).
+     *
+     * <p>Devuelve {@code null} cuando no hay ninguna liquidacion, para que el llamador
+     * decida su fallback en vez de recibir un cero que parece un promedio real.</p>
+     */
+    public BigDecimal promedioUltimosMeses(Long funcionarioId, int meses) {
+        if (funcionarioId == null || meses < 1) return null;
+        List<Object[]> filas = liquidacionItemRepository.percibidoPorPeriodoDesc(funcionarioId);
+        if (filas == null || filas.isEmpty()) return null;
+        BigDecimal suma = BigDecimal.ZERO;
+        int contados = 0;
+        for (Object[] f : filas) {
+            if (contados >= meses) break;
+            if (f == null || f.length < 2 || f[1] == null) continue;
+            suma = suma.add(f[1] instanceof BigDecimal
+                    ? (BigDecimal) f[1]
+                    : new BigDecimal(String.valueOf(f[1])));
+            contados++;
+        }
+        if (contados == 0) return null;
+        return suma.divide(new BigDecimal(contados), 0, java.math.RoundingMode.HALF_UP);
+    }
 }

--- a/src/main/java/com/franco/dev/service/rrhh/LiquidacionConceptoService.java
+++ b/src/main/java/com/franco/dev/service/rrhh/LiquidacionConceptoService.java
@@ -32,6 +32,11 @@ public class LiquidacionConceptoService extends CrudService<LiquidacionConcepto,
         if (entity.getActivo() == null) entity.setActivo(true);
         if (entity.getEsHaber() == null) entity.setEsHaber(true);
         if (entity.getEsCalculadoAuto() == null) entity.setEsCalculadoAuto(false);
+        // Default true, igual que la columna: un cliente viejo que no manda el campo no
+        // puede reventar el insert. La UI si lo pide en el alta -- el default es la red,
+        // no el camino esperado, porque un concepto que entra a la base remunerativa sin
+        // que nadie lo haya decidido es justo la falla silenciosa que este cambio corrige.
+        if (entity.getEsRemunerativo() == null) entity.setEsRemunerativo(true);
         if (entity.getCodigo() != null) entity.setCodigo(entity.getCodigo().toUpperCase());
         return super.save(entity);
     }

--- a/src/main/java/com/franco/dev/service/rrhh/LiquidacionConceptoService.java
+++ b/src/main/java/com/franco/dev/service/rrhh/LiquidacionConceptoService.java
@@ -33,9 +33,12 @@ public class LiquidacionConceptoService extends CrudService<LiquidacionConcepto,
         if (entity.getEsHaber() == null) entity.setEsHaber(true);
         if (entity.getEsCalculadoAuto() == null) entity.setEsCalculadoAuto(false);
         // Default true, igual que la columna: un cliente viejo que no manda el campo no
-        // puede reventar el insert. La UI si lo pide en el alta -- el default es la red,
-        // no el camino esperado, porque un concepto que entra a la base remunerativa sin
-        // que nadie lo haya decidido es justo la falla silenciosa que este cambio corrige.
+        // puede reventar el insert.
+        //
+        // Ojo: hoy no hay ABM de conceptos en el desktop, asi que este default es el
+        // camino normal y no la red. Un concepto nuevo entra a la base remunerativa sin
+        // que nadie lo decida -- la misma falla silenciosa que este cambio corrige en
+        // otro lado. Cuando exista el ABM, tiene que pedir el valor en el alta.
         if (entity.getEsRemunerativo() == null) entity.setEsRemunerativo(true);
         if (entity.getCodigo() != null) entity.setCodigo(entity.getCodigo().toUpperCase());
         return super.save(entity);

--- a/src/main/java/com/franco/dev/service/rrhh/LiquidacionFinalService.java
+++ b/src/main/java/com/franco/dev/service/rrhh/LiquidacionFinalService.java
@@ -80,6 +80,7 @@ public class LiquidacionFinalService extends CrudService<LiquidacionFinal, Liqui
     private final PenalizacionRepository penalizacionRepository;
     private final CreditoConvenioService creditoConvenioService;
     private final com.franco.dev.repository.rrhh.AguinaldoRepository aguinaldoRepository;
+    private final BaseRemunerativaService baseRemunerativaService;
 
     @Override
     public LiquidacionFinalRepository getRepository() {
@@ -207,7 +208,16 @@ public class LiquidacionFinalService extends CrudService<LiquidacionFinal, Liqui
 
         // Descuentos automáticos del funcionario (IPS, vales, cuotas, convenio, penalizaciones),
         // cada uno activable/desactivable desde el diálogo (default: todos activos).
-        BigDecimal ipsBase = in.getIpsBase() != null ? in.getIpsBase() : salarioPromedio;
+        // Base del IPS: el salario del mes ya prorrateado por dias trabajados, mas las
+        // vacaciones no gozadas (causadas y proporcionales, que calcularDiasVacacionesNoGozadas
+        // ya suma juntas) mas el aguinaldo proporcional.
+        //
+        // Antes era salarioPromedio: un mes entero de haberes promediado sobre 6 meses, sin
+        // prorratear por los dias que la persona efectivamente trabajo en el mes de egreso, y
+        // sin las vacaciones ni el aguinaldo que se le pagan en el mismo acto.
+        BigDecimal ipsBase = in.getIpsBase() != null
+                ? in.getIpsBase()
+                : baseIpsFiniquito(salarioDelMes, r.getMontoVacacionesNoGozadas(), r.getAguinaldoProporcional());
         // IPS: override del diálogo, o por defecto según ipsActivo del funcionario.
         boolean descontarIps = in.getDescontarIps() != null ? in.getDescontarIps() : !Boolean.FALSE.equals(f.getIpsActivo());
         boolean cobrarVales = in.getCobrarVales() == null || in.getCobrarVales();
@@ -241,10 +251,28 @@ public class LiquidacionFinalService extends CrudService<LiquidacionFinal, Liqui
         BigDecimal sueldoBase = f.getSueldo() != null ? f.getSueldo() : BigDecimal.ZERO;
         int diasTrabajadosMes = egreso.getDayOfMonth();
         BigDecimal salarioDelMes = salarioPorDiasTrabajados(sueldoBase, diasTrabajadosMes, diasMes);
+        // El monto de las vacaciones no lo traia el preview: solo los dias. Sin el, el
+        // dialogo no puede precargar la base del IPS, que es justamente donde entran.
+        BigDecimal montoVac = LiquidacionFinalCalculator.montoVacaciones(salarioPromedio, diasVac, diasMes);
+        BigDecimal ipsBase = baseIpsFiniquito(salarioDelMes, montoVac, aguinaldo);
         return new LiquidacionFinalPreview(
                 ingreso != null ? ingreso.toString() : null,
                 ant.getAnios(), (int) ant.getDias(), salarioPromedio, sueldoBase, diasTrabajadosMes, salarioDelMes,
-                aguinaldo, diasVac, preavisoDias, salarioPromedio, ipsActivo);
+                aguinaldo, diasVac, montoVac, preavisoDias, ipsBase, ipsActivo);
+    }
+
+    /**
+     * Base sobre la que se calcula el IPS del finiquito.
+     *
+     * <p>Los tres componentes se pagan en el mismo acto, asi que los tres aportan. El
+     * aguinaldo entra por decision expresa (2026-08-21); si en algun momento contabilidad
+     * define que esta exento, se saca de aca y de ningun otro lado.</p>
+     */
+    private BigDecimal baseIpsFiniquito(BigDecimal salarioDelMes, BigDecimal vacaciones, BigDecimal aguinaldo) {
+        BigDecimal base = salarioDelMes != null ? salarioDelMes : BigDecimal.ZERO;
+        if (vacaciones != null) base = base.add(vacaciones);
+        if (aguinaldo != null) base = base.add(aguinaldo);
+        return base;
     }
 
     /** Salario por días trabajados: (sueldo / diasMes) × días, guaraníes enteros. */
@@ -469,23 +497,21 @@ public class LiquidacionFinalService extends CrudService<LiquidacionFinal, Liqui
     }
 
     /** Promedio de total_haberes de las últimas N liquidaciones APROBADA/PAGADA; fallback al sueldo. */
+    /**
+     * Salario promedio de los ultimos N meses liquidados. Es la base de la
+     * INDEMNIZACION, asi que cuenta solo lo remunerativo.
+     *
+     * <p>Antes promediaba {@code total_haberes} crudo, que incluye el propio AGUINALDO:
+     * la indemnizacion de quien se iba el mismo anio que habia cobrado el aguinaldo salia
+     * inflada por ese aguinaldo. Tambien entraban viaticos y reintegros, que compensan un
+     * gasto en vez de retribuir trabajo.</p>
+     */
     private BigDecimal calcularSalarioPromedio(Funcionario f) {
         int mesesPromedio = configuracionRrhhService.getNumber("MESES_PROMEDIO_LIQUIDACION_FINAL", new BigDecimal("6")).intValue();
         if (mesesPromedio < 1) mesesPromedio = 6;
-        List<LiquidacionSueldo> liqs = liquidacionSueldoRepository.findByFuncionarioIdOrderByPeriodoDesc(f.getId());
-        List<BigDecimal> haberes = new ArrayList<>();
-        for (LiquidacionSueldo l : liqs) {
-            if (l.getEstado() == LiquidacionSueldoEstado.APROBADA || l.getEstado() == LiquidacionSueldoEstado.PAGADA) {
-                if (l.getTotalHaberes() != null) haberes.add(l.getTotalHaberes());
-                if (haberes.size() >= mesesPromedio) break;
-            }
-        }
-        if (haberes.isEmpty()) {
-            return f.getSueldo() != null ? f.getSueldo() : BigDecimal.ZERO;
-        }
-        BigDecimal suma = BigDecimal.ZERO;
-        for (BigDecimal h : haberes) suma = suma.add(h);
-        return suma.divide(new BigDecimal(haberes.size()), 0, RoundingMode.HALF_UP);
+        BigDecimal promedio = baseRemunerativaService.promedioUltimosMeses(f.getId(), mesesPromedio);
+        if (promedio != null) return promedio;
+        return f.getSueldo() != null ? f.getSueldo() : BigDecimal.ZERO;
     }
 
     private int calcularDiasVacacionesNoGozadas(Long funcionarioId) {
@@ -498,22 +524,20 @@ public class LiquidacionFinalService extends CrudService<LiquidacionFinal, Liqui
         return dias;
     }
 
-    /** Σ total_haberes de las liquidaciones del año del egreso / 12; fallback sueldo × meses/12. */
+    /**
+     * Aguinaldo proporcional del año del egreso: lo percibido / 12.
+     *
+     * <p>Sale del mismo {@link BaseRemunerativaService} que el aguinaldo anual. Antes cada
+     * uno tenia su propia copia de la formula y el aguinaldo anual usaba otra: el mismo
+     * funcionario cobraba distinto segun si se quedaba o si se iba.</p>
+     */
     private BigDecimal calcularAguinaldoProporcional(Funcionario f, LocalDate egreso) {
         int anio = egreso.getYear();
-        BigDecimal suma = BigDecimal.ZERO;
-        boolean hay = false;
-        for (LiquidacionSueldo l : liquidacionSueldoRepository.findByFuncionarioIdOrderByPeriodoDesc(f.getId())) {
-            if (l.getPeriodo() != null && l.getPeriodo().startsWith(anio + "-")
-                    && (l.getEstado() == LiquidacionSueldoEstado.APROBADA || l.getEstado() == LiquidacionSueldoEstado.PAGADA)
-                    && l.getTotalHaberes() != null) {
-                suma = suma.add(l.getTotalHaberes());
-                hay = true;
-            }
-        }
+        com.franco.dev.service.rrhh.builder.BaseRemunerativa.Resultado base =
+                baseRemunerativaService.percibidoAnual(f.getId(), anio);
         BigDecimal proporcional;
-        if (hay) {
-            proporcional = suma.divide(new BigDecimal("12"), 0, RoundingMode.HALF_UP);
+        if (!base.vacio()) {
+            proporcional = com.franco.dev.service.rrhh.builder.BaseRemunerativa.aguinaldo(base.total);
         } else {
             // fallback: sueldo × meses trabajados en el año / 12
             BigDecimal sueldo = f.getSueldo() != null ? f.getSueldo() : BigDecimal.ZERO;

--- a/src/main/java/com/franco/dev/service/rrhh/builder/BaseRemunerativa.java
+++ b/src/main/java/com/franco/dev/service/rrhh/builder/BaseRemunerativa.java
@@ -1,0 +1,129 @@
+package com.franco.dev.service.rrhh.builder;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Base remunerativa de un funcionario en un anio: lo que efectivamente percibio,
+ * mes por mes, contando solo los conceptos que retribuyen trabajo.
+ *
+ * <p>Es el punto unico del que salen el aguinaldo (anual y proporcional), la base del
+ * IPS del finiquito y la base de la indemnizacion. Antes cada uno tenia su propia
+ * formula: el aguinaldo anual usaba el sueldo actual y puntual, y el finiquito sumaba
+ * total_haberes -- que incluye el propio aguinaldo. El mismo funcionario cobraba
+ * distinto segun si se quedaba o si se iba.</p>
+ *
+ * <p>Calculo puro, sin Spring ni JPA: recibe los montos ya agregados por la query y
+ * decide. Lo que entra a la suma lo define {@code es_remunerativo} en el catalogo de
+ * conceptos, no esta clase.</p>
+ */
+public final class BaseRemunerativa {
+
+    private BaseRemunerativa() {
+    }
+
+    /** Lo percibido en un mes del anio. {@code mes} es 1..12. */
+    public static final class Mes {
+        public final int mes;
+        public final BigDecimal monto;
+
+        public Mes(int mes, BigDecimal monto) {
+            this.mes = mes;
+            this.monto = monto != null ? monto : BigDecimal.ZERO;
+        }
+    }
+
+    public static final class Resultado {
+        /** Suma de lo percibido en el anio. */
+        public final BigDecimal total;
+        /** Cuantos meses del anio tienen liquidacion contada. */
+        public final int mesesConLiquidacion;
+        /** Primer y ultimo mes con liquidacion (0 si no hay ninguna). */
+        public final int primerMes;
+        public final int ultimoMes;
+        /**
+         * Si falta algun mes ENTRE el primero y el ultimo.
+         *
+         * <p>Que falte el mes en curso no es un hueco: es el ciclo normal de nomina, y
+         * avisar por eso seria ruido todos los meses. Un hueco en el medio si significa
+         * que hay una liquidacion sin cargar, y ahi el aguinaldo sale bajo sin que se
+         * note.</p>
+         */
+        public final boolean hayHueco;
+
+        Resultado(BigDecimal total, int mesesConLiquidacion, int primerMes, int ultimoMes, boolean hayHueco) {
+            this.total = total;
+            this.mesesConLiquidacion = mesesConLiquidacion;
+            this.primerMes = primerMes;
+            this.ultimoMes = ultimoMes;
+            this.hayHueco = hayHueco;
+        }
+
+        public boolean vacio() {
+            return mesesConLiquidacion == 0;
+        }
+
+        /**
+         * Promedio mensual observado. Es lo que se proyecta sobre los meses que faltan
+         * para llegar al 31/12: el proyectado no puede salir del percibido directo
+         * porque no existen liquidaciones de meses futuros.
+         */
+        public BigDecimal promedioMensual() {
+            if (mesesConLiquidacion <= 0) return BigDecimal.ZERO;
+            return total.divide(new BigDecimal(mesesConLiquidacion), 0, RoundingMode.HALF_UP);
+        }
+    }
+
+    /** Aguinaldo = percibido / 12, en guaranies enteros. */
+    public static BigDecimal aguinaldo(BigDecimal percibido) {
+        BigDecimal v = percibido != null ? percibido : BigDecimal.ZERO;
+        return v.divide(new BigDecimal("12"), 0, RoundingMode.HALF_UP);
+    }
+
+    /**
+     * Aguinaldo proyectado al 31/12: se extiende el promedio mensual observado sobre los
+     * meses proyectados. Con el anio ya terminado coincide con {@link #aguinaldo}.
+     */
+    public static BigDecimal aguinaldoProyectado(Resultado r, int mesesProyectados) {
+        if (r == null || r.vacio() || mesesProyectados <= 0) return BigDecimal.ZERO;
+        return r.promedioMensual()
+                .multiply(new BigDecimal(mesesProyectados))
+                .divide(new BigDecimal("12"), 0, RoundingMode.HALF_UP);
+    }
+
+    public static Resultado de(List<Mes> meses) {
+        if (meses == null || meses.isEmpty()) {
+            return new Resultado(BigDecimal.ZERO, 0, 0, 0, false);
+        }
+        List<Integer> presentes = new ArrayList<>();
+        BigDecimal total = BigDecimal.ZERO;
+        int primero = Integer.MAX_VALUE;
+        int ultimo = 0;
+        for (Mes m : meses) {
+            if (m == null || m.mes < 1 || m.mes > 12) continue;
+            total = total.add(m.monto);
+            presentes.add(m.mes);
+            if (m.mes < primero) primero = m.mes;
+            if (m.mes > ultimo) ultimo = m.mes;
+        }
+        if (presentes.isEmpty()) {
+            return new Resultado(BigDecimal.ZERO, 0, 0, 0, false);
+        }
+        // Hueco = el tramo entre el primero y el ultimo tiene mas meses que los contados.
+        boolean hueco = (ultimo - primero + 1) > presentes.size();
+        return new Resultado(total, presentes.size(), primero, ultimo, hueco);
+    }
+
+    /** Extrae el mes de un periodo "YYYY-MM". Devuelve 0 si no tiene esa forma. */
+    public static int mesDePeriodo(String periodo) {
+        if (periodo == null || periodo.length() < 7 || periodo.charAt(4) != '-') return 0;
+        try {
+            int m = Integer.parseInt(periodo.substring(5, 7));
+            return (m >= 1 && m <= 12) ? m : 0;
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+}

--- a/src/main/java/com/franco/dev/service/rrhh/builder/LiquidacionFinalCalculator.java
+++ b/src/main/java/com/franco/dev/service/rrhh/builder/LiquidacionFinalCalculator.java
@@ -104,6 +104,20 @@ public final class LiquidacionFinalCalculator {
         return new Antiguedad(dias, meses, anios);
     }
 
+    /**
+     * Monto de las vacaciones no gozadas: promedio diario x dias.
+     *
+     * <p>Publico porque lo necesitan dos lugares — el finiquito al generarse y el preview
+     * del dialogo, que no llama a {@link #calcular}. Duplicar la formula seria repetir el
+     * error que este cambio corrige en otro lado.</p>
+     */
+    public static BigDecimal montoVacaciones(BigDecimal salarioPromedio, int diasNoGozados, int diasMes) {
+        if (salarioPromedio == null || diasNoGozados <= 0) return BigDecimal.ZERO;
+        BigDecimal divisor = new BigDecimal(diasMes > 0 ? diasMes : 30);
+        return salarioPromedio.multiply(new BigDecimal(diasNoGozados))
+                .divide(divisor, 0, RoundingMode.HALF_UP);
+    }
+
     public static Resultado calcular(LocalDate ingreso, LocalDate egreso, MotivoEgreso motivo,
                                      BigDecimal salarioPromedio, int diasNoGozados,
                                      BigDecimal aguinaldoProporcional, BigDecimal indemnizacionDiasPorAnio,
@@ -127,8 +141,7 @@ public final class LiquidacionFinalCalculator {
                     .divide(divisorDiasMes, 0, RoundingMode.HALF_UP);
         }
 
-        BigDecimal montoVac = promedio.multiply(new BigDecimal(diasVac))
-                .divide(divisorDiasMes, 0, RoundingMode.HALF_UP);
+        BigDecimal montoVac = montoVacaciones(promedio, diasVac, divisorDiasMes.intValue());
 
         // Preaviso: solo si NO se otorgó. Despido injustificado → el empleador lo paga
         // (HABER, días completos del tramo); renuncia → el empleador lo descuenta

--- a/src/main/java/com/franco/dev/service/rrhh/dto/LiquidacionFinalPreview.java
+++ b/src/main/java/com/franco/dev/service/rrhh/dto/LiquidacionFinalPreview.java
@@ -23,6 +23,7 @@ public class LiquidacionFinalPreview {
     private BigDecimal salarioDelMes;
     private BigDecimal aguinaldoProporcional;
     private Integer diasVacacionesNoGozadas;
+    private BigDecimal montoVacacionesNoGozadas;
     private Integer preavisoDias;
     private BigDecimal ipsBase;
     private Boolean ipsActivo;

--- a/src/main/resources/db/migration/V205.5__rrhh_concepto_es_remunerativo.sql
+++ b/src/main/resources/db/migration/V205.5__rrhh_concepto_es_remunerativo.sql
@@ -1,0 +1,36 @@
+-- Que conceptos entran a la BASE REMUNERATIVA (aguinaldo, IPS del finiquito,
+-- indemnizacion) deja de estar implicito en "todo item HABER" y pasa a ser un dato del
+-- catalogo, editable sin deploy.
+--
+-- El problema que resuelve: total_haberes es un saco. Incluye el propio AGUINALDO
+-- (LiquidacionSueldoService lo emite como item HABER), asi que calcular el aguinaldo
+-- sumando total_haberes mete el aguinaldo del anio dentro de la base del aguinaldo del
+-- anio. Lo mismo con VIATICO y REINTEGRO, que compensan un gasto o devuelven plata
+-- adelantada: no retribuyen trabajo.
+--
+-- DEFAULT TRUE a proposito: cualquier codigo que hoy exista y no este en la lista de
+-- abajo sigue contando igual que antes, asi que la migracion no cambia ningun monto por
+-- si sola. Los tres UPDATE de abajo si lo hacen, y esa es la correccion buscada.
+--
+-- OJO al reverso de ese default: un concepto nuevo cargado sin marcar es_remunerativo =
+-- false entra a la base sin que nadie lo note. Por eso el ABM pide el valor en el alta en
+-- vez de dejarlo al default.
+--
+-- rrhh.* no esta en central_pub ni en configuraciones.replication_table: esta tabla no
+-- replica a las filiales.
+
+ALTER TABLE rrhh.liquidacion_concepto
+    ADD COLUMN IF NOT EXISTS es_remunerativo BOOLEAN NOT NULL DEFAULT TRUE;
+
+COMMENT ON COLUMN rrhh.liquidacion_concepto.es_remunerativo IS
+    'Si el concepto suma a la base remunerativa (aguinaldo, IPS del finiquito, indemnizacion).';
+
+UPDATE rrhh.liquidacion_concepto SET es_remunerativo = false
+ WHERE codigo IN ('AGUINALDO', 'VIATICO', 'REINTEGRO');
+
+-- Las comisiones no existian como concepto de haber: el unico COMISION del sistema es
+-- PenalizacionTipo.COMISION_DESCUENTO, que es un descuento. Sin este concepto, una
+-- comision solo puede cargarse como BONO_MANUAL y pierde su etiqueta en el recibo.
+INSERT INTO rrhh.liquidacion_concepto (codigo, descripcion, es_haber, es_calculado_auto, es_remunerativo, activo, creado_en)
+SELECT 'COMISION', 'COMISION', true, false, true, true, now()
+WHERE NOT EXISTS (SELECT 1 FROM rrhh.liquidacion_concepto WHERE codigo = 'COMISION');

--- a/src/main/resources/db/migration/V205.5__rrhh_concepto_es_remunerativo.sql
+++ b/src/main/resources/db/migration/V205.5__rrhh_concepto_es_remunerativo.sql
@@ -13,8 +13,14 @@
 -- si sola. Los tres UPDATE de abajo si lo hacen, y esa es la correccion buscada.
 --
 -- OJO al reverso de ese default: un concepto nuevo cargado sin marcar es_remunerativo =
--- false entra a la base sin que nadie lo note. Por eso el ABM pide el valor en el alta en
--- vez de dejarlo al default.
+-- false entra a la base del aguinaldo y del IPS sin que nadie lo note. Hoy no hay ABM de
+-- conceptos en el desktop -- el catalogo solo se edita por SQL -- asi que el que agregue
+-- un concepto tiene que acordarse de definir esta columna a mano:
+--
+--   UPDATE rrhh.liquidacion_concepto SET es_remunerativo = false WHERE codigo = 'XXX';
+--
+-- Mientras no exista ese ABM pidiendo el valor en el alta, esta sigue siendo una falla
+-- silenciosa posible. Es la misma clase de problema que este cambio corrige.
 --
 -- rrhh.* no esta en central_pub ni en configuraciones.replication_table: esta tabla no
 -- replica a las filiales.

--- a/src/main/resources/db/migration/V206.5__rrhh_aguinaldo_trazabilidad_base.sql
+++ b/src/main/resources/db/migration/V206.5__rrhh_aguinaldo_trazabilidad_base.sql
@@ -1,0 +1,27 @@
+-- Trazabilidad del recalculo de aguinaldo.
+--
+-- calcularAguinaldosAnio() es idempotente por (funcionario, anio): al correrlo PISA
+-- monto_calculado de los que estan en CALCULADO. Hasta ahora eso no dejaba ningun rastro:
+-- si la formula nueva resultara equivocada, el monto viejo no se puede recuperar -- el
+-- rollback del JAR no rollbackea un dato ya escrito.
+--
+-- monto_anterior guarda lo que habia antes de cada recalculo. Es la unica forma de
+-- deshacer uno.
+--
+-- Los otros tres campos existen para poder explicar un monto sin reconstruirlo a mano
+-- cuando un funcionario lo reclama: de que fuente salio, sobre cuantos meses, y cuando.
+
+ALTER TABLE rrhh.aguinaldo
+    ADD COLUMN IF NOT EXISTS origen_base VARCHAR(20),
+    ADD COLUMN IF NOT EXISTS meses_con_liquidacion INTEGER,
+    ADD COLUMN IF NOT EXISTS monto_anterior NUMERIC,
+    ADD COLUMN IF NOT EXISTS recalculado_en TIMESTAMP;
+
+COMMENT ON COLUMN rrhh.aguinaldo.origen_base IS
+    'PERCIBIDO = suma de liquidaciones del anio; SUELDO_ACTUAL = fallback sin liquidaciones.';
+COMMENT ON COLUMN rrhh.aguinaldo.monto_anterior IS
+    'monto_calculado previo al ultimo recalculo. Permite deshacer un recalculo equivocado.';
+
+-- Nullable a proposito: las filas historicas no tienen de donde sacar estos valores y
+-- ponerles algo inventado seria peor que dejarlas vacias. Un origen_base NULL significa
+-- "calculado antes de que esto existiera".

--- a/src/main/resources/graphql/rrhh/configuracion-rrhh.graphqls
+++ b/src/main/resources/graphql/rrhh/configuracion-rrhh.graphqls
@@ -33,6 +33,7 @@ type LiquidacionConcepto {
     descripcion: String
     esHaber: Boolean
     esCalculadoAuto: Boolean
+    esRemunerativo: Boolean
     activo: Boolean
     usuario: Usuario
     creadoEn: Date
@@ -44,6 +45,7 @@ input LiquidacionConceptoInput {
     descripcion: String
     esHaber: Boolean
     esCalculadoAuto: Boolean
+    esRemunerativo: Boolean
     activo: Boolean
     creadoEn: Date
     usuarioId: Int

--- a/src/main/resources/graphql/rrhh/liquidacion-final.graphqls
+++ b/src/main/resources/graphql/rrhh/liquidacion-final.graphqls
@@ -47,6 +47,7 @@ type LiquidacionFinalPreview {
     salarioDelMes: Float
     aguinaldoProporcional: Float
     diasVacacionesNoGozadas: Int
+    montoVacacionesNoGozadas: Float
     preavisoDias: Int
     ipsBase: Float
     ipsActivo: Boolean

--- a/src/main/resources/graphql/rrhh/vacaciones-aguinaldo-bonos.graphqls
+++ b/src/main/resources/graphql/rrhh/vacaciones-aguinaldo-bonos.graphqls
@@ -86,6 +86,10 @@ type Aguinaldo {
     cajaVirtualId: Int
     movimientoCajaVirtualId: Int
     creadoEn: Date
+    origenBase: String
+    mesesConLiquidacion: Int
+    montoAnterior: Float
+    recalculadoEn: Date
 }
 
 type Bono {

--- a/src/test/java/com/franco/dev/service/rrhh/builder/BaseRemunerativaTest.java
+++ b/src/test/java/com/franco/dev/service/rrhh/builder/BaseRemunerativaTest.java
@@ -1,0 +1,113 @@
+package com.franco.dev.service.rrhh.builder;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BaseRemunerativaTest {
+
+    private static BaseRemunerativa.Mes m(int mes, String monto) {
+        return new BaseRemunerativa.Mes(mes, new BigDecimal(monto));
+    }
+
+    @Test
+    void sumaLoPercibidoYCuentaLosMeses() {
+        BaseRemunerativa.Resultado r = BaseRemunerativa.de(Arrays.asList(
+                m(1, "3000000"), m(2, "3000000"), m(3, "3500000")));
+        assertEquals(0, new BigDecimal("9500000").compareTo(r.total));
+        assertEquals(3, r.mesesConLiquidacion);
+        assertEquals(1, r.primerMes);
+        assertEquals(3, r.ultimoMes);
+    }
+
+    /**
+     * Que falte el mes en curso NO es un hueco. Si avisara por eso, avisaria todos los
+     * meses del anio y nadie miraria el aviso cuando importe.
+     */
+    @Test
+    void laColaFaltanteNoEsHueco() {
+        BaseRemunerativa.Resultado r = BaseRemunerativa.de(Arrays.asList(
+                m(1, "3000000"), m(2, "3000000"), m(3, "3000000")));
+        assertFalse(r.hayHueco, "meses 1-2-3 en marzo no deberia marcar hueco");
+    }
+
+    /** Un mes salteado en el medio si: significa una liquidacion sin cargar. */
+    @Test
+    void unMesSalteadoEnElMedioEsHueco() {
+        BaseRemunerativa.Resultado r = BaseRemunerativa.de(Arrays.asList(
+                m(1, "3000000"), m(3, "3000000"), m(4, "3000000")));
+        assertTrue(r.hayHueco, "falta febrero entre enero y abril");
+        assertEquals(3, r.mesesConLiquidacion);
+    }
+
+    @Test
+    void sinLiquidacionesQuedaVacioYNoRompe() {
+        BaseRemunerativa.Resultado r = BaseRemunerativa.de(Collections.emptyList());
+        assertTrue(r.vacio());
+        assertEquals(0, BigDecimal.ZERO.compareTo(r.total));
+        assertEquals(0, BigDecimal.ZERO.compareTo(r.promedioMensual()));
+        assertFalse(r.hayHueco);
+        assertEquals(0, BigDecimal.ZERO.compareTo(BaseRemunerativa.aguinaldoProyectado(r, 12)));
+    }
+
+    /** Un anio completo: el aguinaldo es un doceavo de todo lo percibido. */
+    @Test
+    void anioCompletoDaUnDoceavo() {
+        BaseRemunerativa.Mes[] doce = new BaseRemunerativa.Mes[12];
+        for (int i = 1; i <= 12; i++) doce[i - 1] = m(i, "3000000");
+        BaseRemunerativa.Resultado r = BaseRemunerativa.de(Arrays.asList(doce));
+        assertEquals(0, new BigDecimal("3000000").compareTo(BaseRemunerativa.aguinaldo(r.total)),
+                "12 meses de 3.000.000 tienen que dar un aguinaldo de 3.000.000");
+        assertEquals(12, r.mesesConLiquidacion);
+    }
+
+    /**
+     * Con el anio ya terminado, el proyectado y el devengado tienen que coincidir. Si no,
+     * en diciembre la pantalla mostraria dos numeros distintos para lo mismo.
+     */
+    @Test
+    void conElAnioTerminadoProyectadoYDevengadoCoinciden() {
+        BaseRemunerativa.Mes[] doce = new BaseRemunerativa.Mes[12];
+        for (int i = 1; i <= 12; i++) doce[i - 1] = m(i, "2680373");
+        BaseRemunerativa.Resultado r = BaseRemunerativa.de(Arrays.asList(doce));
+        assertEquals(0, BaseRemunerativa.aguinaldo(r.total)
+                        .compareTo(BaseRemunerativa.aguinaldoProyectado(r, 12)),
+                "devengado y proyectado difieren con el anio completo");
+    }
+
+    /**
+     * A mitad de anio el proyectado extiende el promedio observado. Con 6 meses de
+     * 3.000.000 el proyectado al 31/12 tiene que ser 3.000.000, no 1.500.000.
+     */
+    @Test
+    void elProyectadoExtiendeElPromedioObservado() {
+        BaseRemunerativa.Resultado r = BaseRemunerativa.de(Arrays.asList(
+                m(1, "3000000"), m(2, "3000000"), m(3, "3000000"),
+                m(4, "3000000"), m(5, "3000000"), m(6, "3000000")));
+        assertEquals(0, new BigDecimal("1500000").compareTo(BaseRemunerativa.aguinaldo(r.total)),
+                "el devengado a junio es medio aguinaldo");
+        assertEquals(0, new BigDecimal("3000000").compareTo(BaseRemunerativa.aguinaldoProyectado(r, 12)),
+                "el proyectado al 31/12 tiene que ser el aguinaldo entero");
+    }
+
+    /** Un aumento a mitad de anio tiene que verse en el promedio, no perderse. */
+    @Test
+    void unAumentoAMitadDeAnioEntraAlPromedio() {
+        BaseRemunerativa.Resultado r = BaseRemunerativa.de(Arrays.asList(
+                m(1, "2000000"), m(2, "2000000"), m(3, "4000000"), m(4, "4000000")));
+        assertEquals(0, new BigDecimal("3000000").compareTo(r.promedioMensual()));
+    }
+
+    @Test
+    void elMesSaleDelPeriodo() {
+        assertEquals(1, BaseRemunerativa.mesDePeriodo("2026-01"));
+        assertEquals(12, BaseRemunerativa.mesDePeriodo("2026-12"));
+        assertEquals(0, BaseRemunerativa.mesDePeriodo("2026-13"));
+        assertEquals(0, BaseRemunerativa.mesDePeriodo("basura"));
+        assertEquals(0, BaseRemunerativa.mesDePeriodo(null));
+    }
+}

--- a/src/test/java/com/franco/dev/service/rrhh/builder/MontoVacacionesTest.java
+++ b/src/test/java/com/franco/dev/service/rrhh/builder/MontoVacacionesTest.java
@@ -1,0 +1,43 @@
+package com.franco.dev.service.rrhh.builder;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * El monto de las vacaciones no gozadas se calcula en dos lugares: al generar el
+ * finiquito y en el preview del dialogo, que no llama a {@code calcular()}. Este test
+ * fija la formula para que no se separen.
+ */
+public class MontoVacacionesTest {
+
+    @Test
+    void esElPromedioDiarioPorLosDias() {
+        // 3.000.000 / 30 = 100.000 por dia; 12 dias = 1.200.000
+        assertEquals(0, new BigDecimal("1200000").compareTo(
+                LiquidacionFinalCalculator.montoVacaciones(new BigDecimal("3000000"), 12, 30)));
+    }
+
+    @Test
+    void sinDiasNoHayMonto() {
+        assertEquals(0, BigDecimal.ZERO.compareTo(
+                LiquidacionFinalCalculator.montoVacaciones(new BigDecimal("3000000"), 0, 30)));
+        assertEquals(0, BigDecimal.ZERO.compareTo(
+                LiquidacionFinalCalculator.montoVacaciones(new BigDecimal("3000000"), -5, 30)));
+    }
+
+    @Test
+    void sinPromedioNoRompe() {
+        assertEquals(0, BigDecimal.ZERO.compareTo(
+                LiquidacionFinalCalculator.montoVacaciones(null, 12, 30)));
+    }
+
+    /** Un divisor invalido cae a 30, que es la convencion del modulo (DIAS_MES_PROMEDIO). */
+    @Test
+    void unDivisorInvalidoCaeATreinta() {
+        assertEquals(0, LiquidacionFinalCalculator.montoVacaciones(new BigDecimal("3000000"), 12, 30)
+                .compareTo(LiquidacionFinalCalculator.montoVacaciones(new BigDecimal("3000000"), 12, 0)));
+    }
+}


### PR DESCRIPTION
Cierra **B14** y **B15**. Segundo de dos: **sale de `refactor/funcionario-sueldo-bigdecimal` (#233), que hay que mergear primero.** Plan completo y las dos auditorías en `docs/manuales-implementacion/rrhh/PLAN-B14-B15-BASE-REMUNERATIVA.md`.

## El hallazgo que cambió el trabajo

**No había que inventar la fórmula del aguinaldo: había que unificarla.** El finiquito ya calculaba lo pedido —Σ haberes del año / 12— y el aguinaldo anual usaba `sueldo actual × meses / 12`.

O sea que hoy, en producción, **el mismo funcionario cobra un aguinaldo distinto según si se queda o si se va.** Con un aumento a mitad de año o con variables, los dos números no coinciden.

## Qué cambia de monto, y en qué dirección

| Cálculo | Antes | Ahora | Dirección |
|---|---|---|---|
| **Aguinaldo anual** | sueldo actual × meses / 12 | percibido / 12 | Sube o baja según si hubo aumento y cuánto pesan HE, bonos y comisiones |
| **Aguinaldo proporcional** (finiquito) | Σ `total_haberes` / 12 | igual, pero sin conceptos no remunerativos | Baja para quien cobró aguinaldo, viáticos o reintegros ese año |
| **Indemnización** | promedio de `total_haberes` crudo | mismo promedio, solo remunerativo | **Baja** para quien se va el mismo año que cobró aguinaldo |
| **IPS del finiquito** | promedio de 6 meses | salario del mes /30 + vacaciones + aguinaldo | **Sube** en la mayoría de los casos |

El predicado es `APROBADA || PAGADA` (confirmado): es el que el finiquito ya usaba, así que **su aguinaldo no cambia por el cambio de fuente** — solo por el filtro de conceptos.

## `total_haberes` era un saco

Incluye el propio `AGUINALDO` — `LiquidacionSueldoService:322` lo emite como ítem HABER. Calcular el aguinaldo sumando `total_haberes` **mete el aguinaldo del año dentro de la base del aguinaldo del año**. Lo mismo con `VIATICO` y `REINTEGRO`, que compensan un gasto en vez de retribuir trabajo.

Se resuelve con `es_remunerativo` en el catálogo, no con un `switch`. Y se agrega el concepto `COMISION`, que **no existía**: el único `COMISION` del sistema era `PenalizacionTipo.COMISION_DESCUENTO`, un descuento.

## Dos cosas que la auditoría encontró y sin las cuales esto salía mal

**El método produce dos montos, no uno.** `montoCalculado` (devengado) y `montoProyectado` (al 31/12). El proyectado **no puede** salir del percibido directo — no existen liquidaciones de meses futuros. Extiende el promedio mensual observado. Sin esto la unificación quedaba a medias en un campo que nadie había decidido.

**Un recálculo no se podía deshacer.** `calcularAguinaldosAnio()` **pisa** `montoCalculado`, y el rollback del JAR no devuelve un dato ya escrito. Ahora cada recálculo guarda `monto_anterior`, con `origen_base`, `meses_con_liquidacion` y `recalculado_en`.

## Una promesa que tuve que retirar

El plan decía que el ABM de conceptos pediría `es_remunerativo` en el alta, y que por eso el `DEFAULT TRUE` era solo una red. **Ese ABM no existe** — el lote B agregó una query de lectura y nada más. Hoy el catálogo solo se edita por SQL, así que el default es el camino normal: **un concepto nuevo entra a la base sin que nadie lo decida.** Está corregido en los comentarios y anotado como follow-up obligatorio.

## Migraciones

`V205.5` (columna + 3 `UPDATE` + `COMISION`) y `V206.5` (4 columnas nullable en `rrhh.aguinaldo`). Aditivas y reversibles a mano sin pérdida de datos. **`rrhh.*` no está en `central_pub` ni en `configuraciones.replication_table`** — verificado por los dos caminos, no replica a filiales.

## Cómo probarlo

1. *R.R.H.H. → Aguinaldos → Calcular año*: los montos cambian para quien tuvo aumento o variables. Correrlo **dos veces** y verificar que la segunda deja `monto_anterior` con el valor de la primera.
2. Cargar una liquidación con un ítem `VIATICO` y recalcular: el aguinaldo **no** debe subir.
3. Generar un finiquito: la base del IPS precargada tiene que ser salario del mes + vacaciones + aguinaldo, no el promedio de 6 meses.
4. Un funcionario con un mes salteado en el medio del año tiene que marcar hueco; a uno al que solo le falta el mes en curso **no**.

**Riesgo:** alto — mueve cuatro cálculos de dinero. Antes de deployar hay que avisar a RRHH que el criterio del aguinaldo cambió: el botón de recalcular es manual y rutinario en diciembre, y nadie va a notar por sí solo que la fórmula cambió por debajo.


---

Closes #161.

Ese issue anticipó tres cosas que este PR resuelve tal cual: que había que decidir **qué conceptos entran** ("¿el reintegro de un gasto debería?" — resuelto con `es_remunerativo`, y `REINTEGRO` queda fuera), que hacía falta un **fallback** para cuando no hay liquidaciones cargadas (`origen_base = SUELDO_ACTUAL`), y que `LiquidacionFinalService.calcularAguinaldoProporcional` **debía unificarse** con la misma base (se le borró la copia).

Difiere en un punto: el issue proponía contar solo las `PAGADA`. Se confirmó con Gabriel contar **`APROBADA` o `PAGADA`** — un BORRADOR no cuenta, pero una liquidación aprobada sin desembolsar sí.
