### PR TITLE
feat(financiero): filtro por moneda en movimientos de caja + fix de moneda.decimales

### DIFF
--- a/src/main/java/com/franco/dev/graphql/financiero/MovimientoCajaVirtualGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/MovimientoCajaVirtualGraphQL.java
@@ -48,14 +48,18 @@ public class MovimientoCajaVirtualGraphQL implements GraphQLQueryResolver, Graph
         return service.findByCajaVirtualIdAndFecha(cajaVirtualId, inicio, fin, pageable);
     }
 
-    /** Movimientos filtrados por fecha/tipo, con opción de ocultar anulados (para el dashboard). */
+    /**
+     * Movimientos filtrados por fecha/tipo/moneda, con opción de ocultar anulados (para el dashboard).
+     * El filtro por moneda es lo que activan las cards de saldo al hacer click.
+     */
     public Page<MovimientoCajaVirtual> movimientosCajaVirtualFilter(Long cajaVirtualId, String desde, String fin,
                                                                     com.franco.dev.domain.financiero.enums.CajaVirtualTipoMovimiento tipo,
+                                                                    Long monedaId,
                                                                     Boolean soloActivos, int page, int size) {
         seg.requireVer();
         seg.requireLecturaCaja(cajaVirtualId);
         Pageable pageable = PageRequest.of(page, size);
-        return service.filter(cajaVirtualId, desde, fin, tipo, soloActivos != null && soloActivos, pageable);
+        return service.filter(cajaVirtualId, desde, fin, tipo, monedaId, soloActivos != null && soloActivos, pageable);
     }
 
     public MovimientoCajaVirtual saveMovimientoCajaVirtual(MovimientoCajaVirtualInput input) {

--- a/src/main/java/com/franco/dev/repository/financiero/MovimientoCajaVirtualRepository.java
+++ b/src/main/java/com/franco/dev/repository/financiero/MovimientoCajaVirtualRepository.java
@@ -34,12 +34,14 @@ public interface MovimientoCajaVirtualRepository extends JpaRepository<Movimient
             + "and (cast(:desde as timestamp) is null or m.creadoEn >= :desde) "
             + "and (cast(:fin as timestamp) is null or m.creadoEn <= :fin) "
             + "and (:tipo is null or cast(m.tipoMovimiento as string) = :tipo) "
+            + "and (:monedaId is null or m.moneda.id = :monedaId) "
             + "and (:soloActivos = false or m.activo = true) "
             + "order by m.creadoEn desc")
     Page<MovimientoCajaVirtual> filter(@Param("cajaId") Long cajaId,
                                        @Param("desde") LocalDateTime desde,
                                        @Param("fin") LocalDateTime fin,
                                        @Param("tipo") String tipo,
+                                       @Param("monedaId") Long monedaId,
                                        @Param("soloActivos") boolean soloActivos,
                                        Pageable pageable);
 }

--- a/src/main/java/com/franco/dev/service/financiero/MovimientoCajaVirtualService.java
+++ b/src/main/java/com/franco/dev/service/financiero/MovimientoCajaVirtualService.java
@@ -39,14 +39,14 @@ public class MovimientoCajaVirtualService {
                 cajaVirtualId, stringToDate(inicio), stringToDate(fin), pageable);
     }
 
-    /** Filtro combinado de movimientos: fecha (opcional), tipo (opcional), y soloActivos (oculta anulados). */
+    /** Filtro combinado de movimientos: fecha, tipo, moneda (todos opcionales) y soloActivos (oculta anulados). */
     public Page<MovimientoCajaVirtual> filter(Long cajaVirtualId, String desde, String fin,
                                               com.franco.dev.domain.financiero.enums.CajaVirtualTipoMovimiento tipo,
-                                              boolean soloActivos, Pageable pageable) {
+                                              Long monedaId, boolean soloActivos, Pageable pageable) {
         return repository.filter(cajaVirtualId,
                 (desde != null && !desde.isEmpty()) ? stringToDate(desde) : null,
                 (fin != null && !fin.isEmpty()) ? stringToDate(fin) : null,
-                tipo != null ? tipo.name() : null, soloActivos, pageable);
+                tipo != null ? tipo.name() : null, monedaId, soloActivos, pageable);
     }
 
     /** Registra un movimiento y actualiza el saldo de la caja de forma atómica (delega en TesoreriaService). */

--- a/src/main/resources/db/migration/V207.5__financiero_moneda_decimales.sql
+++ b/src/main/resources/db/migration/V207.5__financiero_moneda_decimales.sql
@@ -1,0 +1,24 @@
+-- Pobla financiero.moneda.decimales, que quedo en 0 para TODAS las monedas desde que se creo
+-- la columna. El 0 no es una decision: es el default que nunca se sobreescribio (regla_redondeo
+-- y redondeo_multiplo tambien estan nulos en las 4 filas).
+--
+-- Es un dato equivocado, no una convencion: los saldos en real y dolar SI llevan centavos
+-- (ej. 3.339,78 R$ en la caja mayor) y las denominaciones cargadas para el real bajan hasta
+-- 0,05. Con decimales=0 la UI redondea y muestra "0 R$" donde hay 0,05.
+--
+-- El codigo que lee decimales usa el patron `decimales != null ? decimales : (GUARANI ? 0 : 2)`
+-- (ver pagar-compras-dialog.component.ts), que nunca se dispara porque el valor es 0 y no null.
+-- Esta migracion alinea el dato con lo que ese fallback ya asumia.
+--
+-- Aditiva: solo UPDATE de una columna existente, y solo sobre las filas que siguen en el
+-- default. Si alguien ya configuro decimales a proposito (valor != 0), no se toca.
+UPDATE financiero.moneda
+SET decimales = 2
+WHERE decimales = 0
+  AND upper(denominacion) NOT LIKE '%GUARAN%';
+
+-- El guarani no tiene fraccion en circulacion: se deja explicitamente en 0.
+UPDATE financiero.moneda
+SET decimales = 0
+WHERE upper(denominacion) LIKE '%GUARAN%'
+  AND decimales IS NULL;

--- a/src/main/resources/graphql/financiero/movimiento-caja-virtual.graphqls
+++ b/src/main/resources/graphql/financiero/movimiento-caja-virtual.graphqls
@@ -74,7 +74,7 @@ extend type Query {
     movimientoCajaVirtual(id: ID!): MovimientoCajaVirtual
     movimientosCajaVirtual(cajaVirtualId: ID!, page: Int = 0, size: Int = 20): MovimientoCajaVirtualPage
     movimientosCajaVirtualPorFecha(cajaVirtualId: ID!, inicio: String, fin: String, page: Int = 0, size: Int = 20): MovimientoCajaVirtualPage
-    movimientosCajaVirtualFilter(cajaVirtualId: ID!, desde: String, fin: String, tipo: CajaVirtualTipoMovimiento, soloActivos: Boolean, page: Int = 0, size: Int = 20): MovimientoCajaVirtualPage
+    movimientosCajaVirtualFilter(cajaVirtualId: ID!, desde: String, fin: String, tipo: CajaVirtualTipoMovimiento, monedaId: ID, soloActivos: Boolean, page: Int = 0, size: Int = 20): MovimientoCajaVirtualPage
 }
 
 extend type Mutation {

--- a/src/test/java/com/franco/dev/service/financiero/CajaVirtualQueriesTest.java
+++ b/src/test/java/com/franco/dev/service/financiero/CajaVirtualQueriesTest.java
@@ -43,7 +43,7 @@ class CajaVirtualQueriesTest {
         movRepo = mock(MovimientoCajaVirtualRepository.class);
         tesoreriaService = mock(TesoreriaService.class);
         movService = new MovimientoCajaVirtualService(movRepo, tesoreriaService);
-        when(movRepo.filter(any(), any(), any(), any(), anyBoolean(), any(Pageable.class)))
+        when(movRepo.filter(any(), any(), any(), any(), any(), anyBoolean(), any(Pageable.class)))
                 .thenReturn(new PageImpl<>(Collections.emptyList()));
     }
 
@@ -70,19 +70,27 @@ class CajaVirtualQueriesTest {
 
     @Test
     void filtro_movimientos_fecha_vacia_es_null() {
-        movService.filter(1L, "", "", CajaVirtualTipoMovimiento.INGRESO, true, pageable);
+        movService.filter(1L, "", "", CajaVirtualTipoMovimiento.INGRESO, null, true, pageable);
 
         verify(movRepo).filter(eq(1L), isNull(), isNull(),
-                eq("INGRESO"), eq(true), eq(pageable));
+                eq("INGRESO"), isNull(), eq(true), eq(pageable));
+    }
+
+    @Test
+    void filtro_movimientos_pasa_la_moneda() {
+        movService.filter(1L, null, null, null, 3L, false, pageable);
+
+        // La moneda es el filtro que activan las cards de saldo del dashboard.
+        verify(movRepo).filter(eq(1L), isNull(), isNull(), isNull(), eq(3L), eq(false), eq(pageable));
     }
 
     @Test
     void filtro_movimientos_convierte_fechas() {
-        movService.filter(1L, "2026-07-01 00:00", "2026-07-31 23:59", null, false, pageable);
+        movService.filter(1L, "2026-07-01 00:00", "2026-07-31 23:59", null, null, false, pageable);
 
         ArgumentCaptor<LocalDateTime> desde = ArgumentCaptor.forClass(LocalDateTime.class);
         ArgumentCaptor<LocalDateTime> fin = ArgumentCaptor.forClass(LocalDateTime.class);
-        verify(movRepo).filter(eq(1L), desde.capture(), fin.capture(), isNull(), eq(false), eq(pageable));
+        verify(movRepo).filter(eq(1L), desde.capture(), fin.capture(), isNull(), isNull(), eq(false), eq(pageable));
         assertEquals(2026, desde.getValue().getYear());
         assertEquals(7, desde.getValue().getMonthValue());
         assertEquals(1, desde.getValue().getDayOfMonth());


### PR DESCRIPTION
## Qué resuelve

Dos cosas, las dos del lado del dinero en caja virtual.

**1. Filtro por moneda en los movimientos de caja.** El dashboard de la caja mayor pasa a mostrar el saldo de efectivo en una card por moneda (PR del desktop), y al clickear una card la tabla se filtra por esa moneda. Ese filtro no existía: `movimientosCajaVirtualFilter` aceptaba fecha, tipo y `soloActivos` nada más.

`monedaId` es opcional y se compara igual que el resto de los filtros del query (`null` = sin filtro), así que las llamadas existentes no cambian de comportamiento.

**2. `financiero.moneda.decimales` estaba en 0 para las 4 monedas.** Nunca se pobló — es el default de la columna, junto con `regla_redondeo` y `redondeo_multiplo` sin valor. No es una convención, es un dato equivocado: los saldos en real y dólar llevan centavos, y las denominaciones cargadas para el real bajan hasta `0,05`. Con `decimales = 0` la UI redondea y muestra `0 R$` donde hay `0,05`.

Lo notable es que el código ya asumía otra cosa: el patrón `decimales != null ? decimales : (GUARANI ? 0 : 2)` que está en `pagar-compras-dialog.component.ts:408` **nunca se dispara**, porque el valor es `0` y no `null`. O sea que ese diálogo y `ajustar-saldo-cuenta-dialog` venían redondeando todo a enteros sin que se note. La migración alinea el dato con lo que el fallback ya daba por sentado.

## Cómo probarlo

1. Levantar el central y abrir el dashboard de una caja mayor con saldo en más de una moneda.
2. `movimientosCajaVirtualFilter(cajaVirtualId: X, monedaId: Y)` debe devolver solo los movimientos de esa moneda; sin `monedaId`, todos.
3. `select denominacion, decimales from financiero.moneda` → guaraní en 0, el resto en 2.
4. En el desktop, las denominaciones del real en el diálogo de conteo deben mostrar `0,5` / `0,25` / `0,1` / `0,05` y no `1` / `0`.

## Impacto en DB

`V207.5__financiero_moneda_decimales.sql` — aditiva, dos `UPDATE` sobre una columna que ya existe. Conservadora: solo toca las filas que siguen en el default, así que si alguien configuró `decimales` a propósito (valor distinto de 0) no se pisa. Sin `DROP` ni `RENAME`, sin estrategia de dos versiones.

Numerada `207.5` porque la base de desarrollo local ya tiene aplicadas `201.5`–`206.5` de la rama de RRHH, que todavía no está en `develop`.

## Riesgo

**Bajo.** El filtro es un parámetro opcional nuevo. La migración cambia cómo se **formatean** los montos, no los montos: ningún saldo ni movimiento cambia de valor. El efecto visible es que real y dólar vuelven a mostrar centavos donde antes se redondeaban.

Va junto con el PR del desktop (`GabFrank/frc-sistemas-integrados-angular`), que es quien consume el argumento nuevo. El desktop no rompe si este se mergea primero; este sí queda sin usar si se mergea solo.

## Tests

`CajaVirtualQueriesTest` actualizado a la firma nueva, más un caso `filtro_movimientos_pasa_la_moneda`. `./mvnw test-compile` en verde.
