### PR TITLE
feat(impresoras): soportar impresoras compartidas por una PC Windows (SMB)

### DIFF
--- a/src/main/java/com/franco/dev/domain/empresarial/Impresora.java
+++ b/src/main/java/com/franco/dev/domain/empresarial/Impresora.java
@@ -66,6 +66,17 @@ public class Impresora implements Identifiable<Long> {
     /** Direccion IP (conexion RED / inalambrica). */
     private String ip;
 
+    /**
+     * Datos del share de Windows (conexion SMB). Son informativos/para reinstalar la cola: el
+     * transporte real vive en el device-uri de la cola CUPS. La password NO se guarda aca -- esta
+     * tabla se replica a TODAS las filiales via central_pub, asi que no puede llevar secretos;
+     * queda solo en /etc/cups/printers.conf del host duenio.
+     */
+    private String smbHost;
+    private String smbRecurso;
+    private String smbUsuario;
+    private String smbDominio;
+
     /** Puerto RAW/JetDirect (default 9100) para conexion RED. */
     private Integer puerto;
 

--- a/src/main/java/com/franco/dev/domain/empresarial/enums/TipoConexion.java
+++ b/src/main/java/com/franco/dev/domain/empresarial/enums/TipoConexion.java
@@ -4,5 +4,7 @@ public enum TipoConexion {
     CUPS,
     USB,
     RED,
+    /** Impresora compartida por un host Windows; el transporte lo hace el backend smb de CUPS. */
+    SMB,
     BLUETOOTH
 }

--- a/src/main/java/com/franco/dev/graphql/empresarial/input/ImpresoraInput.java
+++ b/src/main/java/com/franco/dev/graphql/empresarial/input/ImpresoraInput.java
@@ -19,6 +19,11 @@ public class ImpresoraInput {
     private String colaCups;
     private String ip;
     private Integer puerto;
+    /** Share de Windows (conexion SMB). Sin password: no se persiste (ver Impresora). */
+    private String smbHost;
+    private String smbRecurso;
+    private String smbUsuario;
+    private String smbDominio;
     private PerfilPapel perfilPapel;
     private Integer columnas;
     private Integer anchoMm;

--- a/src/main/java/com/franco/dev/graphql/impresion/CupsAdminGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/impresion/CupsAdminGraphQL.java
@@ -1,5 +1,6 @@
 package com.franco.dev.graphql.impresion;
 
+import com.franco.dev.service.impresion.ColaEstado;
 import com.franco.dev.service.impresion.CupsAdminService;
 import com.franco.dev.service.impresion.DispositivoDetectado;
 import graphql.kickstart.tools.GraphQLMutationResolver;
@@ -10,7 +11,8 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 
 /**
- * Detectar-para-instalar impresoras a nivel CUPS (Linux) en esta filial.
+ * Detectar-para-instalar impresoras a nivel CUPS (Linux) en este host, y ver/reparar el
+ * estado real de las colas.
  */
 @Component
 public class CupsAdminGraphQL implements GraphQLQueryResolver, GraphQLMutationResolver {
@@ -23,9 +25,32 @@ public class CupsAdminGraphQL implements GraphQLQueryResolver, GraphQLMutationRe
         return cupsAdminService.detectarDispositivos();
     }
 
+    /**
+     * Shares de impresora publicados por un host Windows. La password autentica la consulta y
+     * se descarta; las URIs devueltas van sin credenciales.
+     */
+    public List<DispositivoDetectado> recursosSmb(String host, String usuario, String dominio, String password) {
+        return cupsAdminService.detectarRecursosSmb(host, usuario, dominio, password);
+    }
+
+    /** Estado real de las colas de este host (lpstat -p), no el flag activo de la BD. */
+    public List<ColaEstado> estadoColas() {
+        return cupsAdminService.estadoColas();
+    }
+
     /** Instala una cola CUPS (raw por defecto, ideal para termicas ESC/POS). */
     public Boolean instalarImpresoraCups(String nombreCola, String uri, Boolean raw) {
         return cupsAdminService.instalarImpresora(nombreCola, uri, raw == null || raw);
+    }
+
+    /**
+     * Instala una cola CUPS que entrega los jobs a una impresora compartida por un host Windows
+     * (backend smb de CUPS / smbspool). La password solo se usa para armar el device-uri.
+     */
+    public Boolean instalarImpresoraSmb(String nombreCola, String host, String recurso,
+                                        String usuario, String dominio, String password, Boolean raw) {
+        return cupsAdminService.instalarImpresoraSmb(nombreCola, host, recurso, usuario, dominio,
+                password, raw == null || raw);
     }
 
     /**
@@ -34,5 +59,10 @@ public class CupsAdminGraphQL implements GraphQLQueryResolver, GraphQLMutationRe
      */
     public Boolean compartirColaCups(String nombreCola, String ipDestino) {
         return cupsAdminService.compartirCola(nombreCola, ipDestino);
+    }
+
+    /** Rehabilita una cola frenada por CUPS y libera los jobs retenidos. */
+    public Boolean reactivarCola(String nombreCola) {
+        return cupsAdminService.reactivarCola(nombreCola);
     }
 }

--- a/src/main/java/com/franco/dev/service/impresion/ColaEstado.java
+++ b/src/main/java/com/franco/dev/service/impresion/ColaEstado.java
@@ -1,0 +1,93 @@
+package com.franco.dev.service.impresion;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Estado real de una cola CUPS, tal como lo reporta {@code lpstat -p}.
+ *
+ * <p>Existe porque el chip de la tarjeta mostraba {@code impresora.activo} (un flag de la BD)
+ * y no el estado del sistema: en produccion la cola adm_ticket estuvo {@code disabled} tres
+ * dias mientras la app decia "Activa". CUPS deshabilita una cola ante un fallo del backend
+ * (politica {@code stop-printer}) y no se recupera sola.</p>
+ */
+public class ColaEstado {
+
+    public static final String INACTIVA = "INACTIVA";
+    public static final String IMPRIMIENDO = "IMPRIMIENDO";
+    public static final String DESHABILITADA = "DESHABILITADA";
+    public static final String DESCONOCIDA = "DESCONOCIDA";
+
+    private static final String PREFIJO = "printer ";
+
+    private String nombre;
+    private String estado;
+    private String razon;
+    private Boolean habilitada;
+
+    /**
+     * Parsea {@code lpstat -p}. Se ejecuta con {@code LC_ALL=C} para que las frases que se
+     * matchean aca no dependan del idioma del sistema.
+     */
+    public static List<ColaEstado> parsear(String salidaLpstat) {
+        List<ColaEstado> colas = new ArrayList<>();
+        if (salidaLpstat == null || salidaLpstat.isEmpty()) {
+            return colas;
+        }
+        String[] lineas = salidaLpstat.split("\\R");
+        for (int i = 0; i < lineas.length; i++) {
+            String linea = lineas[i];
+            if (!linea.startsWith(PREFIJO)) {
+                continue;
+            }
+            String resto = linea.substring(PREFIJO.length());
+            int sp = resto.indexOf(' ');
+            if (sp < 0) {
+                continue;
+            }
+            ColaEstado cola = new ColaEstado();
+            cola.nombre = resto.substring(0, sp);
+            cola.aplicarEstado(resto.substring(sp + 1));
+            cola.razon = razonSiguiente(lineas, i);
+            colas.add(cola);
+        }
+        return colas;
+    }
+
+    /** La razon del fallo viene en la linea indentada que sigue al encabezado de la cola. */
+    private static String razonSiguiente(String[] lineas, int indice) {
+        if (indice + 1 >= lineas.length) {
+            return "";
+        }
+        String siguiente = lineas[indice + 1];
+        if (siguiente.isEmpty() || !Character.isWhitespace(siguiente.charAt(0))) {
+            return "";
+        }
+        return siguiente.trim();
+    }
+
+    private void aplicarEstado(String descripcion) {
+        if (descripcion.contains("disabled since")) {
+            estado = DESHABILITADA;
+            habilitada = false;
+        } else if (descripcion.contains("now printing") || descripcion.contains("is busy")) {
+            estado = IMPRIMIENDO;
+            habilitada = true;
+        } else if (descripcion.contains("is idle")) {
+            estado = INACTIVA;
+            habilitada = true;
+        } else {
+            estado = DESCONOCIDA;
+            habilitada = !descripcion.contains("disabled");
+        }
+    }
+
+    public String getNombre() { return nombre; }
+    public void setNombre(String nombre) { this.nombre = nombre; }
+    public String getEstado() { return estado; }
+    public void setEstado(String estado) { this.estado = estado; }
+    public String getRazon() { return razon; }
+    public void setRazon(String razon) { this.razon = razon; }
+    public Boolean getHabilitada() { return habilitada; }
+    public void setHabilitada(Boolean habilitada) { this.habilitada = habilitada; }
+}

--- a/src/main/java/com/franco/dev/service/impresion/CupsAdminService.java
+++ b/src/main/java/com/franco/dev/service/impresion/CupsAdminService.java
@@ -11,7 +11,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -83,12 +85,7 @@ public class CupsAdminService {
             log.warn("[CUPS] Parametros invalidos para instalar (cola='{}', uri='{}')", cola, uri);
             return false;
         }
-        // printer-error-policy=retry-current-job: ante un error del backend la cola NO se pausa
-        // (evita el "stop-printer" por defecto, que deja la impresora inactiva y los jobs pendientes).
-        List<String> cmd = new ArrayList<>(Arrays.asList(
-                "lpadmin", "-p", cola, "-E", "-v", uri, "-m", raw ? "raw" : "everywhere",
-                "-o", "printer-error-policy=retry-current-job"));
-        return ejecutar(cmd);
+        return ejecutar(comandoInstalar(cola, uri, raw));
     }
 
     /**
@@ -171,7 +168,106 @@ public class CupsAdminService {
         }
     }
 
+
+    // ---- impresoras compartidas por un host Windows (SMB/CIFS) ----
+
+    /**
+     * Lista los shares de impresora publicados por un host Windows via
+     * {@code smbclient -L //host -g}. Sin credenciales usa login anonimo ({@code -N}), que en
+     * la practica suele devolver {@code NT_STATUS_ACCESS_DENIED} (asi respondio adm-bodega).
+     *
+     * <p>La password se pasa por la variable de entorno {@code PASSWD} y no por argumento, para
+     * que no quede visible en {@code ps} para el resto de los usuarios del host.</p>
+     */
+    public List<DispositivoDetectado> detectarRecursosSmb(String host, String usuario,
+                                                          String dominio, String password) {
+        if (host == null || host.trim().isEmpty()) {
+            log.warn("[SMB] Host requerido para detectar recursos");
+            return Collections.emptyList();
+        }
+        List<String> cmd = new ArrayList<>(Arrays.asList("smbclient", "-L", "//" + host.trim(), "-g"));
+        Map<String, String> env = new HashMap<>();
+        if (usuario != null && !usuario.trim().isEmpty()) {
+            String identidad = (dominio != null && !dominio.trim().isEmpty())
+                    ? dominio.trim() + "\\" + usuario.trim()
+                    : usuario.trim();
+            cmd.add("-U");
+            cmd.add(identidad);
+            env.put("PASSWD", password == null ? "" : password);
+        } else {
+            cmd.add("-N");
+        }
+        Resultado r = correr(cmd, env);
+        List<DispositivoDetectado> recursos = SmbPrinterSupport.recursosDeImpresora(host.trim(), r.salida);
+        if (recursos.isEmpty() && r.codigo != 0) {
+            log.warn("[SMB] No se pudieron listar los recursos de {}: {}", host, r.salida.trim());
+        }
+        return recursos;
+    }
+
+    /**
+     * Instala una cola CUPS que entrega los jobs a una impresora compartida por un host Windows,
+     * usando el backend {@code smb} de CUPS (smbspool). Para el motor de impresion Java pasa a ser
+     * una cola local mas.
+     *
+     * <p>La password se usa solo para armar el device-uri y no se persiste en la BD: queda en
+     * {@code /etc/cups/printers.conf} (root-only), que es donde CUPS la necesita para reconectar.</p>
+     */
+    public boolean instalarImpresoraSmb(String nombreCola, String host, String recurso,
+                                        String usuario, String dominio, String password, boolean raw) {
+        String cola = sanearNombre(nombreCola);
+        if (cola.isEmpty()) {
+            log.warn("[SMB] Nombre de cola invalido");
+            return false;
+        }
+        String uri;
+        try {
+            uri = SmbPrinterSupport.deviceUri(host, recurso, usuario, dominio, password);
+        } catch (IllegalArgumentException e) {
+            log.warn("[SMB] No se pudo armar el device-uri: {}", e.getMessage());
+            return false;
+        }
+        return ejecutar(comandoInstalar(cola, uri, raw));
+    }
+
+    // ---- estado real de las colas ----
+
+    /**
+     * Estado real de las colas CUPS de este host ({@code lpstat -p}). La app mostraba
+     * {@code impresora.activo} de la BD, que no sabe nada de una cola frenada por CUPS.
+     */
+    public List<ColaEstado> estadoColas() {
+        return ColaEstado.parsear(correr(Arrays.asList("lpstat", "-p")).salida);
+    }
+
+    /**
+     * Vuelve a habilitar una cola que CUPS freno ante un fallo del backend y libera los jobs
+     * retenidos. Ademas le fija {@code printer-error-policy=retry-current-job}: sin eso la cola
+     * se vuelve a deshabilitar sola en el proximo corte (es lo que le paso a adm_ticket, creada
+     * a mano con la politica {@code stop-printer} por defecto).
+     */
+    public boolean reactivarCola(String nombreCola) {
+        String cola = sanearNombre(nombreCola);
+        if (cola.isEmpty()) {
+            log.warn("[CUPS] Nombre de cola invalido para reactivar");
+            return false;
+        }
+        ejecutar(Arrays.asList("lpadmin", "-p", cola, "-o", "printer-error-policy=retry-current-job"));
+        ejecutar(Arrays.asList("cupsaccept", cola));
+        return ejecutar(Arrays.asList("cupsenable", "--release", cola));
+    }
+
     // ---- helpers ----
+
+    /**
+     * printer-error-policy=retry-current-job: ante un error del backend la cola NO se pausa
+     * (evita el "stop-printer" por defecto, que deja la impresora inactiva y los jobs pendientes).
+     */
+    private List<String> comandoInstalar(String cola, String uri, boolean raw) {
+        return new ArrayList<>(Arrays.asList(
+                "lpadmin", "-p", cola, "-E", "-v", uri, "-m", raw ? "raw" : "everywhere",
+                "-o", "printer-error-policy=retry-current-job"));
+    }
 
     private DispositivoDetectado parsearLinea(String lineaRaw) {
         if (lineaRaw == null) {
@@ -259,8 +355,23 @@ public class CupsAdminService {
     }
 
     private Resultado correr(List<String> cmd) {
+        return correr(cmd, Collections.emptyMap());
+    }
+
+    /**
+     * Ejecuta un comando con {@code LC_ALL=C} (las salidas de lpstat/lpadmin se parsean por texto,
+     * no pueden depender del idioma del sistema) y con las variables de entorno extra que reciba
+     * (se usa para pasarle {@code PASSWD} a smbclient sin exponerla en {@code ps}).
+     *
+     * <p>Tanto el comando como su salida se loguean redactados: pueden contener la password del
+     * share de Windows.</p>
+     */
+    private Resultado correr(List<String> cmd, Map<String, String> envExtra) {
         try {
-            Process proceso = new ProcessBuilder(cmd).redirectErrorStream(true).start();
+            ProcessBuilder pb = new ProcessBuilder(cmd).redirectErrorStream(true);
+            pb.environment().put("LC_ALL", "C");
+            pb.environment().putAll(envExtra);
+            Process proceso = pb.start();
             StringBuilder salida = new StringBuilder();
             try (BufferedReader reader = new BufferedReader(
                     new InputStreamReader(proceso.getInputStream(), StandardCharsets.UTF_8))) {
@@ -272,13 +383,14 @@ public class CupsAdminService {
             boolean termino = proceso.waitFor(TIMEOUT_SEG, TimeUnit.SECONDS);
             int codigo = termino ? proceso.exitValue() : -1;
             if (codigo != 0) {
-                log.warn("[CUPS] Comando {} terminó con código {}: {}", cmd, codigo, salida.toString().trim());
+                log.warn("[CUPS] Comando {} terminó con código {}: {}", SmbPrinterSupport.redactar(cmd),
+                        codigo, SmbPrinterSupport.redactarTexto(salida.toString().trim()));
             } else {
-                log.info("[CUPS] Comando {} OK", cmd);
+                log.info("[CUPS] Comando {} OK", SmbPrinterSupport.redactar(cmd));
             }
             return new Resultado(codigo, salida.toString());
         } catch (Exception e) {
-            log.error("[CUPS] Error ejecutando {}: {}", cmd, e.getMessage(), e);
+            log.error("[CUPS] Error ejecutando {}: {}", SmbPrinterSupport.redactar(cmd), e.getMessage(), e);
             return new Resultado(-1, e.getMessage() == null ? "" : e.getMessage());
         }
     }

--- a/src/main/java/com/franco/dev/service/impresion/ImpresoraPrintService.java
+++ b/src/main/java/com/franco/dev/service/impresion/ImpresoraPrintService.java
@@ -18,7 +18,9 @@ import java.io.OutputStream;
 /**
  * Abre el destino de impresion correcto a partir de una {@link Impresora} del registro:
  * <ul>
- *   <li>CUPS / USB / BLUETOOTH: cola local del sistema via {@link PrinterOutputStream}.</li>
+ *   <li>CUPS / USB / SMB / BLUETOOTH: cola local del sistema via {@link PrinterOutputStream}.
+ *       En SMB la cola apunta a un share de Windows (device-uri {@code smb://...}); el que habla
+ *       CIFS es el backend smb de CUPS, para Java es una cola mas.</li>
  *   <li>RED / inalambrica: socket a IP:puerto via {@link TcpIpOutputStream} (RAW/JetDirect).</li>
  * </ul>
  * Devuelve un {@link EscPos} listo para escribir y el {@link TicketFormato} con las
@@ -43,7 +45,8 @@ public class ImpresoraPrintService {
             log.info("Imprimiendo por RED a {}:{}", impresora.getIp(), puerto);
             return new TcpIpOutputStream(impresora.getIp(), puerto);
         }
-        // CUPS / USB / BLUETOOTH: cola local por nombre.
+        // CUPS / USB / SMB / BLUETOOTH: cola local por nombre. En SMB el device-uri de la cola
+        // apunta al share de Windows y smbspool hace la entrega; aca no cambia nada.
         PrintService ps = PrinterOutputStream.getPrintServiceByName(impresora.getColaCups());
         log.info("Imprimiendo por cola local '{}'", impresora.getColaCups());
         return new PrinterOutputStream(ps);

--- a/src/main/java/com/franco/dev/service/impresion/SmbPrinterSupport.java
+++ b/src/main/java/com/franco/dev/service/impresion/SmbPrinterSupport.java
@@ -1,0 +1,135 @@
+package com.franco.dev.service.impresion;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Helpers puros para impresoras compartidas por un host Windows (SMB/CIFS).
+ * Sin estado ni I/O: se testean directamente (ver SmbPrinterSupportTest).
+ *
+ * El transporte real lo hace CUPS: se instala una cola con device-uri {@code smb://...} y el
+ * backend {@code /usr/lib/cups/backend/smb} (smbspool, de Samba) entrega el job al share de
+ * Windows. Para el motor de impresion Java es una cola CUPS mas.
+ */
+public final class SmbPrinterSupport {
+
+    /** Clase que se reporta al frontend para distinguirlos de los dispositivos de lpinfo. */
+    public static final String CLASE = "smb";
+
+    private static final String MASCARA = "***";
+
+    private SmbPrinterSupport() {
+    }
+
+    /**
+     * Arma el device-uri que entiende smbspool:
+     * {@code smb://[usuario[:password]@][dominio/]host/recurso}.
+     *
+     * <p>La contrasena queda SOLO aca: la URI se pasa a {@code lpadmin} y CUPS la guarda en
+     * {@code /etc/cups/printers.conf} (root-only). Nunca se persiste en la BD, que se replica
+     * a todas las filiales.</p>
+     */
+    public static String deviceUri(String host, String recurso, String usuario,
+                                   String dominio, String password) {
+        if (esVacio(host)) {
+            throw new IllegalArgumentException("Host SMB requerido");
+        }
+        if (esVacio(recurso)) {
+            throw new IllegalArgumentException("Recurso (share) SMB requerido");
+        }
+        StringBuilder uri = new StringBuilder("smb://");
+        if (!esVacio(usuario)) {
+            uri.append(codificar(usuario));
+            if (!esVacio(password)) {
+                uri.append(':').append(codificar(password));
+            }
+            uri.append('@');
+        }
+        if (!esVacio(dominio)) {
+            uri.append(codificar(dominio)).append('/');
+        }
+        uri.append(codificar(host)).append('/').append(codificar(recurso));
+        return uri.toString();
+    }
+
+    /**
+     * Parsea la salida de {@code smbclient -L //host -g} y devuelve solo los shares de impresora.
+     * Formato por linea: {@code Tipo|Nombre|Comentario} (Disk, Printer, IPC, Server, Workgroup).
+     *
+     * <p>Las URIs devueltas van SIN credenciales: esta lista viaja al frontend.</p>
+     */
+    public static List<DispositivoDetectado> recursosDeImpresora(String host, String salida) {
+        List<DispositivoDetectado> recursos = new ArrayList<>();
+        if (salida == null || salida.isEmpty()) {
+            return recursos;
+        }
+        for (String linea : salida.split("\\R")) {
+            String[] partes = linea.split("\\|", 3);
+            if (partes.length < 2 || !"Printer".equalsIgnoreCase(partes[0].trim())) {
+                continue;
+            }
+            String nombre = partes[1].trim();
+            if (nombre.isEmpty()) {
+                continue;
+            }
+            DispositivoDetectado d = new DispositivoDetectado();
+            d.setClase(CLASE);
+            d.setUri(deviceUri(host, nombre, null, null, null));
+            d.setNombre(nombre);
+            d.setDescripcion(partes.length > 2 ? partes[2].trim() : "");
+            recursos.add(d);
+        }
+        return recursos;
+    }
+
+    /** Enmascara la password del userinfo de cualquier URI smb:// que aparezca en un texto. */
+    public static String redactarTexto(String texto) {
+        if (texto == null) {
+            return null;
+        }
+        return texto.replaceAll("(smb://[^:/@\\s]+):[^@\\s]*@", "$1:" + MASCARA + "@");
+    }
+
+    /**
+     * Enmascara la password en los argumentos antes de loguear el comando: el userinfo de una
+     * URI {@code smb://usuario:password@...} y el {@code -U usuario%password} de smbclient.
+     */
+    public static List<String> redactar(List<String> comando) {
+        List<String> redactado = new ArrayList<>(comando.size());
+        String anterior = "";
+        for (String arg : comando) {
+            if (("-U".equals(anterior) || "--user".equals(anterior)) && arg.contains("%")) {
+                redactado.add(arg.substring(0, arg.indexOf('%') + 1) + MASCARA);
+            } else {
+                redactado.add(redactarTexto(arg));
+            }
+            anterior = arg;
+        }
+        return redactado;
+    }
+
+    private static boolean esVacio(String s) {
+        return s == null || s.trim().isEmpty();
+    }
+
+    /**
+     * Percent-encoding RFC 3986: deja pasar los "unreserved" y codifica todo lo demas.
+     * No sirve {@code URLEncoder}, que codifica el espacio como {@code +} (valido en un query
+     * string, no en el userinfo ni en el path de una URI).
+     */
+    private static String codificar(String valor) {
+        StringBuilder salida = new StringBuilder(valor.length());
+        for (byte b : valor.getBytes(StandardCharsets.UTF_8)) {
+            int c = b & 0xFF;
+            boolean unreserved = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+                    || (c >= '0' && c <= '9') || c == '-' || c == '.' || c == '_' || c == '~';
+            if (unreserved) {
+                salida.append((char) c);
+            } else {
+                salida.append('%').append(String.format("%02X", c));
+            }
+        }
+        return salida.toString();
+    }
+}

--- a/src/main/resources/db/migration/V201.5__impresora_smb_windows.sql
+++ b/src/main/resources/db/migration/V201.5__impresora_smb_windows.sql
@@ -1,0 +1,15 @@
+-- Impresoras alojadas en una PC Windows y compartidas por SMB/CIFS.
+--
+-- El transporte ya lo resolvia CUPS (backend /usr/lib/cups/backend/smb -> smbspool): en produccion
+-- la cola adm_ticket ya apuntaba a smb://100.64.0.10/adm_ticket, creada a mano. Lo que faltaba era
+-- que la app pudiera registrarlas, detectarlas e instalarlas. Ver impresoras.md seccion SMB.
+--
+-- Estas columnas son informativas / para reinstalar la cola. La contrasena del share NO se guarda:
+-- impresora se replica MAIN_TO_ALL a todas las filiales (V144.3), asi que no puede llevar secretos.
+-- La credencial vive unicamente en el device-uri que CUPS persiste en /etc/cups/printers.conf
+-- (root-only) del host donde esta instalada la cola.
+ALTER TABLE empresarial.impresora
+    ADD COLUMN IF NOT EXISTS smb_host VARCHAR(120),
+    ADD COLUMN IF NOT EXISTS smb_recurso VARCHAR(255),
+    ADD COLUMN IF NOT EXISTS smb_usuario VARCHAR(120),
+    ADD COLUMN IF NOT EXISTS smb_dominio VARCHAR(120);

--- a/src/main/resources/graphql/empresarial/cups-admin.graphqls
+++ b/src/main/resources/graphql/empresarial/cups-admin.graphqls
@@ -6,11 +6,36 @@ type DispositivoDetectado {
     descripcion: String
 }
 
+# Estado real de una cola CUPS (lpstat -p), independiente del flag impresora.activo de la BD.
+type ColaEstado {
+    nombre: String
+    # INACTIVA | IMPRIMIENDO | DESHABILITADA | DESCONOCIDA
+    estado: String
+    razon: String
+    habilitada: Boolean
+}
+
 extend type Query {
     dispositivosParaInstalar: [DispositivoDetectado]
+    # Shares de impresora publicados por un host Windows (smbclient -L). La password se usa
+    # solo para autenticar la consulta; no se persiste ni vuelve en la respuesta.
+    recursosSmb(host: String!, usuario: String, dominio: String, password: String): [DispositivoDetectado]
+    estadoColas: [ColaEstado]
 }
 
 extend type Mutation {
     instalarImpresoraCups(nombreCola: String!, uri: String!, raw: Boolean): Boolean
     compartirColaCups(nombreCola: String!, ipDestino: String): Boolean
+    # Instala una cola CUPS que entrega a un share de Windows via smbspool.
+    instalarImpresoraSmb(
+        nombreCola: String!
+        host: String!
+        recurso: String!
+        usuario: String
+        dominio: String
+        password: String
+        raw: Boolean
+    ): Boolean
+    # Rehabilita una cola que CUPS freno ante un fallo y le fija la politica de reintento.
+    reactivarCola(nombreCola: String!): Boolean
 }

--- a/src/main/resources/graphql/empresarial/impresora.graphqls
+++ b/src/main/resources/graphql/empresarial/impresora.graphqls
@@ -16,6 +16,8 @@ enum TipoConexion {
     CUPS
     USB
     RED
+    # Impresora compartida por un host Windows (transporte via backend smb de CUPS)
+    SMB
     BLUETOOTH
 }
 
@@ -41,6 +43,11 @@ type Impresora {
     colaCups: String
     ip: String
     puerto: Int
+    # Share de Windows (conexion SMB). Nunca incluye la password.
+    smbHost: String
+    smbRecurso: String
+    smbUsuario: String
+    smbDominio: String
     perfilPapel: PerfilPapel
     columnas: Int
     anchoMm: Int
@@ -72,6 +79,11 @@ input ImpresoraInput {
     colaCups: String
     ip: String
     puerto: Int
+    # Share de Windows (conexion SMB). Nunca incluye la password.
+    smbHost: String
+    smbRecurso: String
+    smbUsuario: String
+    smbDominio: String
     perfilPapel: PerfilPapel
     columnas: Int
     anchoMm: Int

--- a/src/test/java/com/franco/dev/service/impresion/ColaEstadoTest.java
+++ b/src/test/java/com/franco/dev/service/impresion/ColaEstadoTest.java
@@ -1,0 +1,83 @@
+package com.franco.dev.service.impresion;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * La tarjeta de la app mostraba "Activa" (impresora.activo de la BD) mientras CUPS tenia la
+ * cola deshabilitada hace tres dias y los tickets se perdian. Estos tests fijan la lectura
+ * del estado real de lpstat -p, que es lo que ahora muestra la UI.
+ */
+class ColaEstadoTest {
+
+    /** Salida real de frc-servidor (LC_ALL=C). */
+    private static final String SALIDA_PROD = String.join("\n",
+            "printer adm_ticket disabled since Wed 19 Aug 2026 01:11:49 PM -03 -",
+            "\tUnable to connect to CIFS host after (tried 3 times)",
+            "printer EPSON_L395_Series is idle.  enabled since Wed 22 Jul 2026 09:50:13 AM -03",
+            "printer pronet is idle.  enabled since Wed 31 Dec 1969 08:00:00 PM -04",
+            "printer ticket_soporte is idle.  enabled since Sat 22 Aug 2026 11:05:19 AM -03");
+
+    @Test
+    void leeTodasLasColas() {
+        assertEquals(4, ColaEstado.parsear(SALIDA_PROD).size());
+    }
+
+    @Test
+    void colaFrenadaQuedaDeshabilitadaConSuRazon() {
+        ColaEstado cola = ColaEstado.parsear(SALIDA_PROD).get(0);
+
+        assertEquals("adm_ticket", cola.getNombre());
+        assertEquals("DESHABILITADA", cola.getEstado());
+        assertFalse(cola.getHabilitada());
+        assertEquals("Unable to connect to CIFS host after (tried 3 times)", cola.getRazon());
+    }
+
+    @Test
+    void colaSanaQuedaInactivaYHabilitada() {
+        ColaEstado cola = ColaEstado.parsear(SALIDA_PROD).get(1);
+
+        assertEquals("EPSON_L395_Series", cola.getNombre());
+        assertEquals("INACTIVA", cola.getEstado());
+        assertTrue(cola.getHabilitada());
+    }
+
+    @Test
+    void colaTrabajandoQuedaImprimiendo() {
+        List<ColaEstado> colas = ColaEstado.parsear(
+                "printer ticket_soporte now printing ticket_soporte-42.  enabled since Sat 22 Aug 2026");
+
+        assertEquals("IMPRIMIENDO", colas.get(0).getEstado());
+        assertTrue(colas.get(0).getHabilitada());
+    }
+
+    @Test
+    void deshabilitadaSinRazonNoRompe() {
+        List<ColaEstado> colas = ColaEstado.parsear("printer adm_ticket disabled since Wed 19 Aug 2026 -");
+
+        assertEquals("DESHABILITADA", colas.get(0).getEstado());
+        assertEquals("", colas.get(0).getRazon());
+    }
+
+    @Test
+    void ignoraLasLineasQueNoSonUnaCola() {
+        List<ColaEstado> colas = ColaEstado.parsear(String.join("\n",
+                "scheduler is running",
+                "no system default destination",
+                "printer adm_ticket is idle.  enabled since Wed 22 Jul 2026"));
+
+        assertEquals(1, colas.size());
+        assertEquals("adm_ticket", colas.get(0).getNombre());
+    }
+
+    @Test
+    void salidaVaciaDevuelveListaVacia() {
+        assertTrue(ColaEstado.parsear("").isEmpty());
+        assertTrue(ColaEstado.parsear(null).isEmpty());
+    }
+}

--- a/src/test/java/com/franco/dev/service/impresion/SmbPrinterSupportTest.java
+++ b/src/test/java/com/franco/dev/service/impresion/SmbPrinterSupportTest.java
@@ -1,0 +1,145 @@
+package com.franco.dev.service.impresion;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.franco.dev.service.impresion.SmbPrinterSupport.deviceUri;
+import static com.franco.dev.service.impresion.SmbPrinterSupport.recursosDeImpresora;
+import static com.franco.dev.service.impresion.SmbPrinterSupport.redactar;
+import static com.franco.dev.service.impresion.SmbPrinterSupport.redactarTexto;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * El device-uri es lo unico que ve smbspool: si esta mal armado la cola queda instalada
+ * pero nunca conecta (el sintoma que tuvimos en produccion con adm_ticket). No se puede
+ * verificar contra un host Windows en CI, asi que estos tests fijan el formato.
+ */
+class SmbPrinterSupportTest {
+
+    @Test
+    void sinCredencialesQuedaLaUriDesnuda() {
+        assertEquals("smb://100.64.0.10/adm_ticket",
+                deviceUri("100.64.0.10", "adm_ticket", null, null, null));
+    }
+
+    @Test
+    void usuarioYPasswordVanComoUserinfo() {
+        assertEquals("smb://admin:secreta@100.64.0.10/adm_ticket",
+                deviceUri("100.64.0.10", "adm_ticket", "admin", null, "secreta"));
+    }
+
+    @Test
+    void usuarioSinPasswordNoDejaLosDosPuntos() {
+        assertEquals("smb://admin@100.64.0.10/adm_ticket",
+                deviceUri("100.64.0.10", "adm_ticket", "admin", null, null));
+    }
+
+    @Test
+    void elDominioVaComoPrimerSegmentoDelPath() {
+        // Formato de smbspool: smb://usuario:pass@workgroup/servidor/impresora
+        assertEquals("smb://admin:secreta@WORKGROUP/100.64.0.10/adm_ticket",
+                deviceUri("100.64.0.10", "adm_ticket", "admin", "WORKGROUP", "secreta"));
+    }
+
+    @Test
+    void losCaracteresReservadosSeCodifican() {
+        // Un password con @ o / partiria la URI en dos y CUPS conectaria a otro host.
+        assertEquals("smb://adm%40bodega:p%40ss%2Fword%3A1@100.64.0.10/adm_ticket",
+                deviceUri("100.64.0.10", "adm_ticket", "adm@bodega", null, "p@ss/word:1"));
+    }
+
+    @Test
+    void elEspacioEnElRecursoSeCodifica() {
+        assertEquals("smb://ADM-BODEGA/Microsoft%20Print%20to%20PDF",
+                deviceUri("ADM-BODEGA", "Microsoft Print to PDF", null, null, null));
+    }
+
+    @Test
+    void hostVacioEsError() {
+        assertThrows(IllegalArgumentException.class,
+                () -> deviceUri("  ", "adm_ticket", null, null, null));
+    }
+
+    @Test
+    void recursoVacioEsError() {
+        assertThrows(IllegalArgumentException.class,
+                () -> deviceUri("100.64.0.10", null, null, null, null));
+    }
+
+    @Test
+    void soloDevuelveLosSharesDeImpresora() {
+        String salida = String.join("\n",
+                "Anonymous login successful",
+                "Disk|ADMIN$|Remote Admin",
+                "Disk|C$|Default share",
+                "Printer|adm_ticket|Impresora de tickets ADM",
+                "IPC|IPC$|Remote IPC",
+                "Printer|Microsoft Print to PDF|",
+                "Server|ADM-BODEGA|",
+                "Workgroup|WORKGROUP|ADM-BODEGA");
+
+        List<DispositivoDetectado> recursos = recursosDeImpresora("100.64.0.10", salida);
+
+        assertEquals(2, recursos.size());
+        assertEquals("adm_ticket", recursos.get(0).getNombre());
+        assertEquals("Impresora de tickets ADM", recursos.get(0).getDescripcion());
+        assertEquals("Microsoft Print to PDF", recursos.get(1).getNombre());
+    }
+
+    @Test
+    void laUriDelRecursoDetectadoNoLlevaCredenciales() {
+        // Esta lista viaja al frontend: no puede filtrar la contrasena del share.
+        List<DispositivoDetectado> recursos =
+                recursosDeImpresora("100.64.0.10", "Printer|adm_ticket|Tickets");
+
+        assertEquals("smb://100.64.0.10/adm_ticket", recursos.get(0).getUri());
+        assertEquals("smb", recursos.get(0).getClase());
+    }
+
+    @Test
+    void salidaSinSharesDevuelveListaVacia() {
+        String salida = "session setup failed: NT_STATUS_ACCESS_DENIED";
+        assertTrue(recursosDeImpresora("100.64.0.10", salida).isEmpty());
+    }
+
+    @Test
+    void elLogNoPuedeFiltrarLaPasswordDelShare() {
+        // CupsAdminService loguea el comando completo; con la URI cruda la contrasena de
+        // Windows terminaria en backend*.log.
+        List<String> cmd = List.of("lpadmin", "-p", "adm_ticket", "-E",
+                "-v", "smb://admin:secreta@100.64.0.10/adm_ticket", "-m", "raw");
+
+        assertEquals(List.of("lpadmin", "-p", "adm_ticket", "-E",
+                "-v", "smb://admin:***@100.64.0.10/adm_ticket", "-m", "raw"), redactar(cmd));
+    }
+
+    @Test
+    void tambienRedactaLaPasswordDeSmbclient() {
+        assertEquals(List.of("smbclient", "-L", "//100.64.0.10", "-g", "-U", "WORKGROUP\\admin%***"),
+                redactar(List.of("smbclient", "-L", "//100.64.0.10", "-g", "-U", "WORKGROUP\\admin%secreta")));
+    }
+
+    @Test
+    void unaUriSinPasswordQuedaIgual() {
+        List<String> cmd = List.of("lpadmin", "-v", "smb://100.64.0.10/adm_ticket");
+        assertEquals(cmd, redactar(cmd));
+    }
+
+    @Test
+    void tambienRedactaLaSalidaDelComando() {
+        // lpadmin repite el device-uri en sus mensajes de error, y esa salida tambien se loguea.
+        assertEquals("lpadmin: Bad device-uri \"smb://admin:***@100.64.0.10/adm_ticket\"",
+                redactarTexto("lpadmin: Bad device-uri \"smb://admin:secreta@100.64.0.10/adm_ticket\""));
+    }
+
+    @Test
+    void unaSalidaSinCredencialesQuedaIgual() {
+        assertEquals("Unable to connect to CIFS host after (tried 3 times)",
+                redactarTexto("Unable to connect to CIFS host after (tried 3 times)"));
+        assertNull(redactarTexto(null));
+    }
+}


### PR DESCRIPTION
## Qué resuelve

Una impresora colgada por USB de una PC Windows y compartida por SMB **ya se podía usar**, pero solo creando la cola CUPS a mano en el host — así estaba `adm_ticket`, apuntando a `smb://100.64.0.10/adm_ticket`. La app no sabía registrarlas, detectarlas ni instalarlas, y tampoco veía cuándo CUPS frenaba una cola.

Este PR cierra las tres cosas.

### Registro
- Nuevo `TipoConexion.SMB`.
- Columnas informativas `smb_host` / `smb_recurso` / `smb_usuario` / `smb_dominio` en `empresarial.impresora` (`V201.5`).
- **La password NO se persiste.** `impresora` se replica `MAIN_TO_ALL` a todas las filiales (V144.3), así que la tabla no puede llevar secretos. La credencial vive únicamente en el device-uri que CUPS guarda en `/etc/cups/printers.conf` (root-only) del host dueño de la cola.

### Detección e instalación
- `Query recursosSmb(host, usuario, dominio, password)` — lista los shares de impresora del host Windows vía `smbclient -L //host -g`. La password se pasa por la env `PASSWD`, **no por argumento**, para que no quede visible en `ps` para el resto de los usuarios del host. Sin credenciales usa login anónimo (`-N`), que en la práctica devuelve `NT_STATUS_ACCESS_DENIED`.
- `Mutation instalarImpresoraSmb(...)` — crea la cola con el backend `smb` de CUPS (smbspool). Para el motor de impresión Java pasa a ser una cola local más, así que `ImpresoraPrintService` **no cambia de camino**: solo se documentó que SMB entra por la rama de cola local.

### Estado real de las colas
- `Query estadoColas` (`lpstat -p`) y `Mutation reactivarCola(nombreCola)`.
- El problema: la app mostraba `impresora.activo`, un flag de BD que no sabe nada de una cola frenada. CUPS deshabilita una cola ante un fallo del backend y **no se recupera sola** — es lo que dejaba tickets sin salir sin ningún aviso.
- `reactivarCola` hace `cupsaccept` + `cupsenable --release` (libera los jobs retenidos) y además le fija `printer-error-policy=retry-current-job`, para que no se vuelva a frenar en el próximo corte. `adm_ticket` fue creada a mano con la política `stop-printer` por defecto.

### Endurecimiento del runner de comandos
- Los comandos y sus salidas se loguean **redactados** (pueden traer la password del share).
- Se corren con `LC_ALL=C`: el parseo de `lpstat`/`lpadmin` es por texto y no puede depender del idioma del sistema.

## Cómo probarlo

1. En el host del backend, tener instalado `smbclient` y el backend smb de CUPS (`/usr/lib/cups/backend/smb`).
2. GraphiQL → `recursosSmb(host: "100.64.0.10", usuario: "...", dominio: "WORKGROUP", password: "...")` → debe devolver los shares de impresora publicados.
3. `instalarImpresoraSmb(nombreCola: "prueba_smb", host: "...", recurso: "...", usuario: "...", dominio: "...", password: "...")` → verificar con `lpstat -v prueba_smb` que el device-uri quedó `smb://...`, y con `lpstat -p prueba_smb` que la cola está habilitada.
4. Registrar la impresora con `conexion: SMB` y `colaCups: "prueba_smb"`, e imprimir la prueba: debe salir por la Windows.
5. `estadoColas` → comparar contra `lpstat -p`. Frenar una cola a mano (`cupsdisable`) y verificar que aparece `DESHABILITADA` con su razón, y que `reactivarCola` la vuelve a `INACTIVA`.

## Impacto en DB

`V201.5__impresora_smb_windows.sql` — solo `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` (4 columnas nullable). Sin `DROP`, sin `RENAME`, sin cambio de tipo. **Retrocompatible**: la versión anterior del backend ignora las columnas nuevas. Número único (la máxima previa es `V200.5`).

## Impacto en rollback

Ninguno. El JAR anterior corre igual contra el esquema nuevo; las columnas quedan sin uso. Las colas CUPS ya instaladas siguen funcionando porque el transporte está en `printers.conf`, no en la app.

## Riesgo

**Bajo.** El camino de impresión existente no cambia. Todo lo nuevo son endpoints adicionales que requieren que el backend pueda ejecutar `lpadmin`/`cupsenable`/`smbclient` en su host — si no tiene permisos, devuelven `false` y se loguea el motivo, sin afectar nada más.

## Cross-proyecto

Requiere el PR par del desktop (`GabFrank/frc-sistemas-integrados-angular`). Los campos nuevos de `Impresora`/`ImpresoraInput` son opcionales, así que el desktop y el mobile en su versión actual siguen andando contra este schema.

## Verificación

`./mvnw clean verify -DskipFlyway=true` → BUILD SUCCESS, 53 clases de test, 0 failures / 0 errors (incluye `SmbPrinterSupportTest` y `ColaEstadoTest`, nuevos).

> **Nota:** el cambio local `spring.profiles.active=user-dev` en `application.properties` quedó deliberadamente fuera del commit — es un override de dev.