### PR TITLE
feat(rrhh): revertir un egreso hecho por error

### DIFF
--- a/src/main/java/com/franco/dev/domain/rrhh/FuncionarioEgresoHistorico.java
+++ b/src/main/java/com/franco/dev/domain/rrhh/FuncionarioEgresoHistorico.java
@@ -1,0 +1,102 @@
+package com.franco.dev.domain.rrhh;
+
+import com.franco.dev.config.Identifiable;
+import com.franco.dev.domain.personas.Funcionario;
+import com.franco.dev.domain.personas.Usuario;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.*;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * Snapshot del estado que un egreso destruye, tomado ANTES de guardarlo.
+ *
+ * <p>Egresar no solo apaga tres campos: {@code FuncionarioService.save} pone el credito
+ * del funcionario en cero, y la cascada de estado inactiva al usuario, inactiva al
+ * cliente, lo devuelve a NORMAL y le borra el credito. Sin esta foto, revertir un egreso
+ * hecho por error obliga a ir a un backup -- que es lo que paso en farmacia el
+ * 2026-08-21.</p>
+ *
+ * <p>Con el snapshot la reversa <b>restaura</b> en vez de preguntar, y el cliente
+ * recupera su tipo real: sin {@code clienteTipoAnterior} la cascada lo reactiva siempre
+ * como FUNCIONARIO, degradando en silencio a un VIP.</p>
+ *
+ * <p>Aditivo y central-only, como las otras dos historicas del modulo.</p>
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "funcionario_egreso_historico", schema = "rrhh")
+public class FuncionarioEgresoHistorico implements Identifiable<Long> {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GenericGenerator(
+            name = "assigned-identity",
+            strategy = "com.franco.dev.config.AssignedIdentityGenerator"
+    )
+    @GeneratedValue(
+            generator = "assigned-identity",
+            strategy = GenerationType.IDENTITY
+    )
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "funcionario_id", nullable = true)
+    private Funcionario funcionario;
+
+    @Column(name = "fecha_egreso")
+    private LocalDateTime fechaEgreso;
+
+    @Column(name = "motivo_egreso")
+    private String motivoEgreso;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "egresado_por_id", nullable = true)
+    private Usuario egresadoPor;
+
+    /** Credito del funcionario antes del egreso. save() lo pone en cero. */
+    @Column(name = "credito_anterior")
+    private BigDecimal creditoAnterior;
+
+    @Column(name = "usuario_id")
+    private Long usuarioId;
+
+    @Column(name = "usuario_activo_anterior")
+    private Boolean usuarioActivoAnterior;
+
+    @Column(name = "cliente_id")
+    private Long clienteId;
+
+    /** Tipo del cliente antes del egreso. Sin esto, revertir degrada a un VIP. */
+    @Column(name = "cliente_tipo_anterior")
+    private String clienteTipoAnterior;
+
+    @Column(name = "cliente_credito_anterior")
+    private BigDecimal clienteCreditoAnterior;
+
+    @Column(name = "cliente_activo_anterior")
+    private Boolean clienteActivoAnterior;
+
+    /** NULL mientras el egreso siga vigente. */
+    @Column(name = "revertido_en")
+    private LocalDateTime revertidoEn;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "revertido_por_id", nullable = true)
+    private Usuario revertidoPor;
+
+    @Column(name = "motivo_reversion")
+    private String motivoReversion;
+
+    @CreationTimestamp
+    @Column(name = "creado_en")
+    private LocalDateTime creadoEn;
+}

--- a/src/main/java/com/franco/dev/graphql/rrhh/FuncionarioRrhhGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/rrhh/FuncionarioRrhhGraphQL.java
@@ -94,6 +94,16 @@ public class FuncionarioRrhhGraphQL implements GraphQLQueryResolver, GraphQLMuta
     }
 
     /**
+     * El egreso vigente del funcionario, para que el dialogo de reversa precargue el
+     * credito en vez de pedirle al usuario que lo reconstruya. Null si el egreso es
+     * anterior al historico.
+     */
+    public com.franco.dev.domain.rrhh.FuncionarioEgresoHistorico egresoVigenteFuncionario(Long funcionarioId) {
+        seg.requireVer();
+        return funcionarioRrhhService.egresoVigente(funcionarioId).orElse(null);
+    }
+
+    /**
      * Revierte un egreso hecho por error. Mismo gating que egresar: quien puede sacar a
      * alguien es quien puede volver a meterlo.
      *

--- a/src/main/java/com/franco/dev/graphql/rrhh/FuncionarioRrhhGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/rrhh/FuncionarioRrhhGraphQL.java
@@ -93,6 +93,18 @@ public class FuncionarioRrhhGraphQL implements GraphQLQueryResolver, GraphQLMuta
         return funcionarioRrhhService.egresar(funcionarioId, parseFecha(fecha), motivo);
     }
 
+    /**
+     * Revierte un egreso hecho por error. Mismo gating que egresar: quien puede sacar a
+     * alguien es quien puede volver a meterlo.
+     *
+     * <p>El credito va como parametro porque el egreso lo borra y no queda guardado en
+     * ninguna parte -- ver {@code FuncionarioRrhhService.revertirEgreso}.</p>
+     */
+    public Funcionario revertirEgresoFuncionario(Long funcionarioId, Float credito, String motivo) {
+        seg.requireAnyRole(seg.GESTIONAR, seg.APROBAR);
+        return funcionarioRrhhService.revertirEgreso(funcionarioId, credito, motivo);
+    }
+
     public FuncionarioDocumento saveFuncionarioDocumento(FuncionarioDocumentoInput input) {
         seg.requireAnyRole(seg.GESTIONAR);
         FuncionarioDocumento e = input.getId() != null

--- a/src/main/java/com/franco/dev/repository/rrhh/FuncionarioEgresoHistoricoRepository.java
+++ b/src/main/java/com/franco/dev/repository/rrhh/FuncionarioEgresoHistoricoRepository.java
@@ -1,0 +1,24 @@
+package com.franco.dev.repository.rrhh;
+
+import com.franco.dev.domain.rrhh.FuncionarioEgresoHistorico;
+import com.franco.dev.repository.HelperRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FuncionarioEgresoHistoricoRepository extends HelperRepository<FuncionarioEgresoHistorico, Long> {
+
+    default Class<FuncionarioEgresoHistorico> getEntityClass() {
+        return FuncionarioEgresoHistorico.class;
+    }
+
+    /**
+     * El egreso vigente del funcionario: el ultimo que todavia no se revirtio.
+     *
+     * <p>Se ordena por id y no por fecha_egreso porque la fecha la elige el usuario en el
+     * dialogo y puede ser retroactiva; el id es el orden real en que se cargaron.</p>
+     */
+    Optional<FuncionarioEgresoHistorico> findFirstByFuncionarioIdAndRevertidoEnIsNullOrderByIdDesc(Long funcionarioId);
+
+    List<FuncionarioEgresoHistorico> findByFuncionarioIdOrderByIdDesc(Long funcionarioId);
+}

--- a/src/main/java/com/franco/dev/service/rrhh/FuncionarioRrhhService.java
+++ b/src/main/java/com/franco/dev/service/rrhh/FuncionarioRrhhService.java
@@ -6,7 +6,12 @@ import com.franco.dev.domain.personas.Funcionario;
 import com.franco.dev.domain.personas.Usuario;
 import com.franco.dev.domain.rrhh.FuncionarioCargoHistorico;
 import com.franco.dev.domain.rrhh.FuncionarioSalarioHistorico;
+import com.franco.dev.domain.personas.Cliente;
+import com.franco.dev.domain.rrhh.LiquidacionFinal;
+import com.franco.dev.domain.rrhh.enums.LiquidacionFinalEstado;
+import com.franco.dev.repository.rrhh.LiquidacionFinalRepository;
 import com.franco.dev.service.empresarial.CargoService;
+import com.franco.dev.service.personas.ClienteService;
 import com.franco.dev.service.financiero.MonedaService;
 import com.franco.dev.service.personas.FuncionarioService;
 import com.franco.dev.service.personas.UsuarioService;
@@ -27,6 +32,7 @@ import java.util.List;
  */
 @Service
 @AllArgsConstructor
+@lombok.extern.slf4j.Slf4j
 public class FuncionarioRrhhService {
 
     private final FuncionarioService funcionarioService;
@@ -35,6 +41,8 @@ public class FuncionarioRrhhService {
     private final UsuarioService usuarioService;
     private final FuncionarioCargoHistoricoService cargoHistoricoService;
     private final FuncionarioSalarioHistoricoService salarioHistoricoService;
+    private final ClienteService clienteService;
+    private final LiquidacionFinalRepository liquidacionFinalRepository;
 
     /**
      * Cambia el cargo del funcionario dejando rastro: cierra el histórico abierto
@@ -106,5 +114,74 @@ public class FuncionarioRrhhService {
         f.setMotivoEgreso(motivo != null ? motivo.toUpperCase() : null);
         f.setActivo(false);
         return funcionarioService.save(f);
+    }
+
+    /**
+     * Revierte un egreso: deshace lo que {@link #egresar} dejo, incluido el dano
+     * colateral que egresar provoca y que no se ve en la pantalla de egreso.
+     *
+     * <p>Existe porque no habia ninguna forma de revertir un egreso desde la aplicacion.
+     * El 2026-08-21 se egreso por error a una funcionaria en farmacia y hubo que resolverlo
+     * el 22 con un UPDATE directo en produccion.</p>
+     *
+     * <p><b>Por que hace falta el parametro credito.</b> Egresar no solo apaga tres campos:
+     * {@code FuncionarioService.save} pone {@code credito = 0} cuando activo llega en false,
+     * y la cascada de estado hace lo mismo con el cliente ademas de pasarlo a NORMAL. Ese
+     * crédito no queda guardado en ninguna tabla -- {@code funcionario_salario_historico}
+     * guarda salario, no crédito -- asi que reactivar no puede recuperarlo solo: hay que
+     * decirle cual era. En el caso real hubo que sacarlo de un backup de nueve dias antes.</p>
+     *
+     * <p><b>El orden importa.</b> {@code save()} pisa el credito a cero cuando activo viene
+     * en false, asi que activo se setea en true ANTES de guardar. Y la cascada deja
+     * {@code cliente.credito = 0}, por lo que el crédito del cliente se re-sincroniza
+     * DESPUES del save -- esa sincronizacion vive en {@code FuncionarioGraphQL.saveFuncionario},
+     * no en el servicio, asi que por este camino hay que hacerla a mano o el funcionario
+     * queda con su crédito restaurado y el cliente en cero.</p>
+     *
+     * <p><b>El motivo no se persiste.</b> No hay tabla de historico de egresos; se deja en
+     * el log. Si la reversa tiene que ser auditable, hace falta esa tabla.</p>
+     */
+    @Transactional
+    public Funcionario revertirEgreso(Long funcionarioId, Float credito, String motivo) {
+        Funcionario f = funcionarioService.findById(funcionarioId)
+                .orElseThrow(() -> new GraphQLException("Funcionario no encontrado"));
+
+        if (Boolean.TRUE.equals(f.getActivo())) {
+            throw new GraphQLException("El funcionario ya esta activo: no hay egreso que revertir.");
+        }
+
+        // Un finiquito vigente es la contabilidad del egreso. Revertir el egreso dejandolo
+        // en pie deja al funcionario activo y con una liquidacion final que dice que se fue;
+        // si ademas esta PAGADA, ya salio plata de la caja por su salida.
+        for (LiquidacionFinal lf : liquidacionFinalRepository.findByFuncionarioIdOrderByCreadoEnDesc(funcionarioId)) {
+            if (lf.getEstado() != null && lf.getEstado() != LiquidacionFinalEstado.ANULADA) {
+                throw new GraphQLException("El funcionario tiene una liquidacion final "
+                        + lf.getEstado() + " (#" + lf.getId() + "). Anulala antes de revertir el egreso.");
+            }
+        }
+
+        LocalDateTime egresoPrevio = f.getFechaEgreso();
+        String motivoPrevio = f.getMotivoEgreso();
+        Float creditoRestaurado = credito != null ? credito : 0f;
+
+        f.setFechaEgreso(null);
+        f.setMotivoEgreso(null);
+        f.setActivo(true);
+        f.setCredito(creditoRestaurado);
+        Funcionario guardado = funcionarioService.save(f);
+
+        // La cascada reactivo al cliente y lo devolvio a FUNCIONARIO, pero le dejo el
+        // credito en cero.
+        if (guardado.getPersona() != null && guardado.getPersona().getId() != null) {
+            Cliente cliente = clienteService.findByPersonaId(guardado.getPersona().getId());
+            if (cliente != null && !java.util.Objects.equals(cliente.getCredito(), creditoRestaurado)) {
+                cliente.setCredito(creditoRestaurado);
+                clienteService.save(cliente);
+            }
+        }
+
+        log.info("Egreso revertido: funcionario={} egresoPrevio={} motivoPrevio={} creditoRestaurado={} motivoReversa={}",
+                funcionarioId, egresoPrevio, motivoPrevio, creditoRestaurado, motivo);
+        return guardado;
     }
 }

--- a/src/main/java/com/franco/dev/service/rrhh/FuncionarioRrhhService.java
+++ b/src/main/java/com/franco/dev/service/rrhh/FuncionarioRrhhService.java
@@ -9,6 +9,8 @@ import com.franco.dev.domain.rrhh.FuncionarioSalarioHistorico;
 import com.franco.dev.domain.personas.Cliente;
 import com.franco.dev.domain.rrhh.LiquidacionFinal;
 import com.franco.dev.domain.rrhh.enums.LiquidacionFinalEstado;
+import com.franco.dev.domain.rrhh.FuncionarioEgresoHistorico;
+import com.franco.dev.repository.rrhh.FuncionarioEgresoHistoricoRepository;
 import com.franco.dev.repository.rrhh.LiquidacionFinalRepository;
 import com.franco.dev.service.empresarial.CargoService;
 import com.franco.dev.service.personas.ClienteService;
@@ -43,6 +45,7 @@ public class FuncionarioRrhhService {
     private final FuncionarioSalarioHistoricoService salarioHistoricoService;
     private final ClienteService clienteService;
     private final LiquidacionFinalRepository liquidacionFinalRepository;
+    private final FuncionarioEgresoHistoricoRepository egresoHistoricoRepository;
 
     /**
      * Cambia el cargo del funcionario dejando rastro: cierra el histórico abierto
@@ -105,15 +108,67 @@ public class FuncionarioRrhhService {
     /**
      * Egresa al funcionario: marca fecha/motivo de egreso y activo=false.
      * El cálculo de la liquidación final se dispara aparte (Fase 6).
+     *
+     * <p>Antes de guardar toma un <b>snapshot</b> de lo que el egreso va a destruir. No es
+     * solo trazabilidad: es lo unico que hace reversible un egreso. {@code save()} pone el
+     * credito en cero y la cascada apaga usuario y cliente, lo devuelve a NORMAL y le borra
+     * el credito -- nada de eso queda en otro lado. El orden importa: leer despues de
+     * guardar seria fotografiar el dano, no el estado previo.</p>
      */
     @Transactional
     public Funcionario egresar(Long funcionarioId, LocalDate fecha, String motivo) {
         Funcionario f = funcionarioService.findById(funcionarioId)
                 .orElseThrow(() -> new GraphQLException("Funcionario no encontrado"));
+
+        FuncionarioEgresoHistorico snap = snapshotPrevioAlEgreso(f);
+
         f.setFechaEgreso(fecha != null ? fecha.atStartOfDay() : LocalDateTime.now());
         f.setMotivoEgreso(motivo != null ? motivo.toUpperCase() : null);
         f.setActivo(false);
-        return funcionarioService.save(f);
+        Funcionario guardado = funcionarioService.save(f);
+
+        snap.setFechaEgreso(guardado.getFechaEgreso());
+        snap.setMotivoEgreso(guardado.getMotivoEgreso());
+        snap.setEgresadoPor(usuarioAutenticado());
+        egresoHistoricoRepository.save(snap);
+        return guardado;
+    }
+
+    /** Foto del estado que el egreso va a destruir. Se arma ANTES de guardar. */
+    private FuncionarioEgresoHistorico snapshotPrevioAlEgreso(Funcionario f) {
+        FuncionarioEgresoHistorico snap = new FuncionarioEgresoHistorico();
+        snap.setFuncionario(f);
+        snap.setCreditoAnterior(f.getCredito() != null ? BigDecimal.valueOf(f.getCredito()) : null);
+        if (f.getPersona() != null && f.getPersona().getId() != null) {
+            Usuario u = usuarioService.findByPersonaId(f.getPersona().getId());
+            if (u == null) u = f.getUsuario();
+            if (u != null) {
+                snap.setUsuarioId(u.getId());
+                snap.setUsuarioActivoAnterior(u.getActivo());
+            }
+            Cliente c = clienteService.findByPersonaId(f.getPersona().getId());
+            if (c != null) {
+                snap.setClienteId(c.getId());
+                snap.setClienteTipoAnterior(c.getTipo() != null ? c.getTipo().name() : null);
+                snap.setClienteCreditoAnterior(c.getCredito() != null ? BigDecimal.valueOf(c.getCredito()) : null);
+                snap.setClienteActivoAnterior(c.getActivo());
+            }
+        }
+        return snap;
+    }
+
+    /** El usuario logueado, o null si la mutation corre sin contexto de seguridad. */
+    private Usuario usuarioAutenticado() {
+        org.springframework.security.core.Authentication auth =
+                org.springframework.security.core.context.SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated() || auth.getName() == null) return null;
+        return usuarioService.findByNickname(auth.getName()).orElse(null);
+    }
+
+    /** El egreso vigente del funcionario, si fue hecho desde que existe el historico. */
+    public java.util.Optional<FuncionarioEgresoHistorico> egresoVigente(Long funcionarioId) {
+        if (funcionarioId == null) return java.util.Optional.empty();
+        return egresoHistoricoRepository.findFirstByFuncionarioIdAndRevertidoEnIsNullOrderByIdDesc(funcionarioId);
     }
 
     /**
@@ -138,8 +193,14 @@ public class FuncionarioRrhhService {
      * no en el servicio, asi que por este camino hay que hacerla a mano o el funcionario
      * queda con su crédito restaurado y el cliente en cero.</p>
      *
-     * <p><b>El motivo no se persiste.</b> No hay tabla de historico de egresos; se deja en
-     * el log. Si la reversa tiene que ser auditable, hace falta esa tabla.</p>
+     * <p><b>De donde sale el credito.</b> Del snapshot que {@link #egresar} dejo en
+     * {@code rrhh.funcionario_egreso_historico}. El parametro {@code credito} sigue
+     * existiendo como override, y es el unico camino para los egresos hechos ANTES de que
+     * existiera esa tabla, que no tienen snapshot del cual restaurar.</p>
+     *
+     * <p><b>El tipo del cliente tambien se restaura desde el snapshot.</b> La cascada lo
+     * reactiva siempre como FUNCIONARIO, asi que sin esto revertir el egreso de un cliente
+     * VIP lo degradaba en silencio.</p>
      */
     @Transactional
     public Funcionario revertirEgreso(Long funcionarioId, Float credito, String motivo) {
@@ -162,7 +223,14 @@ public class FuncionarioRrhhService {
 
         LocalDateTime egresoPrevio = f.getFechaEgreso();
         String motivoPrevio = f.getMotivoEgreso();
-        Float creditoRestaurado = credito != null ? credito : 0f;
+
+        FuncionarioEgresoHistorico snap = egresoVigente(funcionarioId).orElse(null);
+        // El override del cliente gana sobre el snapshot: entre el egreso y la reversa el
+        // negocio pudo cambiar. Sin override, manda la foto; sin foto ni override, cero.
+        Float creditoRestaurado = credito != null
+                ? credito
+                : (snap != null && snap.getCreditoAnterior() != null
+                        ? snap.getCreditoAnterior().floatValue() : 0f);
 
         f.setFechaEgreso(null);
         f.setMotivoEgreso(null);
@@ -171,17 +239,49 @@ public class FuncionarioRrhhService {
         Funcionario guardado = funcionarioService.save(f);
 
         // La cascada reactivo al cliente y lo devolvio a FUNCIONARIO, pero le dejo el
-        // credito en cero.
+        // credito en cero y le pudo haber cambiado el tipo.
         if (guardado.getPersona() != null && guardado.getPersona().getId() != null) {
             Cliente cliente = clienteService.findByPersonaId(guardado.getPersona().getId());
-            if (cliente != null && !java.util.Objects.equals(cliente.getCredito(), creditoRestaurado)) {
-                cliente.setCredito(creditoRestaurado);
-                clienteService.save(cliente);
+            if (cliente != null) {
+                boolean cambio = false;
+                BigDecimal cliCred = snap != null && snap.getClienteCreditoAnterior() != null
+                        ? snap.getClienteCreditoAnterior() : null;
+                Float clienteCredito = credito != null
+                        ? credito
+                        : (cliCred != null ? cliCred.floatValue() : creditoRestaurado);
+                if (!java.util.Objects.equals(cliente.getCredito(), clienteCredito)) {
+                    cliente.setCredito(clienteCredito);
+                    cambio = true;
+                }
+                // Tipo real desde el snapshot. La cascada ya lo puso en FUNCIONARIO; si
+                // antes era VIP, dejarlo asi le saca la categoria sin que nadie lo pida.
+                if (snap != null && snap.getClienteTipoAnterior() != null) {
+                    try {
+                        com.franco.dev.domain.personas.enums.TipoCliente tipoPrevio =
+                                com.franco.dev.domain.personas.enums.TipoCliente.valueOf(snap.getClienteTipoAnterior());
+                        if (cliente.getTipo() != tipoPrevio) {
+                            cliente.setTipo(tipoPrevio);
+                            cambio = true;
+                        }
+                    } catch (IllegalArgumentException e) {
+                        // Tipo que ya no existe en el enum: se deja lo que puso la cascada.
+                        log.warn("Tipo de cliente desconocido en el snapshot de egreso: {}", snap.getClienteTipoAnterior());
+                    }
+                }
+                if (cambio) clienteService.save(cliente);
             }
         }
 
-        log.info("Egreso revertido: funcionario={} egresoPrevio={} motivoPrevio={} creditoRestaurado={} motivoReversa={}",
-                funcionarioId, egresoPrevio, motivoPrevio, creditoRestaurado, motivo);
+        if (snap != null) {
+            snap.setRevertidoEn(LocalDateTime.now());
+            snap.setRevertidoPor(usuarioAutenticado());
+            snap.setMotivoReversion(motivo);
+            egresoHistoricoRepository.save(snap);
+        }
+
+        log.info("Egreso revertido: funcionario={} egresoPrevio={} motivoPrevio={} creditoRestaurado={} origen={} motivoReversa={}",
+                funcionarioId, egresoPrevio, motivoPrevio, creditoRestaurado,
+                credito != null ? "OVERRIDE" : (snap != null ? "SNAPSHOT" : "SIN_SNAPSHOT"), motivo);
         return guardado;
     }
 }

--- a/src/main/resources/db/migration/V208.5__rrhh_funcionario_egreso_historico.sql
+++ b/src/main/resources/db/migration/V208.5__rrhh_funcionario_egreso_historico.sql
@@ -1,0 +1,63 @@
+-- Snapshot del estado que el egreso destruye.
+--
+-- Egresar no solo apaga tres campos del funcionario: FuncionarioService.save pone su
+-- credito en cero, y la cascada de estado inactiva al usuario, inactiva al cliente, lo
+-- devuelve a NORMAL y le borra el credito tambien. Nada de eso quedaba guardado en
+-- ningun lado, asi que revertir un egreso hecho por error era imposible sin ir a un
+-- backup: en el caso real de farmacia (2026-08-21) hubo que sacar el credito de uno de
+-- nueve dias antes.
+--
+-- Con esta tabla la reversa RESTAURA en vez de preguntar. Dos consecuencias concretas:
+--
+--   1. El credito ya no se escribe a mano.
+--   2. El cliente recupera su tipo REAL. Sin el snapshot, la cascada lo reactiva como
+--      FUNCIONARIO siempre, asi que revertir el egreso de un cliente VIP lo degradaba
+--      en silencio.
+--
+-- Sigue el patron de las otras dos historicas del modulo (funcionario_salario_historico
+-- y funcionario_cargo_historico, V159.0).
+--
+-- Solo cubre egresos hechos DESDE que existe la tabla: los anteriores no tienen de donde
+-- sacar el snapshot, y por eso el dialogo de reversa conserva el campo de credito manual
+-- como fallback.
+--
+-- rrhh.* no esta en central_pub ni en configuraciones.replication_table: no replica.
+
+CREATE TABLE IF NOT EXISTS rrhh.funcionario_egreso_historico (
+    id                        BIGSERIAL PRIMARY KEY,
+    funcionario_id            BIGINT REFERENCES personas.funcionario(id),
+
+    -- lo que el egreso escribio
+    fecha_egreso              TIMESTAMP,
+    motivo_egreso             TEXT,
+    egresado_por_id           BIGINT REFERENCES personas.usuario(id),
+
+    -- el estado que el egreso destruyo, leido ANTES de guardar
+    credito_anterior          NUMERIC(18,2),
+    usuario_id                BIGINT REFERENCES personas.usuario(id),
+    usuario_activo_anterior   BOOLEAN,
+    cliente_id                BIGINT REFERENCES personas.cliente(id),
+    cliente_tipo_anterior     VARCHAR(30),
+    cliente_credito_anterior  NUMERIC(18,2),
+    cliente_activo_anterior   BOOLEAN,
+
+    -- la reversa, si ocurre
+    revertido_en              TIMESTAMP,
+    revertido_por_id          BIGINT REFERENCES personas.usuario(id),
+    motivo_reversion          TEXT,
+
+    creado_en                 TIMESTAMP NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE rrhh.funcionario_egreso_historico IS
+    'Snapshot previo a cada egreso. Permite revertirlo restaurando el estado exacto.';
+COMMENT ON COLUMN rrhh.funcionario_egreso_historico.cliente_tipo_anterior IS
+    'Tipo del cliente antes del egreso. Sin esto la cascada lo reactiva como FUNCIONARIO y un VIP pierde su categoria.';
+COMMENT ON COLUMN rrhh.funcionario_egreso_historico.revertido_en IS
+    'NULL mientras el egreso siga vigente. Se completa al revertirlo.';
+
+-- El caso normal es buscar el ultimo egreso no revertido de un funcionario.
+CREATE INDEX IF NOT EXISTS idx_func_egreso_hist_funcionario
+    ON rrhh.funcionario_egreso_historico(funcionario_id);
+CREATE INDEX IF NOT EXISTS idx_func_egreso_hist_vigente
+    ON rrhh.funcionario_egreso_historico(funcionario_id) WHERE revertido_en IS NULL;

--- a/src/main/resources/graphql/rrhh/funcionario-rrhh.graphqls
+++ b/src/main/resources/graphql/rrhh/funcionario-rrhh.graphqls
@@ -78,6 +78,13 @@ input FuncionarioDocumentoInput {
 }
 
 extend type Query {
+    """
+    El egreso vigente del funcionario (el ultimo sin revertir), o null si no tiene o si
+    se hizo antes de que existiera el historico. El dialogo de reversa lo usa para
+    precargar el credito en vez de pedirlo a mano.
+    """
+    egresoVigenteFuncionario(funcionarioId: ID!): FuncionarioEgresoHistorico
+
     funcionarioCargoHistoricos(funcionarioId: ID!): [FuncionarioCargoHistorico]
     funcionarioSalarioHistoricos(funcionarioId: ID!): [FuncionarioSalarioHistorico]
     funcionarioDocumentos(funcionarioId: ID!): [FuncionarioDocumento]
@@ -98,4 +105,29 @@ extend type Mutation {
     revertirEgresoFuncionario(funcionarioId: ID!, credito: Float, motivo: String): Funcionario
     saveFuncionarioDocumento(input: FuncionarioDocumentoInput!): FuncionarioDocumento!
     anularFuncionarioDocumento(id: ID!): FuncionarioDocumento
+}
+
+"""
+Snapshot del estado que un egreso destruyo. Permite revertirlo restaurando lo que habia,
+en vez de pedirle al usuario que lo reconstruya de memoria o de un backup.
+
+Es null para egresos hechos antes de que existiera el historico.
+"""
+type FuncionarioEgresoHistorico {
+    id: ID!
+    funcionario: Funcionario
+    fechaEgreso: Date
+    motivoEgreso: String
+    egresadoPor: Usuario
+    creditoAnterior: Float
+    usuarioId: Int
+    usuarioActivoAnterior: Boolean
+    clienteId: Int
+    clienteTipoAnterior: String
+    clienteCreditoAnterior: Float
+    clienteActivoAnterior: Boolean
+    revertidoEn: Date
+    revertidoPor: Usuario
+    motivoReversion: String
+    creadoEn: Date
 }

--- a/src/main/resources/graphql/rrhh/funcionario-rrhh.graphqls
+++ b/src/main/resources/graphql/rrhh/funcionario-rrhh.graphqls
@@ -88,6 +88,14 @@ extend type Mutation {
     cambiarCargoFuncionario(input: CambioCargoInput!): Funcionario
     cambiarSalarioFuncionario(input: CambioSalarioInput!): Funcionario
     egresarFuncionario(funcionarioId: ID!, fecha: String, motivo: String): Funcionario
+    """
+    Revierte un egreso hecho por error: limpia fecha y motivo de egreso, reactiva al
+    funcionario (y con el a su usuario y su cliente) y restaura el credito.
+
+    El credito va como parametro porque egresar lo pone en cero y no queda guardado en
+    ninguna tabla: sin el valor, la reversa no puede recuperarlo.
+    """
+    revertirEgresoFuncionario(funcionarioId: ID!, credito: Float, motivo: String): Funcionario
     saveFuncionarioDocumento(input: FuncionarioDocumentoInput!): FuncionarioDocumento!
     anularFuncionarioDocumento(id: ID!): FuncionarioDocumento
 }

--- a/src/test/java/com/franco/dev/service/rrhh/RevertirEgresoFuncionarioTest.java
+++ b/src/test/java/com/franco/dev/service/rrhh/RevertirEgresoFuncionarioTest.java
@@ -5,9 +5,11 @@ import com.franco.dev.domain.personas.Funcionario;
 import com.franco.dev.domain.personas.Persona;
 import com.franco.dev.domain.personas.Usuario;
 import com.franco.dev.domain.personas.enums.TipoCliente;
+import com.franco.dev.domain.rrhh.FuncionarioEgresoHistorico;
 import com.franco.dev.domain.rrhh.LiquidacionFinal;
 import com.franco.dev.domain.rrhh.enums.LiquidacionFinalEstado;
 import com.franco.dev.repository.personas.FuncionarioRepository;
+import com.franco.dev.repository.rrhh.FuncionarioEgresoHistoricoRepository;
 import com.franco.dev.repository.rrhh.LiquidacionFinalRepository;
 import com.franco.dev.service.empresarial.CargoService;
 import com.franco.dev.service.financiero.MonedaService;
@@ -46,6 +48,7 @@ class RevertirEgresoFuncionarioTest {
     private UsuarioService usuarioService;
     private ClienteService clienteService;
     private LiquidacionFinalRepository liquidacionFinalRepository;
+    private FuncionarioEgresoHistoricoRepository egresoHistoricoRepository;
     private FuncionarioService funcionarioService;
     private FuncionarioRrhhService service;
 
@@ -60,6 +63,7 @@ class RevertirEgresoFuncionarioTest {
         usuarioService = mock(UsuarioService.class);
         clienteService = mock(ClienteService.class);
         liquidacionFinalRepository = mock(LiquidacionFinalRepository.class);
+        egresoHistoricoRepository = mock(FuncionarioEgresoHistoricoRepository.class);
 
         funcionarioService = new FuncionarioService(funcionarioRepository, usuarioService, clienteService);
 
@@ -71,7 +75,8 @@ class RevertirEgresoFuncionarioTest {
                 mock(FuncionarioCargoHistoricoService.class),
                 mock(FuncionarioSalarioHistoricoService.class),
                 clienteService,
-                liquidacionFinalRepository);
+                liquidacionFinalRepository,
+                egresoHistoricoRepository);
 
         persona = new Persona();
         persona.setId(PERSONA_ID);
@@ -102,6 +107,24 @@ class RevertirEgresoFuncionarioTest {
         when(funcionarioRepository.save(any(Funcionario.class))).thenAnswer(i -> i.getArgument(0));
         when(liquidacionFinalRepository.findByFuncionarioIdOrderByCreadoEnDesc(FUNC_ID))
                 .thenReturn(Collections.emptyList());
+        // Por defecto: egreso viejo, sin snapshot. Los tests que lo necesitan lo cargan.
+        when(egresoHistoricoRepository.findFirstByFuncionarioIdAndRevertidoEnIsNullOrderByIdDesc(FUNC_ID))
+                .thenReturn(Optional.empty());
+        when(egresoHistoricoRepository.save(any(FuncionarioEgresoHistorico.class)))
+                .thenAnswer(i -> i.getArgument(0));
+    }
+
+    /** Deja disponible un snapshot del egreso, como si lo hubiera dejado egresar(). */
+    private FuncionarioEgresoHistorico conSnapshot(String creditoFunc, String creditoCli, TipoCliente tipoPrevio) {
+        FuncionarioEgresoHistorico snap = new FuncionarioEgresoHistorico();
+        snap.setId(9L);
+        snap.setFuncionario(funcionario);
+        snap.setCreditoAnterior(new java.math.BigDecimal(creditoFunc));
+        snap.setClienteCreditoAnterior(new java.math.BigDecimal(creditoCli));
+        snap.setClienteTipoAnterior(tipoPrevio != null ? tipoPrevio.name() : null);
+        when(egresoHistoricoRepository.findFirstByFuncionarioIdAndRevertidoEnIsNullOrderByIdDesc(FUNC_ID))
+                .thenReturn(Optional.of(snap));
+        return snap;
     }
 
     @Test
@@ -194,5 +217,62 @@ class RevertirEgresoFuncionarioTest {
     void rechazaSiElFuncionarioNoExiste() {
         when(funcionarioRepository.findById(99L)).thenReturn(Optional.empty());
         assertThrows(GraphQLException.class, () -> service.revertirEgreso(99L, CREDITO_PREVIO, null));
+    }
+
+    // --- Con snapshot: la reversa restaura en vez de preguntar -------------------------
+
+    /** Sin indicar credito, el monto sale del snapshot que dejo el egreso. */
+    @Test
+    void conSnapshotElCreditoSaleDeLaFotoYNoHaceFaltaEscribirlo() {
+        conSnapshot("750000", "750000", TipoCliente.FUNCIONARIO);
+        Funcionario r = service.revertirEgreso(FUNC_ID, null, "error de carga");
+        assertEquals(750000f, r.getCredito(), 0.001f,
+                "el credito tenia que salir del snapshot, salio " + r.getCredito());
+        assertEquals(750000f, cliente.getCredito(), 0.001f);
+    }
+
+    /**
+     * El caso que motivo guardar el tipo: la cascada reactiva al cliente como FUNCIONARIO
+     * siempre. Si antes era VIP y no se restaura, la reversa le saca la categoria sin que
+     * nadie lo haya pedido.
+     */
+    @Test
+    void unClienteVipRecuperaSuCategoria() {
+        cliente.setTipo(TipoCliente.NORMAL);
+        conSnapshot("900000", "900000", TipoCliente.VIP);
+        service.revertirEgreso(FUNC_ID, null, null);
+        assertEquals(TipoCliente.VIP, cliente.getTipo(),
+                "el cliente quedo como " + cliente.getTipo() + ": la reversa lo degrado");
+    }
+
+    /** Lo que el usuario escribe gana sobre la foto: entre egreso y reversa todo pudo cambiar. */
+    @Test
+    void elOverrideManualGanaSobreElSnapshot() {
+        conSnapshot("750000", "750000", TipoCliente.FUNCIONARIO);
+        Funcionario r = service.revertirEgreso(FUNC_ID, 123000f, null);
+        assertEquals(123000f, r.getCredito(), 0.001f);
+        assertEquals(123000f, cliente.getCredito(), 0.001f);
+    }
+
+    /** Revertir marca la foto como usada, con quien y por que. */
+    @Test
+    void laReversaMarcaElSnapshotComoRevertido() {
+        FuncionarioEgresoHistorico snap = conSnapshot("500000", "500000", TipoCliente.FUNCIONARIO);
+        service.revertirEgreso(FUNC_ID, null, "egreso por error");
+        assertNotNull(snap.getRevertidoEn(), "el snapshot quedo sin marcar como revertido");
+        assertEquals("egreso por error", snap.getMotivoReversion());
+    }
+
+    /**
+     * Un tipo que ya no exista en el enum no puede voltear la reversa: se deja lo que puso
+     * la cascada y se sigue.
+     */
+    @Test
+    void unTipoDesconocidoEnElSnapshotNoRompe() {
+        FuncionarioEgresoHistorico snap = conSnapshot("500000", "500000", null);
+        snap.setClienteTipoAnterior("CATEGORIA_QUE_YA_NO_EXISTE");
+        Funcionario r = service.revertirEgreso(FUNC_ID, null, null);
+        assertTrue(Boolean.TRUE.equals(r.getActivo()));
+        assertEquals(TipoCliente.FUNCIONARIO, cliente.getTipo());
     }
 }

--- a/src/test/java/com/franco/dev/service/rrhh/RevertirEgresoFuncionarioTest.java
+++ b/src/test/java/com/franco/dev/service/rrhh/RevertirEgresoFuncionarioTest.java
@@ -1,0 +1,198 @@
+package com.franco.dev.service.rrhh;
+
+import com.franco.dev.domain.personas.Cliente;
+import com.franco.dev.domain.personas.Funcionario;
+import com.franco.dev.domain.personas.Persona;
+import com.franco.dev.domain.personas.Usuario;
+import com.franco.dev.domain.personas.enums.TipoCliente;
+import com.franco.dev.domain.rrhh.LiquidacionFinal;
+import com.franco.dev.domain.rrhh.enums.LiquidacionFinalEstado;
+import com.franco.dev.repository.personas.FuncionarioRepository;
+import com.franco.dev.repository.rrhh.LiquidacionFinalRepository;
+import com.franco.dev.service.empresarial.CargoService;
+import com.franco.dev.service.financiero.MonedaService;
+import com.franco.dev.service.personas.ClienteService;
+import com.franco.dev.service.personas.FuncionarioService;
+import com.franco.dev.service.personas.UsuarioService;
+import graphql.GraphQLException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Reversa de un egreso hecho por error.
+ *
+ * <p>Usa el {@link FuncionarioService} REAL, no un mock, porque lo que hay que probar es
+ * justamente lo que ese servicio hace de mas al guardar: pone el credito en cero cuando
+ * activo llega en false, e inactiva usuario y cliente por cascada. Con un mock, el test
+ * pasaria sin demostrar nada.</p>
+ */
+class RevertirEgresoFuncionarioTest {
+
+    private static final Long FUNC_ID = 1L;
+    private static final Long PERSONA_ID = 7L;
+    private static final float CREDITO_PREVIO = 400000f;
+
+    private FuncionarioRepository funcionarioRepository;
+    private UsuarioService usuarioService;
+    private ClienteService clienteService;
+    private LiquidacionFinalRepository liquidacionFinalRepository;
+    private FuncionarioService funcionarioService;
+    private FuncionarioRrhhService service;
+
+    private Persona persona;
+    private Usuario usuario;
+    private Cliente cliente;
+    private Funcionario funcionario;
+
+    @BeforeEach
+    void setUp() {
+        funcionarioRepository = mock(FuncionarioRepository.class);
+        usuarioService = mock(UsuarioService.class);
+        clienteService = mock(ClienteService.class);
+        liquidacionFinalRepository = mock(LiquidacionFinalRepository.class);
+
+        funcionarioService = new FuncionarioService(funcionarioRepository, usuarioService, clienteService);
+
+        service = new FuncionarioRrhhService(
+                funcionarioService,
+                mock(CargoService.class),
+                mock(MonedaService.class),
+                usuarioService,
+                mock(FuncionarioCargoHistoricoService.class),
+                mock(FuncionarioSalarioHistoricoService.class),
+                clienteService,
+                liquidacionFinalRepository);
+
+        persona = new Persona();
+        persona.setId(PERSONA_ID);
+
+        // Estado en el que queda todo DESPUES de un egreso: apagado y con credito en cero.
+        usuario = new Usuario();
+        usuario.setId(70L);
+        usuario.setActivo(false);
+
+        cliente = new Cliente();
+        cliente.setId(700L);
+        cliente.setActivo(false);
+        cliente.setTipo(TipoCliente.NORMAL);
+        cliente.setCredito(0f);
+
+        funcionario = new Funcionario();
+        funcionario.setId(FUNC_ID);
+        funcionario.setPersona(persona);
+        funcionario.setActivo(false);
+        funcionario.setCredito(0f);
+        funcionario.setFechaEgreso(LocalDateTime.of(2026, 8, 21, 0, 0));
+        funcionario.setMotivoEgreso("ERROR DE CARGA");
+
+        when(usuarioService.findByPersonaId(PERSONA_ID)).thenReturn(usuario);
+        when(clienteService.findByPersonaId(PERSONA_ID)).thenReturn(cliente);
+        when(funcionarioRepository.findById(FUNC_ID)).thenReturn(Optional.of(funcionario));
+        when(funcionarioRepository.findActivoById(FUNC_ID)).thenReturn(false);
+        when(funcionarioRepository.save(any(Funcionario.class))).thenAnswer(i -> i.getArgument(0));
+        when(liquidacionFinalRepository.findByFuncionarioIdOrderByCreadoEnDesc(FUNC_ID))
+                .thenReturn(Collections.emptyList());
+    }
+
+    @Test
+    void dejaAlFuncionarioActivoYSinRastroDeEgreso() {
+        Funcionario r = service.revertirEgreso(FUNC_ID, CREDITO_PREVIO, "egreso por error");
+        assertTrue(Boolean.TRUE.equals(r.getActivo()), "el funcionario tiene que quedar activo");
+        assertNull(r.getFechaEgreso(), "la fecha de egreso tiene que quedar limpia");
+        assertNull(r.getMotivoEgreso(), "el motivo de egreso tiene que quedar limpio");
+    }
+
+    /**
+     * El punto del parametro credito. Ojo con el orden: save() pisa el credito a cero
+     * cuando activo viene en false, asi que si activo se seteara despues, esto daria 0.
+     */
+    @Test
+    void restauraElCreditoDelFuncionario() {
+        Funcionario r = service.revertirEgreso(FUNC_ID, CREDITO_PREVIO, null);
+        assertEquals(CREDITO_PREVIO, r.getCredito(), 0.001f,
+                "el credito volvio en " + r.getCredito() + " en vez del previo al egreso");
+    }
+
+    /** Reactivar al funcionario tiene que devolverle el login. */
+    @Test
+    void reactivaElUsuario() {
+        service.revertirEgreso(FUNC_ID, CREDITO_PREVIO, null);
+        assertTrue(Boolean.TRUE.equals(usuario.getActivo()), "el usuario quedo sin poder entrar");
+    }
+
+    /**
+     * La cascada reactiva al cliente y lo devuelve a FUNCIONARIO, pero le deja el credito
+     * en cero: esa re-sincronizacion vive en el resolver de saveFuncionario, no en el
+     * servicio. Sin hacerla a mano, el funcionario queda con credito y el cliente sin.
+     */
+    @Test
+    void reactivaAlClienteConSuCreditoYSuTipo() {
+        service.revertirEgreso(FUNC_ID, CREDITO_PREVIO, null);
+        assertTrue(Boolean.TRUE.equals(cliente.getActivo()), "el cliente quedo inactivo");
+        assertEquals(TipoCliente.FUNCIONARIO, cliente.getTipo(), "el cliente no volvio a FUNCIONARIO");
+        assertEquals(CREDITO_PREVIO, cliente.getCredito(), 0.001f,
+                "el cliente quedo con credito " + cliente.getCredito() + ": la re-sincronizacion no corrio");
+    }
+
+    /** Sin credito indicado no se inventa uno: queda en cero, que es como lo dejo el egreso. */
+    @Test
+    void sinCreditoIndicadoQuedaEnCero() {
+        Funcionario r = service.revertirEgreso(FUNC_ID, null, null);
+        assertEquals(0f, r.getCredito(), 0.001f);
+        assertEquals(0f, cliente.getCredito(), 0.001f);
+    }
+
+    @Test
+    void rechazaSiYaEstaActivo() {
+        funcionario.setActivo(true);
+        GraphQLException e = assertThrows(GraphQLException.class,
+                () -> service.revertirEgreso(FUNC_ID, CREDITO_PREVIO, null));
+        assertTrue(e.getMessage().toLowerCase().contains("ya esta activo"), e.getMessage());
+    }
+
+    /**
+     * Un finiquito PAGADA significa que ya salio plata de la caja por esa salida. Revertir
+     * el egreso dejandolo en pie deja al funcionario activo y cobrado como si se hubiera ido.
+     */
+    @Test
+    void rechazaSiHayFiniquitoVigente() {
+        LiquidacionFinal lf = new LiquidacionFinal();
+        lf.setId(55L);
+        lf.setEstado(LiquidacionFinalEstado.PAGADA);
+        when(liquidacionFinalRepository.findByFuncionarioIdOrderByCreadoEnDesc(FUNC_ID))
+                .thenReturn(Collections.singletonList(lf));
+
+        GraphQLException e = assertThrows(GraphQLException.class,
+                () -> service.revertirEgreso(FUNC_ID, CREDITO_PREVIO, null));
+        assertTrue(e.getMessage().contains("PAGADA") && e.getMessage().contains("55"), e.getMessage());
+    }
+
+    /** Un finiquito ya anulado no bloquea: es justamente el camino para poder revertir. */
+    @Test
+    void unFiniquitoAnuladoNoBloquea() {
+        LiquidacionFinal anulada = new LiquidacionFinal();
+        anulada.setId(56L);
+        anulada.setEstado(LiquidacionFinalEstado.ANULADA);
+        when(liquidacionFinalRepository.findByFuncionarioIdOrderByCreadoEnDesc(FUNC_ID))
+                .thenReturn(Arrays.asList(anulada));
+
+        Funcionario r = service.revertirEgreso(FUNC_ID, CREDITO_PREVIO, null);
+        assertTrue(Boolean.TRUE.equals(r.getActivo()));
+    }
+
+    @Test
+    void rechazaSiElFuncionarioNoExiste() {
+        when(funcionarioRepository.findById(99L)).thenReturn(Optional.empty());
+        assertThrows(GraphQLException.class, () -> service.revertirEgreso(99L, CREDITO_PREVIO, null));
+    }
+}


### PR DESCRIPTION
No existía **ninguna** forma de deshacer un egreso desde la aplicación. El 2026-08-21 se egresó por error a una funcionaria en farmacia y hubo que resolverlo el 22 con un `UPDATE` directo en producción. La urgencia ya pasó; esto cierra el hueco.

## El egreso hace más de lo que su pantalla sugiere

`egresar()` parece escribir tres campos —`fechaEgreso`, `motivoEgreso`, `activo=false`— pero `FuncionarioService.save` agrega dos efectos que no se ven desde ahí:

- **`credito = 0`** (`FuncionarioService:75`), porque `activo` llega en `false`
- **la cascada de estado** (`:92`): inactiva el usuario —**se pierde el login**—, inactiva el cliente, lo pasa a `NORMAL` y también le borra el crédito

**Ese crédito no queda guardado en ninguna tabla.** `funcionario_salario_historico` guarda salario, no crédito. En el caso real hubo que sacarlo de un backup de nueve días antes. Por eso la reversa lo recibe como parámetro: no puede recuperarlo sola.

## Dos cosas del orden, que no se ven leyendo el método de a poco

**`activo` se setea en `true` ANTES de guardar**, porque `save()` pisa el crédito a cero cuando `activo` viene en `false`. Al revés, el parámetro no serviría de nada.

**El crédito del cliente se re-sincroniza DESPUÉS del save.** Esa sincronización vive en `FuncionarioGraphQL.saveFuncionario:153`, **no en el servicio**, así que por este camino hay que hacerla a mano — si no, el funcionario queda con su crédito restaurado y el cliente en cero. Es el hallazgo que más me preocupó: se pierde en silencio y sólo aparece cuando la persona intenta comprar.

Lo cubre `reactivaAlClienteConSuCreditoYSuTipo`, y **verifiqué que el test falla si se saca la sincronización** (`expected: <400000.0> but was: <0.0>`), no que pase de gratis.

## Qué rechaza

- Funcionario que ya está activo.
- Funcionario con una liquidación final en cualquier estado que no sea `ANULADA`, nombrando cuál y en qué estado. Un finiquito `PAGADA` significa que **ya salió plata de la caja** por esa salida; revertir el egreso dejándolo en pie deja a alguien activo y cobrado como si se hubiera ido.

Gating: `seg.requireAnyRole(GESTIONAR, APROBAR)` — el mismo que `egresarFuncionario`.

## Una limitación que quiero explícita

**El motivo de la reversión no se persiste**, sólo va al log junto con el egreso previo y el crédito restaurado. No hay tabla de histórico de egresos y este PR no la agrega. Si la reversa tiene que ser auditable —y siendo una operación que restaura crédito, probablemente deba serlo— hace falta esa tabla en un PR aparte.

## Tests

9 casos: los cuatro valores esperados (`credito`, `activo`, `usuario.activo`, `cliente.activo` + tipo y crédito del cliente), los dos rechazos, que un finiquito `ANULADA` **no** bloquee, y que sin crédito indicado no se invente uno.

Usan el `FuncionarioService` **real**, no un mock, porque lo que hay que probar es justamente lo que ese servicio hace de más al guardar. Con un mock el test pasaría sin demostrar nada.

## Sin migración

Son columnas que ya existen.

## Cómo probarlo

1. Egresar a un funcionario que tenga crédito y usuario. Verificar en la base que quedó `credito = 0`, `usuario.activo = false` y `cliente.tipo = NORMAL`.
2. Revertir desde el legajo indicando el crédito previo. Tienen que volver: funcionario activo sin fecha de egreso, usuario activo, cliente activo en `FUNCIONARIO` **y con crédito** — mirar el cliente, no sólo el funcionario.
3. Generar un finiquito y aprobarlo; intentar revertir. Tiene que rechazar nombrando el estado y el id.
4. Intentar revertir sobre alguien ya activo. Tiene que rechazar.

**Riesgo:** medio. No hay migración ni cambio de contrato, pero restaura crédito y reactiva accesos.

> ⚠️ En farmacia (central `4.7.0-beta.2`) se observó que el cliente quedó en `tipo = FUNCIONARIO` después del egreso, cuando la cascada que hay en `develop` lo pondría en `NORMAL`. **La versión desplegada se comporta distinto a `develop`** — conviene verificar contra la instancia real antes de asumir el estado de partida.
