### PR TITLE
fix(financiero): declarar PAGADO en el enum EstadoPreGasto del schema GraphQL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,20 @@ Si tu codigo espera que exista una carpeta en disco, crearla programaticamente c
 2. Recien cuando todos los clientes (desktop + mobile) esten actualizados, eliminar el campo viejo.
 3. Si es inevitable, marcarlo como breaking change: `feat!: cambiar respuesta de /productos`. Esto sube MAJOR e implica que filiales + desktop + mobile tienen que actualizarse coordinadamente.
 
+> **Los clientes son dos: el desktop (`frc-sistemas-integrados-angular`) y la PWA (`frc-mobile-pwa`).** `frc-mobile` -- la APK vieja con Ionic/Capacitor -- **es legacy** y no se desarrolla mas; la PWA la reemplaza. Al evaluar el impacto cross-proyecto de un cambio de API, grepear el desktop y la PWA.
+
+### Un valor nuevo en un enum de Java va TAMBIEN en el .graphqls
+
+Es la falla mas silenciosa de este repo. Los enums de `domain/**/enums/` **no** generan el schema: el `.graphqls` los declara a mano y aparte. Si el enum de Java gana un valor y el schema no, la fila que lo tenga **no falla el build ni el CI** -- revienta en runtime al serializar:
+
+```
+CoercingSerializeException: Invalid input for Enum 'EstadoPreGasto'. Unknown value 'PAGADO'
+```
+
+graphql-java loguea un WARN, devuelve `null` en ese campo y la pantalla del cliente se rompe sin explicacion. Paso con `EstadoPreGasto.PAGADO` (V197.5): tumbo la lista de caja chica de la mobile-pwa.
+
+Al agregar un valor: **enum Java + `.graphqls` + migracion (si hay CHECK constraint) en el mismo commit.** `SchemaEnumsSincronizadosTest` compara los 108 enums pareados y falla el build si se desincronizan -- si ese test se pone en rojo, no es el test, es el schema.
+
 ## Convenciones
 
 - **GraphQL, no REST.** Endpoints nuevos van en `graphql/` (resolvers + schema), no `controller/`.

--- a/src/main/resources/graphql/financiero/movimiento-caja.graphqls
+++ b/src/main/resources/graphql/financiero/movimiento-caja.graphqls
@@ -45,6 +45,7 @@ enum PdvCajaTipoMovimiento {
     SALIDA_SENCILLO,
     CAMBIO,
     AJUSTE,
-    ENTRADA_SENCILLO
+    ENTRADA_SENCILLO,
+    CAJA_FINAL
 }
 

--- a/src/main/resources/graphql/financiero/pre_gasto.graphqls
+++ b/src/main/resources/graphql/financiero/pre_gasto.graphqls
@@ -5,6 +5,7 @@ enum EstadoPreGasto {
     RECHAZADO
     COMPLETADO
     ENVIADO_A_TESORERIA
+    PAGADO
 }
 
 type PreGastoDetalleFinanzas {

--- a/src/test/java/com/franco/dev/graphql/SchemaEnumsSincronizadosTest.java
+++ b/src/test/java/com/franco/dev/graphql/SchemaEnumsSincronizadosTest.java
@@ -1,0 +1,178 @@
+package com.franco.dev.graphql;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Un enum de Java que gana un valor y no lo gana su .graphqls revienta recien en runtime:
+ * graphql-java no puede serializar el valor desconocido, loguea un WARN y devuelve null en
+ * ese campo. La pantalla se rompe sin que falle ni el build ni el CI.
+ *
+ * Paso de verdad: el enum de Java. El schema tiene que declarar exactamente sus valores.
+ *
+ * Historial: EstadoPreGasto.PAGADO (V197.5) tumbo la lista de caja chica de la mobile-pwa.
+ */
+class SchemaEnumsSincronizadosTest {
+
+    private static final Pattern ENUM_GRAPHQL = Pattern.compile("\\benum\\s+(\\w+)\\s*\\{([^}]*)\\}");
+    private static final Pattern ENUM_JAVA = Pattern.compile("\\benum\\s+(\\w+)\\s*(?:implements[^{]*)?\\{");
+    private static final Pattern VALOR = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*");
+
+    @Test
+    void cadaEnumDelSchemaDeclaraLosMismosValoresQueSuEnumJava() {
+        Map<String, EnumDeclarado> schema = enumsDelSchema();
+        Map<String, List<Set<String>>> java = enumsDeJava();
+
+        List<String> problemas = new ArrayList<>();
+        for (Map.Entry<String, EnumDeclarado> e : schema.entrySet()) {
+            List<Set<String>> candidatos = java.get(e.getKey());
+            // Un enum declarado solo en el schema (sin contraparte Java) no tiene con que
+            // desincronizarse. Con nombre duplicado en Java alcanza con que uno coincida.
+            if (candidatos == null || candidatos.stream().anyMatch(c -> c.equals(e.getValue().valores))) {
+                continue;
+            }
+            Set<String> deJava = candidatos.get(0);
+            Set<String> falta = new TreeSet<>(deJava);
+            falta.removeAll(e.getValue().valores);
+            Set<String> sobra = new TreeSet<>(e.getValue().valores);
+            sobra.removeAll(deJava);
+            StringBuilder sb = new StringBuilder("  " + e.getKey() + " (" + e.getValue().archivo + ")");
+            if (!falta.isEmpty()) {
+                sb.append("\n      falta en el schema (Java lo tiene, revienta al serializar): ").append(falta);
+            }
+            if (!sobra.isEmpty()) {
+                sb.append("\n      sobra en el schema (Java no lo tiene, revienta al recibirlo): ").append(sobra);
+            }
+            problemas.add(sb.toString());
+        }
+
+        if (!problemas.isEmpty()) {
+            fail("Enums del schema desincronizados con los de Java:\n" + String.join("\n", problemas));
+        }
+    }
+
+    private static class EnumDeclarado {
+        final Set<String> valores;
+        final Path archivo;
+
+        EnumDeclarado(Set<String> valores, Path archivo) {
+            this.valores = valores;
+            this.archivo = archivo;
+        }
+    }
+
+    private Map<String, EnumDeclarado> enumsDelSchema() {
+        Map<String, EnumDeclarado> res = new HashMap<>();
+        for (Path f : archivos(Paths.get("src", "main", "resources", "graphql"), ".graphqls")) {
+            String txt = sinComentariosGraphql(leer(f));
+            Matcher m = ENUM_GRAPHQL.matcher(txt);
+            while (m.find()) {
+                res.put(m.group(1), new EnumDeclarado(valores(m.group(2)), f));
+            }
+        }
+        return res;
+    }
+
+    private Map<String, List<Set<String>>> enumsDeJava() {
+        Map<String, List<Set<String>>> res = new HashMap<>();
+        for (Path f : archivos(Paths.get("src", "main", "java"), ".java")) {
+            String txt = sinComentariosJava(leer(f));
+            Matcher m = ENUM_JAVA.matcher(txt);
+            while (m.find()) {
+                String cuerpo = cuerpoHastaLlaveDeCierre(txt, m.end() - 1);
+                if (cuerpo == null) {
+                    continue;
+                }
+                // Las constantes van antes del primer ';' (despues vienen campos y constructores).
+                int fin = cuerpo.indexOf(';');
+                if (fin != -1) {
+                    cuerpo = cuerpo.substring(0, fin);
+                }
+                cuerpo = cuerpo.replaceAll("\\([^)]*\\)", "").replaceAll("@\\w+", "");
+                Set<String> valores = new LinkedHashSet<>();
+                for (String parte : cuerpo.split(",")) {
+                    String v = parte.trim();
+                    if (v.matches("[A-Z][A-Z0-9_]*")) {
+                        valores.add(v);
+                    }
+                }
+                if (!valores.isEmpty()) {
+                    res.computeIfAbsent(m.group(1), k -> new ArrayList<>()).add(valores);
+                }
+            }
+        }
+        return res;
+    }
+
+    /** Devuelve el contenido entre la llave en {@code aperturaLlave} y la que la cierra. */
+    private String cuerpoHastaLlaveDeCierre(String txt, int aperturaLlave) {
+        int profundidad = 0;
+        for (int i = aperturaLlave; i < txt.length(); i++) {
+            char c = txt.charAt(i);
+            if (c == '{') {
+                profundidad++;
+            } else if (c == '}') {
+                profundidad--;
+                if (profundidad == 0) {
+                    return txt.substring(aperturaLlave + 1, i);
+                }
+            }
+        }
+        return null;
+    }
+
+    private Set<String> valores(String cuerpo) {
+        Set<String> res = new LinkedHashSet<>();
+        Matcher m = VALOR.matcher(cuerpo);
+        while (m.find()) {
+            res.add(m.group());
+        }
+        return res;
+    }
+
+    private String sinComentariosGraphql(String t) {
+        return t.replaceAll("(?s)\"\"\".*?\"\"\"", "").replaceAll("#.*", "");
+    }
+
+    private String sinComentariosJava(String t) {
+        return t.replaceAll("(?s)/\\*.*?\\*/", "").replaceAll("//.*", "");
+    }
+
+    private List<Path> archivos(Path raiz, String extension) {
+        try (Stream<Path> s = Files.walk(raiz)) {
+            return s.filter(Files::isRegularFile)
+                    .filter(p -> p.toString().endsWith(extension))
+                    .sorted()
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private String leer(Path p) {
+        try {
+            return new String(Files.readAllBytes(p), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}


### PR DESCRIPTION
## Qué resuelve

Entrar a **Caja chica** en `frc-mobile-pwa` rompe la lista. En el central:

```
WARN  n.graphql.execution.ExecutionStrategy : Can't serialize value
(/data/getContent[4]/estado) : Invalid input for Enum 'EstadoPreGasto'. Unknown value 'PAGADO'
graphql.schema.CoercingSerializeException
```

`EstadoPreGasto` ganó el valor `PAGADO` en el enum de Java con la migración **V197.5** (commit `d81e9382`), pero el `.graphqls` nunca lo declaró — ese commit tocó 5 archivos y ninguno fue el schema. Los enums de `domain/**/enums/` **no generan** el schema: el `.graphqls` los repite a mano.

Cuando `sincronizarDesdeSolicitudPago` pasa un PreGasto a `PAGADO` (su SolicitudPago GASTO llega a CONCLUIDO), `filterPreGastos` trae esa fila y graphql-java no la puede serializar: WARN, `estado: null` en ese ítem y la pantalla se rompe. **No falla el build ni el CI** — revienta solo en runtime, por eso llegó a alpha.

Afecta a los dos clientes: la lista de caja chica de la PWA y la pestaña `PAGADO` de `list-pre-gastos` en el desktop (que ya existía y estaba rota igual).

Barriendo los 108 enums pareados del repo apareció la **misma deriva** en `PdvCajaTipoMovimiento.CAJA_FINAL` — valor que la `V0` admite por CHECK constraint desde siempre. Se agrega también. Eran los únicos dos de 108: no es un problema sistémico, es el mismo olvido dos veces.

## Cambios

| Archivo | Qué |
|---|---|
| `graphql/financiero/pre_gasto.graphqls` | `+ PAGADO` |
| `graphql/financiero/movimiento-caja.graphqls` | `+ CAJA_FINAL` |
| `SchemaEnumsSincronizadosTest.java` (nuevo) | Compara los 108 enums pareados Java ↔ `.graphqls` y falla el build si se separan |
| `CLAUDE.md` | La regla que faltaba, más los clientes actuales de la API |

**Sin cambios en los clientes.** La PWA trata `estado` como `string` y muestra `estadoEtiqueta`/`estadoColor`/`estadoIcono` calculados por el central; `getStatusMetadataList()` ya devolvía la fila de `PAGADO`. Con el schema arreglado, la PWA muestra "Pagado" sola.

## Cómo probarlo

```bash
./mvnw clean verify -B -DskipFlyway=true
```

`SchemaEnumsSincronizadosTest` se escribió **antes** del fix y fallaba con exactamente los dos valores; con el fix queda verde. Resultado completo: **342 tests, 0 fallos, BUILD SUCCESS**.

Manual, después de desplegar (el `.graphqls` va dentro del JAR, así que **hace falta redesplegar** para que el error desaparezca):

1. PWA → **Operaciones → Caja chica**: la lista carga completa y la solicitud pagada muestra el chip "Pagado".
2. Desktop → `list-pre-gastos`, pestaña **PAGADO**: lista sin error.

## Impacto en DB

**Ninguno.** No hay migración. La `V197.5` que introdujo el valor ya está aplicada; esto solo lo declara en el schema GraphQL.

## Impacto en rollback

**Ninguno.** Volver a la versión anterior deja el schema como estaba y el bug vuelve, nada más. No hay estado nuevo que revertir.

## Riesgo

**Bajo.** Dos valores agregados a dos enums del schema — puramente aditivo. Un cliente que no conozca `PAGADO` ya lo trataba como string. Verificado además que los 222 `.graphqls` parsean con `graphql.parser.Parser` (el único que no es `productos-proveedor.graphqls`, comentado en su totalidad desde antes y no tocado acá).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
