### PR TITLE
feat(recepcion): aceptar lote, vencimiento y fecha de retiro en mobile

### DIFF
--- a/src/main/java/com/franco/dev/domain/operaciones/RecepcionMercaderiaItemVariacion.java
+++ b/src/main/java/com/franco/dev/domain/operaciones/RecepcionMercaderiaItemVariacion.java
@@ -14,6 +14,7 @@ import org.hibernate.annotations.TypeDefs;
 
 import javax.persistence.*;
 import java.io.Serializable;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Data
@@ -50,6 +51,15 @@ public class RecepcionMercaderiaItemVariacion implements Serializable, Identifia
     private Double cantidad;
 
     private LocalDateTime vencimiento;
+
+    /**
+     * Fecha de retiro cargada a mano en la verificacion. Opcional: cuando queda null,
+     * {@code LoteService} la deriva de {@code vencimiento - producto.diasVencimiento}, que es el
+     * comportamiento historico. Vive por variacion y no solo en el item porque cada variacion es
+     * un lote distinto, con su propio vencimiento y su propio retiro.
+     */
+    @Column(name = "fecha_retiro")
+    private LocalDate fechaRetiro;
 
     @Column(name = "lote")
     private String lote;

--- a/src/main/java/com/franco/dev/graphql/operaciones/RecepcionMercaderiaItemGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/RecepcionMercaderiaItemGraphQL.java
@@ -524,6 +524,7 @@ public class RecepcionMercaderiaItemGraphQL implements GraphQLQueryResolver, Gra
                 if (varInput.getVencimiento() != null && !varInput.getVencimiento().isEmpty()) {
                     variacion.setVencimiento(stringToDate(varInput.getVencimiento()));
                 }
+                variacion.setFechaRetiro(parseVencimiento(varInput.getFechaRetiro()));
 
                 variacion.setCantidad(varInput.getCantidad());
                 variacion.setLote(normalizarLote(varInput.getLote()));
@@ -628,6 +629,7 @@ public class RecepcionMercaderiaItemGraphQL implements GraphQLQueryResolver, Gra
                 if (varInput.getVencimiento() != null && !varInput.getVencimiento().isEmpty()) {
                     variacion.setVencimiento(stringToDate(varInput.getVencimiento()));
                 }
+                variacion.setFechaRetiro(parseVencimiento(varInput.getFechaRetiro()));
 
                 variacion.setCantidad(varInput.getCantidad());
                 variacion.setLote(normalizarLote(varInput.getLote()));
@@ -746,6 +748,9 @@ public class RecepcionMercaderiaItemGraphQL implements GraphQLQueryResolver, Gra
      * Verificación de producto para mobile.
      * Distribuye cantidades entre distribuciones automáticamente.
      *
+     * `lote`, `vencimientoRecibido` y `fechaRetiro` son la trazabilidad de lo recibido. El lote es
+     * obligatorio cuando el producto lleva control de lote: lo valida el servicio, no la pantalla.
+     *
      * Usado en:
      * - Desktop: No
      * - Mobile: Sí (verificación de producto en recepción)
@@ -759,6 +764,9 @@ public class RecepcionMercaderiaItemGraphQL implements GraphQLQueryResolver, Gra
             Long notaRecepcionItemIdParaRechazo,
             String motivoRechazo,
             String metodoVerificacion,
+            String lote,
+            String vencimientoRecibido,
+            String fechaRetiro,
             Long usuarioId
     ) {
         if (recepcionMercaderiaId == null || productoId == null || usuarioId == null) {
@@ -774,6 +782,9 @@ public class RecepcionMercaderiaItemGraphQL implements GraphQLQueryResolver, Gra
                 notaRecepcionItemIdParaRechazo,
                 motivoRechazo,
                 metodoVerificacion,
+                lote,
+                vencimientoRecibido,
+                fechaRetiro,
                 usuario
         );
     }

--- a/src/main/java/com/franco/dev/graphql/operaciones/input/RecepcionMercaderiaItemVariacionInput.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/input/RecepcionMercaderiaItemVariacionInput.java
@@ -8,6 +8,8 @@ public class RecepcionMercaderiaItemVariacionInput {
     private Long presentacionId;
     private Double cantidad;
     private String vencimiento;
+    /** Opcional. Si viene, pisa el calculo automatico de la fecha de retiro del lote. */
+    private String fechaRetiro;
     private String lote;
     private Boolean rechazado;
     private MotivoRechazoFisico motivoRechazo;

--- a/src/main/java/com/franco/dev/service/operaciones/MovimientoStockLoteService.java
+++ b/src/main/java/com/franco/dev/service/operaciones/MovimientoStockLoteService.java
@@ -143,10 +143,11 @@ public class MovimientoStockLoteService
             LocalDate vencimiento = variacion.getVencimiento() != null
                     ? variacion.getVencimiento().toLocalDate()
                     : null;
-            // Sin fecha de retiro manual: cada variación es un lote distinto con su propio
-            // vencimiento, así que la del ítem no aplica y se deja derivar por lote.
-            creados.add(crearMovimiento(item, movimiento, numeroLote, vencimiento, null, cantidad,
-                    variacion.getPresentacion()));
+            // La fecha de retiro se toma de la variación y no del ítem: cada variación es un lote
+            // distinto, con su propio vencimiento y su propio retiro. Null deja que LoteService la
+            // derive de los días de vencimiento del producto.
+            creados.add(crearMovimiento(item, movimiento, numeroLote, vencimiento,
+                    variacion.getFechaRetiro(), cantidad, variacion.getPresentacion()));
         }
         return creados;
     }

--- a/src/main/java/com/franco/dev/service/operaciones/RecepcionMercaderiaItemService.java
+++ b/src/main/java/com/franco/dev/service/operaciones/RecepcionMercaderiaItemService.java
@@ -1,6 +1,7 @@
 package com.franco.dev.service.operaciones;
 
 import com.franco.dev.domain.operaciones.RecepcionMercaderiaItem;
+import com.franco.dev.domain.operaciones.RecepcionMercaderiaItemVariacion;
 import com.franco.dev.domain.operaciones.RecepcionMercaderia;
 import com.franco.dev.repository.operaciones.RecepcionMercaderiaItemRepository;
 import com.franco.dev.service.CrudService;
@@ -36,8 +37,13 @@ import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import java.util.ArrayList;
+import com.franco.dev.domain.productos.Producto;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+
+import static com.franco.dev.utilitarios.DateUtils.stringToDate;
 
 @Service
 @RequiredArgsConstructor
@@ -48,6 +54,7 @@ public class RecepcionMercaderiaItemService extends CrudService<RecepcionMercade
     private final RecepcionMercaderiaNotaService recepcionMercaderiaNotaService;
     private final MovimientoStockRepository movimientoStockRepository;
     private final MovimientoStockService movimientoStockService;
+    private final RecepcionMercaderiaItemVariacionService recepcionMercaderiaItemVariacionService;
     
     // Usar @Lazy para romper dependencia circular con RecepcionMercaderiaService
     @Autowired
@@ -681,6 +688,7 @@ public class RecepcionMercaderiaItemService extends CrudService<RecepcionMercade
                 item.setMotivoRechazo(null);
                 item.setLote(null);
                 item.setVencimientoRecibido(null);
+                item.setFechaRetiro(null);
                 item.setMetodoVerificacion(null);
                 item.setMotivoVerificacionManual(null);
                 item.setEstadoVerificacion(EstadoVerificacion.PENDIENTE);
@@ -899,6 +907,10 @@ public class RecepcionMercaderiaItemService extends CrudService<RecepcionMercade
      * @param notaRecepcionItemIdParaRechazo ID de la nota donde se registra el rechazo (null si no hay rechazo)
      * @param motivoRechazo Motivo del rechazo (enum name como String)
      * @param metodoVerificacion Metodo de verificacion (ej. MANUAL)
+     * @param lote Numero de lote de lo recibido. Obligatorio si el producto lleva control de lote.
+     * @param vencimientoRecibido Vencimiento de lo recibido (yyyy-MM-dd). Opcional.
+     * @param fechaRetiro Fecha de retiro cargada a mano (yyyy-MM-dd). Opcional: sin ella,
+     *                    {@code LoteService} la deriva de los dias de vencimiento del producto.
      * @param usuario Usuario que realiza la verificación
      * @return true si se actualizó correctamente
      */
@@ -911,6 +923,9 @@ public class RecepcionMercaderiaItemService extends CrudService<RecepcionMercade
             Long notaRecepcionItemIdParaRechazo,
             String motivoRechazo,
             String metodoVerificacion,
+            String lote,
+            String vencimientoRecibido,
+            String fechaRetiro,
             Usuario usuario
     ) {
         Logger logger = LoggerFactory.getLogger(RecepcionMercaderiaItemService.class);
@@ -942,6 +957,11 @@ public class RecepcionMercaderiaItemService extends CrudService<RecepcionMercade
         if (items.isEmpty()) {
             throw new GraphQLException("No se encontraron items de recepción para el producto " + productoId + " en la sucursal de recepción");
         }
+
+        String numeroLote = LoteService.normalizarNumeroLote(lote);
+        validarLoteObligatorio(items.get(0).getProducto(), cantRec, numeroLote);
+        LocalDate vencimiento = aFecha(vencimientoRecibido);
+        LocalDate retiro = aFecha(fechaRetiro);
 
         double totalPendiente = 0;
         double[] pendientes = new double[items.size()];
@@ -1035,10 +1055,76 @@ public class RecepcionMercaderiaItemService extends CrudService<RecepcionMercade
             if (metodoEnum != null) {
                 item.setMetodoVerificacion(metodoEnum);
             }
+            if (numeroLote != null && rec > 0 && item.getLote() == null) {
+                // Solo la primera vez: si el mismo item ya se verificó con otro lote, el dato de
+                // este nivel dejaría de representar a todo lo recibido. La verdad por lote vive
+                // en las variaciones, que se crean abajo.
+                item.setLote(numeroLote);
+                item.setVencimientoRecibido(vencimiento);
+                item.setFechaRetiro(retiro);
+            }
             actualizarEstadoVerificacionItem(item);
             repository.save(item);
+            if (numeroLote != null && rec > 0) {
+                registrarVariacionDeLote(item, rec, numeroLote, vencimiento, retiro);
+            }
         }
         return true;
+    }
+
+    /**
+     * Si el producto lleva control de lote, exige el número de lote para lo que se recibe.
+     *
+     * Vive acá y no solo en la pantalla porque mobile, el desktop y una llamada directa al
+     * GraphQL son puertas de entrada independientes: sin lote, la finalización de la recepción no
+     * puede desglosar el stock y la mercadería entra sin trazabilidad, en silencio.
+     *
+     * Solo aplica a lo que efectivamente se recibe: una verificación que es toda rechazo no tiene
+     * lote que informar. Es la misma regla que
+     * {@code RecepcionMercaderiaItemGraphQL.validarLoteObligatorio} aplica al guardar un ítem
+     * desde el desktop.
+     */
+    private void validarLoteObligatorio(Producto producto, double cantidadRecibida, String numeroLote) {
+        if (cantidadRecibida <= 0 || producto == null || !Boolean.TRUE.equals(producto.getLote())) {
+            return;
+        }
+        if (numeroLote == null) {
+            throw new GraphQLException("El producto '" + producto.getDescripcion()
+                    + "' requiere control de lote: el número de lote es obligatorio.");
+        }
+    }
+
+    /**
+     * Deja registrada la parte de lo recibido que corresponde a este lote.
+     *
+     * Se guarda como variación —y no solo en el ítem— porque el mismo producto puede verificarse
+     * en varias pasadas con lotes distintos: dos cajas del lote A ahora y cinco unidades del lote
+     * B después. El ítem tiene un solo campo `lote`, así que la segunda pasada pisaría a la
+     * primera y todo el stock terminaría atribuido al último lote tipeado.
+     *
+     * Al finalizar la recepción, {@code MovimientoStockLoteService.registrarEntradaCompra} prefiere
+     * las variaciones sobre el ítem justamente para este caso.
+     */
+    private void registrarVariacionDeLote(RecepcionMercaderiaItem item, double cantidad,
+                                          String numeroLote, LocalDate vencimiento,
+                                          LocalDate fechaRetiro) {
+        RecepcionMercaderiaItemVariacion variacion = new RecepcionMercaderiaItemVariacion();
+        variacion.setRecepcionMercaderiaItem(item);
+        variacion.setPresentacion(item.getPresentacionRecibida());
+        // En unidades base, igual que cantidadRecibida: es la escala con la que el desglose por
+        // lote se compara contra el movimiento de stock agregado.
+        variacion.setCantidad(cantidad);
+        variacion.setLote(numeroLote);
+        variacion.setVencimiento(vencimiento != null ? vencimiento.atStartOfDay() : null);
+        variacion.setFechaRetiro(fechaRetiro);
+        variacion.setRechazado(false);
+        recepcionMercaderiaItemVariacionService.save(variacion);
+    }
+
+    /** Las fechas llegan como "yyyy-MM-dd" desde mobile; stringToDate también acepta ISO-8601. */
+    private LocalDate aFecha(String valor) {
+        LocalDateTime fecha = stringToDate(valor);
+        return fecha != null ? fecha.toLocalDate() : null;
     }
 
     private void actualizarEstadoVerificacionItem(RecepcionMercaderiaItem item) {

--- a/src/main/resources/db/migration/V202.5__add_fecha_retiro_to_recepcion_mercaderia_item_variacion.sql
+++ b/src/main/resources/db/migration/V202.5__add_fecha_retiro_to_recepcion_mercaderia_item_variacion.sql
@@ -1,0 +1,22 @@
+-- Fecha de retiro por variacion de un item de recepcion.
+--
+-- Una variacion es "una parte de lo recibido que tiene su propio lote": es como se registra que
+-- del mismo producto bajaron del camion dos lotes distintos. El desglose por lote
+-- (MovimientoStockLoteService.desglosarVariaciones) crea una fila de stock por variacion y llama
+-- a LoteService.obtenerOCrear con las fechas de esa variacion.
+--
+-- Hasta ahora esa llamada pasaba fechaRetiro = null y el retiro se derivaba siempre de
+-- (vencimiento - producto.dias_vencimiento). La verificacion en mobile carga la fecha de retiro a
+-- mano, igual que la verificacion detallada del desktop (V158.3 agrego la columna equivalente en
+-- recepcion_mercaderia_item), asi que sin esta columna ese dato se perdia entre la verificacion y
+-- la finalizacion de la recepcion.
+--
+-- Es opcional: NULL mantiene el comportamiento historico (derivar de dias_vencimiento).
+--
+-- operaciones.recepcion_mercaderia_item_variacion NO esta registrada en
+-- configuraciones.replication_table, asi que agregar la columna no toca ninguna publicacion.
+ALTER TABLE operaciones.recepcion_mercaderia_item_variacion
+    ADD COLUMN IF NOT EXISTS fecha_retiro DATE;
+
+COMMENT ON COLUMN operaciones.recepcion_mercaderia_item_variacion.fecha_retiro IS
+    'Fecha de retiro cargada manualmente en la verificacion. NULL = derivar de dias_vencimiento.';

--- a/src/main/resources/graphql/operaciones/recepcion-mercaderia-item.graphqls
+++ b/src/main/resources/graphql/operaciones/recepcion-mercaderia-item.graphqls
@@ -28,6 +28,7 @@ type RecepcionMercaderiaItemVariacion {
     presentacion: Presentacion
     cantidad: Float
     vencimiento: String
+    fechaRetiro: Date
     lote: String
     rechazado: Boolean
     motivoRechazo: MotivoRechazoFisico
@@ -61,6 +62,7 @@ input RecepcionMercaderiaItemVariacionInput {
     presentacionId: ID
     cantidad: Float
     vencimiento: String
+    fechaRetiro: String
     lote: String
     rechazado: Boolean
     motivoRechazo: MotivoRechazoFisico
@@ -158,6 +160,9 @@ extend type Mutation {
         notaRecepcionItemIdParaRechazo: ID,
         motivoRechazo: String,
         metodoVerificacion: String,
+        lote: String,
+        vencimientoRecibido: String,
+        fechaRetiro: String,
         usuarioId: ID!
     ): Boolean!
     


### PR DESCRIPTION
## Por qué

`verificarProductoMobile` recibía cantidades y nada más. Un producto con control de lote se recepcionaba desde la PWA **sin número**, y al finalizar, `MovimientoStockLoteService.registrarEntradaCompra` no encontraba con qué desglosar el stock: la mercadería entraba **sin trazabilidad**, con un warning en el log y sin un solo error visible.

## Qué cambia

- Tres argumentos nuevos en `verificarProductoMobile`: `lote`, `vencimientoRecibido` y `fechaRetiro`.
- El lote es **obligatorio** cuando el producto lo lleva y hay cantidad recibida, validado en el servicio: mobile, el desktop y una llamada directa al GraphQL son tres puertas independientes. Es la misma regla que ya aplicaba `RecepcionMercaderiaItemGraphQL.validarLoteObligatorio` al guardar un ítem desde el desktop. Una verificación que es **toda rechazo** no lo pide.
- Cada pasada deja una **variación** con su cantidad, su lote y sus fechas. El ítem tiene un solo campo `lote`, así que verificar el mismo producto dos veces con lotes distintos atribuía todo el stock al último número tipeado. `registrarEntradaCompra` ya prefiere las variaciones.
- La variación gana `fecha_retiro` (**V202.5**): el desglose por lote la pasaba siempre en `null` y el retiro cargado a mano se perdía entre la verificación y la finalización.
- Deshacer una verificación también limpia `fecha_retiro` del ítem, que había quedado afuera del reset.

## Migración

`V202.5` es **aditiva** (`ADD COLUMN IF NOT EXISTS ... DATE`, nullable) sobre `operaciones.recepcion_mercaderia_item_variacion`, que **no está** en `configuraciones.replication_table`: no toca ninguna publicación. `NULL` mantiene el comportamiento histórico — derivar el retiro de `vencimiento − producto.dias_vencimiento`.

## Impacto cross-proyecto

El **desktop** no usa esta mutation y su camino de variaciones no manda `fechaRetiro`: su comportamiento no cambia.

⚠️ **Se publica junto con el PR de la PWA** (`GabFrank/frc-mobile-pwa#24`, misma rama). El cliente nuevo contra un central sin estos argumentos rompe la verificación de productos **entera**, no solo la de los que llevan lote.

## Verificación

En esta sesión solo se abrió el PR: el build y los tests del central **no se volvieron a correr acá**, hay que dejar que pase el CI antes de mergear. La prueba manual está en el bloque 20 del plan de testeo de la PWA (casos 20.22 a 20.29), y necesita un producto marcado con control de lote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)