### PR TITLE
feat(notificaciones): suspender todos los envios menos gasto y credito

### DIFF
--- a/src/main/java/com/franco/dev/domain/configuracion/NotificacionTipoEstado.java
+++ b/src/main/java/com/franco/dev/domain/configuracion/NotificacionTipoEstado.java
@@ -1,0 +1,50 @@
+package com.franco.dev.domain.configuracion;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import javax.persistence.*;
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+/**
+ * El interruptor de un tipo de notificacion.
+ *
+ * <p>
+ * ⚠️ <b>Fila ausente = activo.</b> Un tipo nuevo no nace apagado por
+ * accidente: lo que se apaga se apaga explicitamente, y el motivo queda
+ * escrito en la fila.
+ *
+ * <p>
+ * Es distinto de {@code NotificacionTipoRole}, que dice <i>a quien</i> le
+ * llega. Esto dice si sale.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "notificacion_tipo_estado", schema = "configuraciones")
+public class NotificacionTipoEstado implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "tipo_notificacion", nullable = false, unique = true)
+    private String tipoNotificacion;
+
+    @Column(name = "activo", nullable = false)
+    private Boolean activo = true;
+
+    /** Por que se apago, y desde cuando. Se lee en la configuracion. */
+    @Column(name = "motivo")
+    private String motivo;
+
+    @UpdateTimestamp
+    @Column(name = "actualizado_en")
+    private LocalDateTime actualizadoEn;
+}

--- a/src/main/java/com/franco/dev/fmc/service/PushNotificationService.java
+++ b/src/main/java/com/franco/dev/fmc/service/PushNotificationService.java
@@ -47,6 +47,7 @@ public class PushNotificationService {
     private final FCMService fcmService;
 
     private final NotificacionPreferenciaService preferenciaService;
+    private final com.franco.dev.service.configuracion.NotificacionTipoEstadoService tipoEstadoService;
 
     @PersistenceContext
     private EntityManager entityManager;
@@ -58,7 +59,8 @@ public class PushNotificationService {
             NotificationDispatchService dispatchService,
             InicioSesionService inicioSesionService,
             FCMService fcmService,
-            com.franco.dev.service.configuracion.NotificacionPreferenciaService preferenciaService) {
+            com.franco.dev.service.configuracion.NotificacionPreferenciaService preferenciaService,
+            com.franco.dev.service.configuracion.NotificacionTipoEstadoService tipoEstadoService) {
         this.notificacionRepository = notificacionRepository;
         this.notificacionDestinatarioRepository = notificacionDestinatarioRepository;
         this.notificacionEnvioLogRepository = notificacionEnvioLogRepository;
@@ -66,6 +68,7 @@ public class PushNotificationService {
         this.inicioSesionService = inicioSesionService;
         this.fcmService = fcmService;
         this.preferenciaService = preferenciaService;
+        this.tipoEstadoService = tipoEstadoService;
     }
 
     public void sendPushNotificationToToken(@Valid PushNotificationRequest request) {
@@ -82,6 +85,20 @@ public class PushNotificationService {
     private void enqueue(PushNotificationRequest request) {
         if (!request.hasTopic() && !request.hasDirectTokens() && !request.hasUsuarios()) {
             throw new ValidationException("Debe proveer al menos un token, tópico o usuario destino");
+        }
+        /*
+         * El interruptor va aca y no en el mapa de roles porque los tipos no
+         * comparten forma de elegir destinatario: NUEVO_DISPOSITIVO le llega
+         * al propio usuario y no pasa por esa tabla, asi que vaciarla lo
+         * dejaria vivo. Aca pasan todos.
+         *
+         * Se descarta entero: ni push ni fila en la bandeja. Una notificacion
+         * suspendida que igual aparece en la lista no esta suspendida.
+         */
+        String tipoSolicitado = request.getType() != null ? request.getType() : "GENERAL";
+        if (!tipoEstadoService.estaActivo(tipoSolicitado)) {
+            LOGGER.info("Notificacion de tipo {} suspendida: no se envia", tipoSolicitado);
+            return;
         }
         if (request.hasTopic()) {
             sendPushNotificationToTopic(request);

--- a/src/main/java/com/franco/dev/fmc/service/PushNotificationService.java
+++ b/src/main/java/com/franco/dev/fmc/service/PushNotificationService.java
@@ -348,6 +348,17 @@ public class PushNotificationService {
                 return false;
             }
 
+            /*
+             * El interruptor tambien se mira aca, y no solo en enqueue, porque
+             * este metodo devuelve un booleano que el escritorio muestra como
+             * "enviada". Dejarlo en true con el tipo suspendido hace que la
+             * pantalla afirme algo que no paso.
+             */
+            if (!tipoEstadoService.estaActivo("PERSONALIZADA")) {
+                LOGGER.info("Notificacion personalizada suspendida: no se envia");
+                return false;
+            }
+
             PushNotificationRequest request = new PushNotificationRequest();
             request.setTitle(titulo);
             request.setMessage(mensaje);

--- a/src/main/java/com/franco/dev/graphql/configuracion/ConfiguracionNotificacionesGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/configuracion/ConfiguracionNotificacionesGraphQL.java
@@ -1,9 +1,14 @@
 package com.franco.dev.graphql.configuracion;
 
+import com.franco.dev.domain.configuracion.NotificacionTipoEstado;
+import com.franco.dev.domain.personas.Role;
 import com.franco.dev.domain.personas.Usuario;
 import com.franco.dev.graphql.configuracion.model.ConfiguracionNotificacionDto;
 import com.franco.dev.service.configuracion.NotificacionPreferenciaService;
+import com.franco.dev.service.configuracion.NotificacionTipoEstadoService;
+import com.franco.dev.service.personas.RoleService;
 import com.franco.dev.service.personas.UsuarioService;
+import graphql.GraphQLException;
 import graphql.kickstart.tools.GraphQLMutationResolver;
 import graphql.kickstart.tools.GraphQLQueryResolver;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,6 +28,12 @@ public class ConfiguracionNotificacionesGraphQL implements GraphQLQueryResolver,
     @Autowired
     private UsuarioService usuarioService;
 
+    @Autowired
+    private RoleService roleService;
+
+    @Autowired
+    private NotificacionTipoEstadoService tipoEstadoService;
+
     public List<ConfiguracionNotificacionDto> misConfiguracionesNotificacion() {
         Usuario usuario = getUsuarioActual();
         if (usuario == null) {
@@ -37,6 +48,51 @@ public class ConfiguracionNotificacionesGraphQL implements GraphQLQueryResolver,
             return false;
         }
         return notificacionPreferenciaService.actualizarPreferencia(usuario, tipoNotificacion, habilitado);
+    }
+
+    /**
+     * Que tipos estan suspendidos y por que.
+     *
+     * <p>
+     * Los que no tienen fila estan activos: la lista muestra lo que alguien
+     * decidio apagar, no el universo de tipos.
+     */
+    public List<NotificacionTipoEstado> estadosNotificacion() {
+        exigirAdmin();
+        return tipoEstadoService.listar();
+    }
+
+    /** Prende o apaga un tipo entero, para todos. */
+    public NotificacionTipoEstado cambiarEstadoNotificacion(String tipoNotificacion, Boolean activo, String motivo) {
+        exigirAdmin();
+        return tipoEstadoService.cambiar(tipoNotificacion, activo, motivo);
+    }
+
+    /**
+     * Solo ADMIN prende o apaga notificaciones.
+     *
+     * <p>
+     * ⚠️ <b>No se usa {@code @AdminSecured}.</b> Esa anotacion mira las
+     * authorities del SecurityContext, y el marshaling de roles JWT ->
+     * Authentication esta roto a nivel sistema (issue #177): llegan como
+     * "[ADMIN", "SOPORTE", ... —el toString de la lista partido por comas—,
+     * asi que la comparacion contra "ROLE_ADMIN" no da nunca y el metodo
+     * quedaria cerrado hasta para un ADMIN real. Se resuelve desde la DB.
+     */
+    private void exigirAdmin() {
+        Usuario usuario = getUsuarioActual();
+        if (usuario == null) {
+            throw new GraphQLException("Necesitas iniciar sesion para hacer eso.");
+        }
+        if ("ADMIN".equalsIgnoreCase(usuario.getNickname())) {
+            return;
+        }
+        for (Role rol : roleService.findByUsuarioId(usuario.getId())) {
+            if (rol.getNombre() != null && "ADMIN".equalsIgnoreCase(rol.getNombre().trim())) {
+                return;
+            }
+        }
+        throw new GraphQLException("Solo un administrador puede cambiar el estado de las notificaciones.");
     }
 
     private Usuario getUsuarioActual() {

--- a/src/main/java/com/franco/dev/repository/configuracion/NotificacionTipoEstadoRepository.java
+++ b/src/main/java/com/franco/dev/repository/configuracion/NotificacionTipoEstadoRepository.java
@@ -1,0 +1,15 @@
+package com.franco.dev.repository.configuracion;
+
+import com.franco.dev.domain.configuracion.NotificacionTipoEstado;
+import com.franco.dev.repository.HelperRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface NotificacionTipoEstadoRepository extends HelperRepository<NotificacionTipoEstado, Long> {
+    Optional<NotificacionTipoEstado> findByTipoNotificacion(String tipoNotificacion);
+
+    List<NotificacionTipoEstado> findAllByOrderByTipoNotificacionAsc();
+}

--- a/src/main/java/com/franco/dev/service/configuracion/NotificacionTipoEstadoService.java
+++ b/src/main/java/com/franco/dev/service/configuracion/NotificacionTipoEstadoService.java
@@ -1,0 +1,67 @@
+package com.franco.dev.service.configuracion;
+
+import com.franco.dev.domain.configuracion.NotificacionTipoEstado;
+import com.franco.dev.repository.configuracion.NotificacionTipoEstadoRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Si un tipo de notificacion sale o no sale.
+ *
+ * <p>
+ * Se consulta en el unico lugar por donde pasan todos los envios
+ * ({@code PushNotificationService}), porque los tipos no comparten forma de
+ * elegir destinatario: unos salen por rol, otros a una persona concreta y
+ * otros a todas las sesiones abiertas. Un interruptor puesto en el mapa de
+ * roles dejaria vivos justo a los que no pasan por ahi.
+ *
+ * <p>
+ * ⚠️ <b>Fila ausente = activo.</b> Al agregar un tipo nuevo nadie tiene que
+ * acordarse de prenderlo; lo que se apaga se apaga a proposito.
+ */
+@Service
+public class NotificacionTipoEstadoService {
+
+    @Autowired
+    private NotificacionTipoEstadoRepository repository;
+
+    public boolean estaActivo(String tipoNotificacion) {
+        if (tipoNotificacion == null || tipoNotificacion.trim().isEmpty()) {
+            return true;
+        }
+        Optional<NotificacionTipoEstado> estado = repository.findByTipoNotificacion(tipoNotificacion.trim());
+        return !estado.isPresent() || !Boolean.FALSE.equals(estado.get().getActivo());
+    }
+
+    public List<NotificacionTipoEstado> listar() {
+        return repository.findAllByOrderByTipoNotificacionAsc();
+    }
+
+    /**
+     * Prende o apaga un tipo.
+     *
+     * <p>
+     * Crea la fila si no existia, para que apagar un tipo que nunca se
+     * configuro no exija una migracion.
+     */
+    @Transactional
+    public NotificacionTipoEstado cambiar(String tipoNotificacion, Boolean activo, String motivo) {
+        if (tipoNotificacion == null || tipoNotificacion.trim().isEmpty() || activo == null) {
+            return null;
+        }
+        String tipo = tipoNotificacion.trim().toUpperCase();
+        NotificacionTipoEstado estado = repository.findByTipoNotificacion(tipo)
+                .orElseGet(() -> {
+                    NotificacionTipoEstado nuevo = new NotificacionTipoEstado();
+                    nuevo.setTipoNotificacion(tipo);
+                    return nuevo;
+                });
+        estado.setActivo(activo);
+        estado.setMotivo(motivo);
+        return repository.save(estado);
+    }
+}

--- a/src/main/resources/db/migration/V209.5__notificacion_tipo_estado_suspender_envios.sql
+++ b/src/main/resources/db/migration/V209.5__notificacion_tipo_estado_suspender_envios.sql
@@ -1,0 +1,73 @@
+-- =====================================================================
+-- Interruptor por tipo de notificacion, y suspension de los envios
+-- =====================================================================
+-- Decision del 2026-08-24: se suspenden TODOS los envios automaticos
+-- menos dos, y el esquema de destinatarios se rediscute de cero.
+--
+-- El motivo no es el volumen sino el contenido. Un retiro de PDV le
+-- llegaba a 37 personas por tener el rol de analisis de caja, y avisar
+-- movimientos de plata a alguien por su rol es un riesgo, no un servicio.
+-- Lo que sigue vivo es lo que va dirigido a la persona involucrada:
+--
+--   GASTO                  -> al responsable del gasto
+--   VENTA_CREDITO_CLIENTE  -> a quien hizo la compra a credito
+--
+-- El aviso de vale queda afuera: el unico que existe hoy va a los
+-- aprobadores por rol, y el personal al funcionario no esta escrito.
+--
+-- ⚠️ Esto NO se resuelve borrando el mapa de roles. Hay tipos que se
+-- mandan con destinatario explicito y no pasan por la tabla
+-- —NUEVO_DISPOSITIVO le llega al propio usuario que inicio sesion—, asi
+-- que vaciar notificacion_tipo_role los dejaria vivos. El interruptor va
+-- donde pasan todos: PushNotificationService.
+--
+-- Fila ausente = ACTIVO. Un tipo nuevo no nace apagado por accidente; lo
+-- que se apaga se apaga explicitamente y queda escrito por que.
+--
+-- Se reactiva desde la configuracion del sistema, sin migracion.
+-- =====================================================================
+
+CREATE TABLE IF NOT EXISTS configuraciones.notificacion_tipo_estado (
+    id                BIGSERIAL PRIMARY KEY,
+    tipo_notificacion VARCHAR(100) NOT NULL UNIQUE,
+    activo            BOOLEAN      NOT NULL DEFAULT TRUE,
+    motivo            TEXT,
+    actualizado_en    TIMESTAMP    NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE configuraciones.notificacion_tipo_estado IS
+    'Interruptor por tipo de notificacion. Fila ausente = activo.';
+
+INSERT INTO configuraciones.notificacion_tipo_estado (tipo_notificacion, activo, motivo)
+VALUES
+    -- Movimientos de plata y de stock que salian por rol.
+    ('RETIRO',                            FALSE, 'Suspendido 2026-08-24: informacion financiera saliendo por rol'),
+    ('VENTA_TRANSFERENCIA',               FALSE, 'Suspendido 2026-08-24: informacion financiera saliendo por rol'),
+    ('FACTURA_ALTO_VALOR',                FALSE, 'Suspendido 2026-08-24: informacion financiera saliendo por rol'),
+    ('DIFERENCIA_MALETIN',                FALSE, 'Suspendido 2026-08-24: hasta definir destinatarios por sucursal'),
+    ('COTIZACION_ACTUALIZADA',            FALSE, 'Suspendido 2026-08-24: salia a todas las sesiones activas'),
+    ('VENTA_STOCK_CRITICO',               FALSE, 'Suspendido 2026-08-24: hasta definir destinatarios'),
+    ('AJUSTE_STOCK',                      FALSE, 'Suspendido 2026-08-24: hasta definir destinatarios'),
+    ('AJUSTE_COSTO',                      FALSE, 'Suspendido 2026-08-24: hasta definir destinatarios'),
+    ('PRODUCTO_CREADO',                   FALSE, 'Suspendido 2026-08-24: hasta definir destinatarios'),
+    ('PRECIO_ACTUALIZADO',                FALSE, 'Suspendido 2026-08-24: hasta definir destinatarios'),
+    ('TRANSFERENCIA_INICIADA',            FALSE, 'Suspendido 2026-08-24: hasta definir destinatarios'),
+    ('CAMBIO_SUCURSAL_PRE_TRANSFERENCIA', FALSE, 'Suspendido 2026-08-24: hasta definir destinatarios'),
+    ('INVENTARIO_INICIADO',               FALSE, 'Suspendido 2026-08-24: hasta definir destinatarios'),
+    ('RRHH_ALERTA',                       FALSE, 'Suspendido 2026-08-24: resumen diario, hasta definir destinatarios'),
+    ('RRHH_SOLICITUD',                    FALSE, 'Suspendido 2026-08-24: el vale sale a los aprobadores por rol'),
+
+    -- Alerta de seguridad al propio usuario. Se suspende por pedido
+    -- expreso; no es un envio masivo y conviene revisarla temprano.
+    ('NUEVO_DISPOSITIVO',                 FALSE, 'Suspendido 2026-08-24: revisar en la definicion, es alerta personal'),
+
+    -- Envio manual y avisos genericos.
+    ('PERSONALIZADA',                     FALSE, 'Suspendido 2026-08-24: envio manual masivo desde el escritorio'),
+    ('MANUAL',                            FALSE, 'Suspendido 2026-08-24'),
+    ('SISTEMA',                           FALSE, 'Suspendido 2026-08-24'),
+    ('GENERAL',                           FALSE, 'Suspendido 2026-08-24'),
+
+    -- Los dos que siguen vivos, explicitos para que se lean de una.
+    ('GASTO',                             TRUE,  'Vive: va al responsable del gasto'),
+    ('VENTA_CREDITO_CLIENTE',             TRUE,  'Vive: va a quien hizo la compra a credito')
+ON CONFLICT (tipo_notificacion) DO NOTHING;

--- a/src/main/resources/graphql/configuracion/ConfiguracionNotificaciones.graphqls
+++ b/src/main/resources/graphql/configuracion/ConfiguracionNotificaciones.graphqls
@@ -5,11 +5,23 @@ type ConfiguracionNotificacion {
     esObligatorio: Boolean
 }
 
+# El interruptor de un tipo entero. Sin fila, el tipo esta activo: esta lista
+# muestra lo que alguien decidio apagar, no todos los tipos que existen.
+type NotificacionTipoEstado {
+    id: ID
+    tipoNotificacion: String
+    activo: Boolean
+    motivo: String
+    actualizadoEn: Date
+}
+
 extend type Query {
     misConfiguracionesNotificacion: [ConfiguracionNotificacion]
+    estadosNotificacion: [NotificacionTipoEstado]
 }
 
 extend type Mutation {
     actualizarPreferenciaNotificacion(tipoNotificacion: String!, habilitado: Boolean!): Boolean
+    cambiarEstadoNotificacion(tipoNotificacion: String!, activo: Boolean!, motivo: String): NotificacionTipoEstado
     enviarNotificacionPersonalizada(titulo: String!, mensaje: String!, tipoEnvio: String!, usuariosIds: [Int]): Boolean
 }

--- a/src/test/java/com/franco/dev/service/configuracion/NotificacionTipoEstadoServiceTest.java
+++ b/src/test/java/com/franco/dev/service/configuracion/NotificacionTipoEstadoServiceTest.java
@@ -1,0 +1,68 @@
+package com.franco.dev.service.configuracion;
+
+import com.franco.dev.domain.configuracion.NotificacionTipoEstado;
+import com.franco.dev.repository.configuracion.NotificacionTipoEstadoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * La regla que sostiene todo el interruptor: <b>fila ausente = activo</b>.
+ *
+ * <p>
+ * Si se invirtiera, un tipo nuevo naceria apagado y nadie se enteraria hasta
+ * que alguien preguntara por que no llego el aviso.
+ */
+class NotificacionTipoEstadoServiceTest {
+
+    private NotificacionTipoEstadoRepository repository;
+    private NotificacionTipoEstadoService service;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(NotificacionTipoEstadoRepository.class);
+        service = new NotificacionTipoEstadoService();
+        ReflectionTestUtils.setField(service, "repository", repository);
+    }
+
+    @Test
+    void sinFila_estaActivo() {
+        when(repository.findByTipoNotificacion("TIPO_NUEVO")).thenReturn(Optional.empty());
+
+        assertTrue(service.estaActivo("TIPO_NUEVO"));
+    }
+
+    @Test
+    void conFilaApagada_noEstaActivo() {
+        when(repository.findByTipoNotificacion("RETIRO")).thenReturn(Optional.of(estado(false)));
+
+        assertFalse(service.estaActivo("RETIRO"));
+    }
+
+    @Test
+    void conFilaPrendida_estaActivo() {
+        when(repository.findByTipoNotificacion("GASTO")).thenReturn(Optional.of(estado(true)));
+
+        assertTrue(service.estaActivo("GASTO"));
+    }
+
+    @Test
+    void tipoVacio_noBloquea() {
+        // Un request sin tipo no es razon para comerse el aviso.
+        assertTrue(service.estaActivo(null));
+        assertTrue(service.estaActivo("   "));
+    }
+
+    private NotificacionTipoEstado estado(boolean activo) {
+        NotificacionTipoEstado e = new NotificacionTipoEstado();
+        e.setActivo(activo);
+        return e;
+    }
+}


### PR DESCRIPTION
Suspende todos los envíos automáticos de notificación menos dos. Preparatorio de #239, donde se define el esquema de destinatarios de cero.

## Qué resuelve

El sistema elige destinatarios por rol, y un rol no es un permiso para recibir información financiera. **Un retiro de PDV le llegaba a 37 personas** por tener el rol de análisis de caja — una lista que nadie eligió, salida de un mapeo que ni siquiera coincidía con lo que el código enviaba.

Quedan vivos los dos avisos dirigidos a la persona involucrada:

| Tipo | Destinatario |
|---|---|
| `GASTO` | el responsable del gasto |
| `VENTA_CREDITO_CLIENTE` | quien hizo la compra a crédito |

Los otros veinte quedan suspendidos, cada uno con su motivo escrito en la fila.

## Cómo está hecho

`configuraciones.notificacion_tipo_estado` — un interruptor por tipo, y el chequeo en `PushNotificationService.enqueue`.

**No podía ir en el mapa de roles.** Hay tipos que se mandan con destinatario explícito y no pasan por `notificacion_tipo_role` — `NUEVO_DISPOSITIVO` le llega al propio usuario que inició sesión —, así que vaciar esa tabla los habría dejado vivos. `enqueue` es el único punto por donde pasan todos, sea cual sea la forma de elegir destinatario.

Descarta el envío entero: ni push ni fila en la bandeja. Una notificación suspendida que igual aparece en la lista no está suspendida.

**Fila ausente = activo**, para que un tipo nuevo no nazca apagado por accidente. Lo que se apaga se apaga a propósito y queda escrito por qué.

Se prende y se apaga sin migración:

```graphql
mutation { cambiarEstadoNotificacion(tipoNotificacion: "RETIRO", activo: true, motivo: "...") { activo } }
query { estadosNotificacion { tipoNotificacion activo motivo } }
```

Ambas exigen ADMIN, resuelto **desde la DB y no con `@AdminSecured`**: esa anotación mira las authorities del SecurityContext, y el marshaling de roles JWT → Authentication está roto a nivel sistema (#177) — llegan como `"[ADMIN"`, `"SOPORTE"`…, el `toString` de la lista partido por comas, así que la comparación contra `ROLE_ADMIN` no da nunca y el método quedaría cerrado hasta para un ADMIN real.

**No cambia destinatarios de nada.** `notificacion_tipo_role` queda exactamente como estaba, con sus defectos, porque lo reemplaza lo que se decida en #239.

## Cómo probarlo

1. `query { estadosNotificacion { tipoNotificacion activo } }` → 22 filas, activas solo `GASTO` y `VENTA_CREDITO_CLIENTE`.
2. `POST /notification/retiro/{id}/{suc}/{persona}/{monto}` → responde 202, y `select count(*) from configuraciones.notificacion where tipo='RETIRO'` **no aumenta**.
3. Prender `RETIRO` con `cambiarEstadoNotificacion`, repetir el paso 2 → ahora **sí** aumenta. Volver a apagarlo.
4. Un gasto real sigue avisando a su responsable.

Los cuatro pasos corridos contra un central local con base de bodega.

## Impacto en DB

Aditivo puro: `CREATE TABLE IF NOT EXISTS` + `COMMENT` + `INSERT`. Sin `DROP`, sin `ALTER` sobre tablas existentes, sin `DELETE`.

## Impacto en rollback

Ninguno. Con el JAR anterior la tabla queda sin que nadie la lea y todos los envíos vuelven solos.

## Riesgo: bajo

No toca auth, SIFEN, replicación, cálculo de dinero ni el esquema de ninguna tabla existente. GraphQL solo agrega un tipo, una query y una mutation — ningún campo eliminado, así que desktop y mobile no se enteran. El constructor de `PushNotificationService` gana un parámetro; no hay ningún `new PushNotificationService(` en el repo, lo resuelve Spring.

Lo que sí cambia de comportamiento, que es el objetivo:

- **El tablero de notificaciones deja de recibir entradas nuevas** de los tipos suspendidos (el flujo `POR_VERIFICAR → VERIFICADO` de maletín y stock crítico). Las históricas no se tocan.
- **`PERSONALIZADA` arrastra tres cosas** porque las tres salen con ese rótulo: el envío manual desde el escritorio, los avisos de RRHH (vale/vacación y la alerta diaria) y **la mención en comentarios**. La última es la que menos se parece a lo que se está apagando —es una conversación entre dos personas, no un aviso automático por rol—. **Decisión pendiente:** dejarla apagada, prender `PERSONALIZADA` entera, o darle tipo propio a la mención.

## De paso

`enviarNotificacionPersonalizada` devolvía `true` y logueaba «enviada exitosamente» aunque el envío se descartara. Ese booleano es lo que muestra el escritorio: la pantalla afirmaba que la notificación salió. Ahora devuelve `false` con el tipo suspendido.
