### PR TITLE
feat(rrhh): agregar filtro funcionarioNombre a liquidacionesPage

### DIFF
--- a/src/main/java/com/franco/dev/graphql/rrhh/LiquidacionSueldoGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/rrhh/LiquidacionSueldoGraphQL.java
@@ -49,10 +49,10 @@ public class LiquidacionSueldoGraphQL implements GraphQLQueryResolver, GraphQLMu
     }
 
     /** Padron del SaaS: toda lista paginada y filtrada en el backend. */
-    public Page<LiquidacionSueldo> liquidacionesPage(int page, int size, Long funcionarioId, String periodo,
-                                                     LiquidacionSueldoEstado estado) {
+    public Page<LiquidacionSueldo> liquidacionesPage(int page, int size, Long funcionarioId, String funcionarioNombre,
+                                                     String periodo, LiquidacionSueldoEstado estado) {
         seg.requireVer();
-        return service.findPage(funcionarioId, periodo, estado, PageRequest.of(page, size));
+        return service.findPage(funcionarioId, funcionarioNombre, periodo, estado, PageRequest.of(page, size));
     }
 
     public List<LiquidacionItem> liquidacionItems(Long liquidacionId) {

--- a/src/main/java/com/franco/dev/repository/rrhh/LiquidacionSueldoRepository.java
+++ b/src/main/java/com/franco/dev/repository/rrhh/LiquidacionSueldoRepository.java
@@ -42,10 +42,12 @@ public interface LiquidacionSueldoRepository extends HelperRepository<Liquidacio
     /** Padron del SaaS: toda lista paginada y filtrada en el backend. */
     @Query("select l from LiquidacionSueldo l where " +
             "(:funcionarioId is null or l.funcionario.id = :funcionarioId) and " +
+            "(:funcionarioNombre is null or upper(l.funcionario.persona.nombre) like upper(concat('%', :funcionarioNombre, '%'))) and " +
             "(:periodo is null or l.periodo = :periodo) and " +
             "(:estado is null or l.estado = :estado) " +
             "order by l.periodo desc, l.id desc")
     Page<LiquidacionSueldo> findPage(@Param("funcionarioId") Long funcionarioId,
+                                     @Param("funcionarioNombre") String funcionarioNombre,
                                      @Param("periodo") String periodo,
                                      @Param("estado") LiquidacionSueldoEstado estado,
                                      Pageable pageable);

--- a/src/main/java/com/franco/dev/service/rrhh/LiquidacionSueldoService.java
+++ b/src/main/java/com/franco/dev/service/rrhh/LiquidacionSueldoService.java
@@ -89,9 +89,9 @@ public class LiquidacionSueldoService extends CrudService<LiquidacionSueldo, Liq
     }
 
     /** Padron del SaaS: toda lista paginada y filtrada en el backend. */
-    public Page<LiquidacionSueldo> findPage(Long funcionarioId, String periodo, LiquidacionSueldoEstado estado,
-                                            Pageable pageable) {
-        return repository.findPage(funcionarioId, periodo, estado, pageable);
+    public Page<LiquidacionSueldo> findPage(Long funcionarioId, String funcionarioNombre, String periodo,
+                                            LiquidacionSueldoEstado estado, Pageable pageable) {
+        return repository.findPage(funcionarioId, funcionarioNombre, periodo, estado, pageable);
     }
 
     public List<LiquidacionItem> findItems(Long liquidacionId) {

--- a/src/main/resources/graphql/rrhh/liquidacion-sueldo.graphqls
+++ b/src/main/resources/graphql/rrhh/liquidacion-sueldo.graphqls
@@ -62,7 +62,7 @@ extend type Query {
     liquidacionSueldo(id: ID!): LiquidacionSueldo
     liquidacionesPorFuncionario(funcionarioId: ID!): [LiquidacionSueldo]
     liquidacionesPorPeriodo(periodo: String!): [LiquidacionSueldo]
-    liquidacionesPage(page: Int = 0, size: Int = 20, funcionarioId: ID, periodo: String, estado: LiquidacionSueldoEstado): LiquidacionSueldoPage
+    liquidacionesPage(page: Int = 0, size: Int = 20, funcionarioId: ID, funcionarioNombre: String, periodo: String, estado: LiquidacionSueldoEstado): LiquidacionSueldoPage
     liquidacionItems(liquidacionId: ID!): [LiquidacionItem]
     imprimirReciboLiquidacion(id: ID!, anchoMm: Int, escpos: Boolean): String
 }


### PR DESCRIPTION
## Resumen
- Agrega el parametro opcional `funcionarioNombre` (LIKE case-insensitive sobre `persona.nombre`) a la query `liquidacionesPage` (schema, resolver, service, repository).
- El frontend necesitaba filtrar liquidaciones por nombre/apellido de funcionario devolviendo multiples resultados, no solo por un `funcionarioId` exacto.
- Companero del PR de frontend: https://github.com/GabFrank/frc-sistemas-integrados-angular/pull/245

## Plan de pruebas
- [x] Arranque local en `develop` sin errores de schema GraphQL (kickstart-tools valida resolver vs schema al levantar)
- [x] Probado desde el frontend contra este backend local

🤖 Generated with [Claude Code](https://claude.com/claude-code)