### PR TITLE
feat(inventario): conteo por lote, fechas del lote y tres arreglos del conteo

### DIFF
--- a/src/main/java/com/franco/dev/domain/operaciones/InventarioProductoItem.java
+++ b/src/main/java/com/franco/dev/domain/operaciones/InventarioProductoItem.java
@@ -44,6 +44,21 @@ public class InventarioProductoItem implements Identifiable<Long> {
     @JoinColumn(name = "zona_id", nullable = true)
     private Zona zona;
 
+    /**
+     * El lote que se está contando. Nulo en los productos sin control de lote —la enorme mayoría—
+     * y también en la mercadería que todavía no se atribuyó a ninguno.
+     *
+     * Con control de lote, un renglón ES un lote: {@code cantidadFisica} guarda el saldo DE ESE
+     * LOTE en la sucursal, no la existencia del producto. Es lo que le permite a
+     * {@code finalizarInventarioEnSucursal()} escribir el desglose en {@code movimiento_stock_lote}
+     * en vez de dejar el ledger sin tocar.
+     *
+     * EAGER como {@code presentacion}: la pantalla de conteo lo muestra siempre.
+     */
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "lote_id", nullable = true)
+    private Lote lote;
+
     private Double cantidad;
 
     private Double cantidadFisica;

--- a/src/main/java/com/franco/dev/domain/operaciones/dto/LoteSinContarDto.java
+++ b/src/main/java/com/franco/dev/domain/operaciones/dto/LoteSinContarDto.java
@@ -1,0 +1,31 @@
+package com.franco.dev.domain.operaciones.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+/**
+ * Un lote con saldo que ningún renglón de la toma contó.
+ *
+ * La finalización deja esos productos ENTEROS fuera del ajuste, con la misma regla que ya aplica al
+ * ítem con {@code cantidad == null}: un lote sin contar no es un lote en cero.
+ *
+ * Este DTO existe para poder avisarlo ANTES de finalizar. Trae la descripción del producto ya
+ * resuelta porque el frontend es capa de presentación y no tiene que salir a buscarla.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class LoteSinContarDto {
+
+    private Long loteId;
+    private String numeroLote;
+    private Long productoId;
+    private String productoDescripcion;
+    private LocalDate fechaVencimiento;
+    private LocalDate fechaRetiro;
+    /** Saldo en unidades base en la sucursal de la toma. */
+    private Double saldo;
+}

--- a/src/main/java/com/franco/dev/graphql/operaciones/InventarioGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/InventarioGraphQL.java
@@ -10,7 +10,9 @@ import com.franco.dev.domain.operaciones.enums.TipoMovimiento;
 import com.franco.dev.domain.productos.Producto;
 import com.franco.dev.graphql.operaciones.input.InventarioInput;
 import com.franco.dev.service.empresarial.SucursalService;
+import com.franco.dev.service.operaciones.InventarioLoteService;
 import com.franco.dev.service.operaciones.InventarioProductoItemService;
+import com.franco.dev.service.operaciones.PlanConteoLote;
 import com.franco.dev.service.operaciones.InventarioProductoService;
 import com.franco.dev.service.operaciones.InventarioService;
 import com.franco.dev.service.operaciones.MovimientoStockService;
@@ -25,6 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import lombok.extern.java.Log;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -32,6 +35,7 @@ import java.util.*;
 
 import static com.franco.dev.utilitarios.DateUtils.stringToDate;
 
+@Log
 @Component
 public class InventarioGraphQL implements GraphQLQueryResolver, GraphQLMutationResolver {
 
@@ -59,6 +63,9 @@ public class InventarioGraphQL implements GraphQLQueryResolver, GraphQLMutationR
 
     @Autowired
     private ProductoService productoService;
+
+    @Autowired
+    private InventarioLoteService inventarioLoteService;
 
     @Autowired
     private MultiTenantService multiTenantService;
@@ -251,34 +258,88 @@ public class InventarioGraphQL implements GraphQLQueryResolver, GraphQLMutationR
                                 Double::sum);
                     }
 
-                    for (Map.Entry<Long, Double> entry : cantidadesPorProducto.entrySet()) {
-                        Long productoId = entry.getKey();
-                        Producto foundProducto = productoService.findById(productoId).orElse(null);
-                        Double cantidadTotal = entry.getValue();
-                        Double stockSistema = 0.0;
-                        MovimientoStock movimientoStockEncontrado = movimientoStockService
-                                .findByTipoMovimientoAndReferenciaAndSucursalIdAndProductoId(TipoMovimiento.AJUSTE,
-                                        inventario.getId(), inventario.getSucursal().getId(), productoId);
-                        if (movimientoStockEncontrado != null) {
-                            stockSistema = movimientoStockService.stockByProductoIdExecptMovStockId(
-                                    movimientoStockEncontrado.getProducto().getId(), movimientoStockEncontrado.getId(),
-                                    inventario.getSucursal().getId());
-                        } else {
-                            stockSistema = movimientoStockService.stockByProductoIdAndSucursalId(productoId,
-                                    inventario.getSucursal().getId());
+                }
+
+                /*
+                 * El desglose por lote de lo contado, por producto. Una sola pasada por toda la
+                 * toma: el mismo lote puede estar en gondola y en deposito, y los dos conteos
+                 * suman contra el mismo saldo.
+                 */
+                Map<Long, Map<Long, Double>> contadoPorLote =
+                        inventarioLoteService.contadoPorProductoYLote(id);
+
+                /*
+                 * ESTE BUCLE VA AFUERA DEL DE ZONAS, y no es un detalle de estilo.
+                 *
+                 * Estaba anidado adentro y `cantidadesPorProducto` nunca se limpia, asi que con N
+                 * zonas cada movimiento agregado se escribia N veces con acumulados parciales.
+                 * Terminaba bien de casualidad —la ultima pasada pisaba con el total correcto—,
+                 * pero el desglose por lote son filas NUEVAS con PK propia: escribirlas N veces
+                 * multiplica el ledger y ahi no hay pisada que lo salve.
+                 */
+                for (Map.Entry<Long, Double> entry : cantidadesPorProducto.entrySet()) {
+                    Long productoId = entry.getKey();
+                    Producto foundProducto = productoService.findById(productoId).orElse(null);
+                    Double cantidadTotal = entry.getValue();
+                    Double stockSistema = 0.0;
+                    MovimientoStock movimientoStockEncontrado = movimientoStockService
+                            .findByTipoMovimientoAndReferenciaAndSucursalIdAndProductoId(TipoMovimiento.AJUSTE,
+                                    inventario.getId(), inventario.getSucursal().getId(), productoId);
+                    if (movimientoStockEncontrado != null) {
+                        stockSistema = movimientoStockService.stockByProductoIdExecptMovStockId(
+                                movimientoStockEncontrado.getProducto().getId(), movimientoStockEncontrado.getId(),
+                                inventario.getSucursal().getId());
+                    } else {
+                        stockSistema = movimientoStockService.stockByProductoIdAndSucursalId(productoId,
+                                inventario.getSucursal().getId());
+                    }
+
+                    /*
+                     * Todo lo nuevo detras de este if: para los ~8.700 productos sin control de
+                     * lote el camino es exactamente el de antes.
+                     */
+                    boolean conLote = foundProducto != null && Boolean.TRUE.equals(foundProducto.getLote());
+                    PlanConteoLote plan = null;
+                    if (conLote) {
+                        plan = InventarioLoteService.planificar(
+                                stockSistema,
+                                cantidadTotal,
+                                inventarioLoteService.saldosPorLote(productoId,
+                                        inventario.getSucursal().getId(), movimientoStockEncontrado),
+                                contadoPorLote.getOrDefault(productoId, Collections.emptyMap()));
+
+                        if (plan.isOmitido()) {
+                            /*
+                             * Hay un lote con saldo que ningun renglon conto. El producto queda
+                             * ENTERO afuera: ni movimiento agregado ni filas del ledger.
+                             *
+                             * Es la misma regla que ya rige para el item con cantidad nula. La
+                             * pantalla lo avisa antes con lotesSinContar(), pero la regla se
+                             * aplica igual, mire alguien esa pantalla o no.
+                             */
+                            log.warning("Inventario " + inventario.getId() + ": el producto "
+                                    + productoId + " queda fuera del ajuste porque los lotes "
+                                    + plan.getLotesSinContar() + " tienen saldo y nadie los conto.");
+                            continue;
                         }
-                        if (movimientoStockEncontrado == null) {
-                            movimientoStockEncontrado = new MovimientoStock();
-                            movimientoStockEncontrado.setTipoMovimiento(TipoMovimiento.AJUSTE);
-                            movimientoStockEncontrado.setSucursalId(inventario.getSucursal().getId());
-                            movimientoStockEncontrado.setReferencia(inventario.getId());
-                            movimientoStockEncontrado.setProducto(foundProducto);
-                            movimientoStockEncontrado.setUsuario(inventario.getUsuario());
-                            movimientoStockEncontrado.setEstado(true);
-                        }
-                        Double diferencia = cantidadTotal - stockSistema; // 9 - 10 = -1, 11 - 10 = 1
-                        movimientoStockEncontrado.setCantidad(diferencia);
-                        movimientoStockEncontrado = movimientoStockService.save(movimientoStockEncontrado);
+                    }
+
+                    if (movimientoStockEncontrado == null) {
+                        movimientoStockEncontrado = new MovimientoStock();
+                        movimientoStockEncontrado.setTipoMovimiento(TipoMovimiento.AJUSTE);
+                        movimientoStockEncontrado.setSucursalId(inventario.getSucursal().getId());
+                        movimientoStockEncontrado.setReferencia(inventario.getId());
+                        movimientoStockEncontrado.setProducto(foundProducto);
+                        movimientoStockEncontrado.setUsuario(inventario.getUsuario());
+                        movimientoStockEncontrado.setEstado(true);
+                    }
+                    Double diferencia = cantidadTotal - stockSistema; // 9 - 10 = -1, 11 - 10 = 1
+                    movimientoStockEncontrado.setCantidad(diferencia);
+                    movimientoStockEncontrado = movimientoStockService.save(movimientoStockEncontrado);
+
+                    if (conLote) {
+                        inventarioLoteService.escribirDesglose(movimientoStockEncontrado, foundProducto,
+                                plan, inventario.getUsuario());
                     }
                 }
             }

--- a/src/main/java/com/franco/dev/graphql/operaciones/InventarioGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/InventarioGraphQL.java
@@ -199,8 +199,20 @@ public class InventarioGraphQL implements GraphQLQueryResolver, GraphQLMutationR
         return service.findInventarioAbiertoPorSucursal(sucId);
     }
 
+    /**
+     * Finaliza la toma y ajusta el stock con lo contado.
+     *
+     * Usado en:
+     * - Desktop: Si (modulo de inventario, boton de finalizar)
+     * - Mobile: Si (detalle de la toma)
+     */
     public Inventario finalizarInventarioEnSucursal(Long id) throws GraphQLException {
         Inventario inventario = service.findById(id).orElse(null);
+        if (inventario == null) {
+            // Antes seguia y reventaba con un NullPointerException en la linea
+            // siguiente, que no dice cual es el problema.
+            throw new GraphQLException("No existe el inventario " + id);
+        }
         Map<Long, Double> cantidadesPorProducto = new HashMap<>();
         Producto selectedProducto = null;
         try {
@@ -214,6 +226,24 @@ public class InventarioGraphQL implements GraphQLQueryResolver, GraphQLMutationR
                     List<InventarioProductoItem> inventarioProductoItemList = inventarioProductoItemService
                             .findByInventarioProductoId(ip.getId());
                     for (InventarioProductoItem ipi : inventarioProductoItemList) {
+                        /*
+                         * Un item SIN contar no es un item contado en cero.
+                         *
+                         * `cantidad` es lo contado y es nullable: un item que se
+                         * sumo a la toma y que nadie fue a contar la tiene en
+                         * null. Multiplicarla reventaba con un NullPointerException
+                         * al desempaquetar el Double, asi que ninguna toma con un
+                         * item sin contar se podia finalizar.
+                         *
+                         * Se saltea, no se toma como cero. Si se tomara como cero y
+                         * un producto tuviera todos sus items sin contar, el ajuste
+                         * le llevaria el stock A CERO sin que nadie hubiera contado
+                         * nada — una perdida de stock muda. Salteandolo, ese
+                         * producto simplemente no entra en el ajuste.
+                         */
+                        if (ipi.getCantidad() == null) {
+                            continue;
+                        }
                         selectedProducto = ipi.getPresentacion().getProducto();
                         cantidadesPorProducto.merge(
                                 ipi.getPresentacion().getProducto().getId(),

--- a/src/main/java/com/franco/dev/graphql/operaciones/InventarioProductoItemGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/InventarioProductoItemGraphQL.java
@@ -5,6 +5,7 @@ import com.franco.dev.domain.empresarial.Sucursal;
 import com.franco.dev.domain.productos.Producto;
 import com.franco.dev.domain.operaciones.InventarioProducto;
 import com.franco.dev.domain.operaciones.InventarioProductoItem;
+import com.franco.dev.domain.operaciones.Lote;
 import com.franco.dev.domain.operaciones.dto.ProductoSaldoDto;
 import com.franco.dev.domain.operaciones.dto.ReporteInventarioDto;
 import com.franco.dev.graphql.operaciones.input.InventarioProductoItemInput;
@@ -12,6 +13,7 @@ import com.franco.dev.domain.operaciones.enums.FuenteVerdadVencimiento;
 import com.franco.dev.domain.operaciones.enums.InventarioProductoEstado;
 import com.franco.dev.graphql.operaciones.dto.ProductoVencidoViewDTO;
 import com.franco.dev.service.operaciones.InventarioProductoItemService;
+import com.franco.dev.service.operaciones.LoteService;
 import com.franco.dev.service.operaciones.InventarioProductoService;
 import com.franco.dev.service.operaciones.MovimientoStockService;
 import com.franco.dev.service.operaciones.ProductosVencidosService;
@@ -23,6 +25,7 @@ import com.franco.dev.service.productos.ProductoService;
 import com.franco.dev.service.utils.ImageService;
 import com.franco.dev.utilitarios.DateUtils;
 import com.franco.dev.utilitarios.IdUtils;
+import graphql.GraphQLException;
 import graphql.kickstart.tools.GraphQLMutationResolver;
 import graphql.kickstart.tools.GraphQLQueryResolver;
 import net.sf.jasperreports.engine.*;
@@ -62,6 +65,9 @@ public class InventarioProductoItemGraphQL implements GraphQLQueryResolver, Grap
 
     @Autowired
     private InventarioProductoService inventarioProductoService;
+
+    @Autowired
+    private LoteService loteService;
 
 
     @Autowired
@@ -152,8 +158,28 @@ public class InventarioProductoItemGraphQL implements GraphQLQueryResolver, Grap
         if (input.getInventarioProductoId() != null) {
             entity.setInventarioProducto(inventarioProductoService.findById(input.getInventarioProductoId()).orElse(null));
         }
+        /*
+         * El lote es opcional y aditivo: el escritorio no lo manda y su renglon sigue entrando sin
+         * lote, que es lo correcto para los productos que no lo llevan.
+         *
+         * Un lote inexistente se rechaza en vez de guardar el renglon sin lote: guardarlo "casi
+         * bien" es lo que despues hace que la finalizacion no encuentre el desglose y el operador
+         * no entienda por que su producto no se ajusto.
+         */
+        if (input.getLoteId() != null) {
+            Lote lote = loteService.findById(input.getLoteId()).orElse(null);
+            if (lote == null) {
+                throw new GraphQLException("No existe el lote " + input.getLoteId() + ".");
+            }
+            entity.setLote(lote);
+        }
 
-        return service.save(entity);
+        try {
+            return service.save(entity);
+        } catch (IllegalStateException e) {
+            // El mensaje del central ya viene escrito para el operador: el cliente lo muestra.
+            throw new GraphQLException(e.getMessage());
+        }
     }
 
     public Boolean deleteInventarioProductoItem(Long id) {

--- a/src/main/java/com/franco/dev/graphql/operaciones/InventarioProductoItemGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/InventarioProductoItemGraphQL.java
@@ -437,6 +437,30 @@ public class InventarioProductoItemGraphQL implements GraphQLQueryResolver, Grap
         return movimientoStockService.findProductosFaltantes(sucursalId, productoId, stringToDate(fechaInicio), stringToDate(fechaFin), pageable);
     }
 
+    /** Cuantas fechas ya vencidas se proponen por presentacion si no se pide otra cosa. */
+    private static final int MAX_VENCIDAS_DEFAULT = 3;
+
+    /**
+     * Los vencimientos que el central conoce de unas presentaciones.
+     *
+     * Usado en:
+     * - Desktop: No
+     * - Mobile: Si (carga del conteo de inventario)
+     *
+     * Ver ProductosVencidosService.vencimientosConocidos() para por que no se
+     * usa productosVencidos.
+     */
+    public List<ProductoVencidoViewDTO> vencimientosConocidos(
+            Long sucursalId,
+            @Nullable List<Long> productoIdList,
+            @Nullable Integer maxVencidas) {
+
+        return productosVencidosService.vencimientosConocidos(
+                sucursalId,
+                productoIdList,
+                maxVencidas == null || maxVencidas < 0 ? MAX_VENCIDAS_DEFAULT : maxVencidas);
+    }
+
     public Page<ProductoVencidoViewDTO> productosVencidos(
             @Nullable String startDate,
             @Nullable String endDate,

--- a/src/main/java/com/franco/dev/graphql/operaciones/MovimientoStockLoteGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/MovimientoStockLoteGraphQL.java
@@ -5,6 +5,7 @@ import com.franco.dev.domain.operaciones.MovimientoStockLote;
 import com.franco.dev.domain.operaciones.dto.AjusteStockLoteResultadoDto;
 import com.franco.dev.domain.operaciones.dto.ClienteLoteDto;
 import com.franco.dev.domain.operaciones.dto.LoteDeProductoDto;
+import com.franco.dev.domain.operaciones.dto.LoteSinContarDto;
 import com.franco.dev.domain.operaciones.dto.MovimientoLoteDto;
 import com.franco.dev.domain.operaciones.dto.ResumenStockLoteDto;
 import com.franco.dev.domain.operaciones.dto.StockLoteDto;
@@ -13,8 +14,10 @@ import com.franco.dev.domain.operaciones.dto.StockLoteSucursalDto;
 import com.franco.dev.domain.operaciones.enums.EstadoLote;
 import com.franco.dev.domain.operaciones.enums.TipoMovimiento;
 import com.franco.dev.domain.personas.Usuario;
+import com.franco.dev.domain.productos.Producto;
 import com.franco.dev.graphql.operaciones.input.AjusteStockLoteInput;
 import com.franco.dev.service.operaciones.AjusteStockLoteService;
+import com.franco.dev.service.operaciones.InventarioLoteService;
 import com.franco.dev.service.operaciones.LoteService;
 import com.franco.dev.service.operaciones.MovimientoStockLoteService;
 import com.franco.dev.service.personas.UsuarioService;
@@ -50,6 +53,12 @@ public class MovimientoStockLoteGraphQL implements GraphQLQueryResolver, GraphQL
 
     @Autowired
     private AjusteStockLoteService ajusteStockLoteService;
+
+    @Autowired
+    private InventarioLoteService inventarioLoteService;
+
+    @Autowired
+    private com.franco.dev.service.productos.ProductoService productoService;
 
     /**
      * Saldo por lote de un producto en una sucursal, ordenado por FEFO.
@@ -169,6 +178,86 @@ public class MovimientoStockLoteGraphQL implements GraphQLQueryResolver, GraphQL
             return ajusteStockLoteService.ajustar(input);
         } catch (IllegalArgumentException e) {
             throw new GraphQLException(e.getMessage());
+        }
+    }
+
+    /**
+     * Alta manual de un lote, sin mover stock.
+     *
+     * Es el camino que faltaba para el conteo: el operador tiene el envase en la mano, el lote no
+     * está en el sistema y necesita registrarlo para poder contarlo. Nace con saldo cero; el stock
+     * se lo pone la finalización de la toma.
+     */
+    public Lote crearLote(Long productoId, String numeroLote, String fechaVencimiento,
+                          String fechaRetiro, String observacion, Long usuarioId) {
+        if (productoId == null) {
+            throw new GraphQLException("productoId es requerido");
+        }
+        Producto producto = productoService.findById(productoId).orElse(null);
+        if (producto == null) {
+            throw new GraphQLException("No existe el producto " + productoId + ".");
+        }
+        Usuario usuario = usuarioId != null ? usuarioService.findById(usuarioId).orElse(null) : null;
+        try {
+            return loteService.crear(producto, numeroLote, aFecha(fechaVencimiento, "vencimiento"),
+                    aFecha(fechaRetiro, "retiro"), observacion, usuario);
+        } catch (IllegalArgumentException e) {
+            throw new GraphQLException(e.getMessage());
+        }
+    }
+
+    /**
+     * Carga o corrige las fechas del maestro de un lote.
+     *
+     * Es la puerta que faltaba: la fecha de retiro solo se podía setear al CREAR el lote —desde la
+     * recepción o desde el ajuste—, así que un lote viejo sin retiro no había forma de completarlo
+     * y uno mal tipeado no había forma de corregirlo.
+     *
+     * El cambio es GLOBAL: el maestro es uno por (producto, número de lote) y replica MAIN_TO_ALL,
+     * así que reordena el FEFO en todas las sucursales. Quien llama tiene que haberlo dicho en
+     * pantalla.
+     *
+     * Las fechas llegan como texto {@code yyyy-MM-dd}, igual que en {@link AjusteStockLoteInput}.
+     */
+    public Lote actualizarFechasLote(Long loteId, String fechaVencimiento, String fechaRetiro,
+                                     String motivo, Long usuarioId) {
+        if (loteId == null) {
+            throw new GraphQLException("loteId es requerido");
+        }
+        Usuario usuario = usuarioId != null ? usuarioService.findById(usuarioId).orElse(null) : null;
+        try {
+            return loteService.actualizarFechas(loteId, aFecha(fechaVencimiento, "vencimiento"),
+                    aFecha(fechaRetiro, "retiro"), motivo, usuario);
+        } catch (IllegalArgumentException e) {
+            throw new GraphQLException(e.getMessage());
+        }
+    }
+
+    /**
+     * Los lotes con saldo que ningún renglón de la toma contó.
+     *
+     * Existe para poder avisarlo ANTES de finalizar: la finalización deja esos productos enteros
+     * fuera del ajuste, y sin esta consulta el operador se entera después de cerrar la toma.
+     */
+    public List<LoteSinContarDto> lotesSinContar(Long inventarioId) {
+        if (inventarioId == null) {
+            throw new GraphQLException("inventarioId es requerido");
+        }
+        return inventarioLoteService.lotesSinContar(inventarioId);
+    }
+
+    /**
+     * Una fecha vacía es "no la mandé", no un error: el input distingue nulo de dato, y un texto
+     * en blanco llega cuando el formulario nunca se tocó.
+     */
+    private java.time.LocalDate aFecha(String valor, String cual) {
+        if (valor == null || valor.trim().isEmpty()) {
+            return null;
+        }
+        try {
+            return java.time.LocalDate.parse(valor.trim());
+        } catch (java.time.format.DateTimeParseException e) {
+            throw new GraphQLException("La fecha de " + cual + " no tiene el formato yyyy-MM-dd.");
         }
     }
 

--- a/src/main/java/com/franco/dev/graphql/operaciones/input/InventarioProductoItemInput.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/input/InventarioProductoItemInput.java
@@ -21,4 +21,12 @@ public class InventarioProductoItemInput {
     private InventarioProductoEstado estado;
     private LocalDateTime creadoEn;
     private Long usuarioId;
+    /**
+     * Lote que se esta contando. Opcional y aditivo: el escritorio no lo manda y su renglon sigue
+     * entrando sin lote.
+     *
+     * Con lote, {@code cantidadFisica} es el saldo DE ESE LOTE en la sucursal, no la existencia
+     * del producto.
+     */
+    private Long loteId;
 }

--- a/src/main/java/com/franco/dev/service/operaciones/InventarioLoteService.java
+++ b/src/main/java/com/franco/dev/service/operaciones/InventarioLoteService.java
@@ -1,0 +1,319 @@
+package com.franco.dev.service.operaciones;
+
+import com.franco.dev.domain.operaciones.Inventario;
+import com.franco.dev.domain.operaciones.InventarioProducto;
+import com.franco.dev.domain.operaciones.InventarioProductoItem;
+import com.franco.dev.domain.operaciones.Lote;
+import com.franco.dev.domain.operaciones.MovimientoStock;
+import com.franco.dev.domain.operaciones.MovimientoStockLote;
+import com.franco.dev.domain.operaciones.dto.LoteSinContarDto;
+import com.franco.dev.domain.operaciones.dto.StockLoteDto;
+import com.franco.dev.domain.personas.Usuario;
+import com.franco.dev.domain.productos.Producto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * El desglose por lote del ajuste que produce la finalización de una toma de inventario.
+ *
+ * Hasta ahora {@code finalizarInventarioEnSucursal()} escribía SOLO el {@code MovimientoStock}
+ * agregado. Para un producto con control de lote eso deja el ledger sin tocar, con lo que la
+ * mercadería contada nunca vuelve a ser asignable por FEFO — el mismo agujero que
+ * {@link AjusteStockLoteService} vino a cerrar para el ajuste manual.
+ *
+ * Contar por lote es, en el fondo, una ATRIBUCIÓN: el stock que estaba en el bucket sin trazar pasa
+ * a tener dueño. Por eso el plan siempre incluye la fila sintética {@code SIN LOTE} con lo que las
+ * filas por lote no explican.
+ *
+ * <pre>
+ *   Existencia 50, lote L1 con saldo 30 (20 sin trazar). Se cuentan 28 de L1:
+ *
+ *   movimiento_stock         AJUSTE    -22      (28 − 50)
+ *     movimiento_stock_lote  L1         -2      (28 − 30)
+ *     movimiento_stock_lote  SIN LOTE  -20      (el resto: el bucket queda en cero)
+ * </pre>
+ *
+ * La decisión —{@link #planificar}— es una función pura y se prueba sola, igual que
+ * {@code AjusteStockLoteService.calcular()}. Lo de acá abajo solo la ejecuta.
+ */
+@Service
+public class InventarioLoteService {
+
+    /** Tolerancia al comparar cantidades en punto flotante, igual que en el resto del módulo. */
+    static final double EPSILON = 0.0001;
+
+    @Autowired
+    private InventarioService inventarioService;
+
+    @Autowired
+    private InventarioProductoService inventarioProductoService;
+
+    @Autowired
+    private InventarioProductoItemService inventarioProductoItemService;
+
+    @Autowired
+    private MovimientoStockLoteService movimientoStockLoteService;
+
+    @Autowired
+    private LoteService loteService;
+
+    /**
+     * Decide qué se escribe para un producto con control de lote.
+     *
+     * @param existencia      stock agregado del producto en la sucursal, en unidades base.
+     * @param contadoTotal    TODO lo contado del producto en la toma, en unidades base — incluidos
+     *                        los renglones SIN lote. No es la suma de {@code contadoPorLote}: un
+     *                        producto con control de lote puede tener renglones sin atribuir, y esa
+     *                        mercadería cuenta para la existencia aunque no pueda generar una fila
+     *                        de lote. Sin este parámetro esas unidades desaparecían del ajuste.
+     * @param saldosPorLote   saldo actual de cada lote REAL en esa sucursal, por id de lote. Las
+     *                        filas {@code SIN LOTE} del ledger no van acá: no son stock atribuido.
+     * @param contadoPorLote  lo contado en la toma, por id de lote, ya convertido a unidades base.
+     */
+    public static PlanConteoLote planificar(double existencia,
+                                            double contadoTotal,
+                                            Map<Long, Double> saldosPorLote,
+                                            Map<Long, Double> contadoPorLote) {
+        Map<Long, Double> saldos = saldosPorLote != null ? saldosPorLote : Collections.emptyMap();
+        Map<Long, Double> contado = contadoPorLote != null ? contadoPorLote : Collections.emptyMap();
+
+        // Sin un solo renglón contado no hay ajuste posible. "Nadie contó" no es "contaron cero":
+        // tomarlo como cero le llevaría la existencia a cero a un producto que nadie miró.
+        if (contado.isEmpty() && Math.abs(contadoTotal) <= EPSILON) {
+            return PlanConteoLote.omitir(sinContar(saldos, contado));
+        }
+
+        List<Long> sinContar = sinContar(saldos, contado);
+        if (!sinContar.isEmpty()) {
+            return PlanConteoLote.omitir(sinContar);
+        }
+
+        double cantidadMovimiento = contadoTotal - existencia;
+
+        Map<Long, Double> porLote = new LinkedHashMap<>();
+        double sumaHijas = 0.0;
+        for (Map.Entry<Long, Double> entrada : contado.entrySet()) {
+            double contadoDelLote = entrada.getValue() != null ? entrada.getValue() : 0.0;
+            // Un lote que el sistema no tenía arranca en cero: es mercadería que apareció en la
+            // góndola y que hasta ahora vivía en el bucket sin trazar.
+            Double saldo = saldos.get(entrada.getKey());
+            double diferencia = contadoDelLote - (saldo != null ? saldo : 0.0);
+            porLote.put(entrada.getKey(), diferencia);
+            sumaHijas += diferencia;
+        }
+
+        return new PlanConteoLote(false, Collections.emptyList(), cantidadMovimiento, porLote,
+                cantidadMovimiento - sumaHijas);
+    }
+
+    /**
+     * Los lotes con saldo que ningún renglón contó.
+     *
+     * Un lote agotado no cuenta: no es mercadería que alguien debió encontrar en la góndola.
+     * La lista sale ordenada para que el mensaje al operador sea estable.
+     */
+    private static List<Long> sinContar(Map<Long, Double> saldos, Map<Long, Double> contado) {
+        List<Long> faltantes = new ArrayList<>();
+        for (Map.Entry<Long, Double> entrada : saldos.entrySet()) {
+            double saldo = entrada.getValue() != null ? entrada.getValue() : 0.0;
+            if (Math.abs(saldo) > EPSILON && !contado.containsKey(entrada.getKey())) {
+                faltantes.add(entrada.getKey());
+            }
+        }
+        Collections.sort(faltantes);
+        return faltantes;
+    }
+
+    /**
+     * El saldo actual de cada lote REAL del producto en la sucursal.
+     *
+     * Las filas {@code SIN LOTE} del ledger quedan afuera: son el registro de lo que salió sin
+     * trazar, no stock atribuido. Es el mismo criterio que usa
+     * {@code AjusteStockLoteService.resumen()}.
+     *
+     * ⚠️ **Se descuentan las filas del propio ajuste de esta toma.** Al re-finalizar, el ledger
+     * todavía tiene el desglose de la corrida anterior, así que el movimiento se estaría
+     * descontando a sí mismo y el plan saldría calculado contra un stock que no existe. Es el
+     * mismo cuidado que documenta {@code MovimientoStockLoteService.limpiarDesglose()}, pero acá no
+     * alcanza con borrar primero: si el plan termina omitiendo el producto, no hay que haber
+     * tocado nada.
+     */
+    public Map<Long, Double> saldosPorLote(Long productoId, Long sucursalId, MovimientoStock excluir) {
+        Map<Long, Double> saldos = new HashMap<>();
+        for (StockLoteDto fila : movimientoStockLoteService.stockPorLote(productoId, sucursalId)) {
+            if (fila.getLoteId() != null) {
+                saldos.put(fila.getLoteId(),
+                        fila.getCantidadDisponible() != null ? fila.getCantidadDisponible() : 0.0);
+            }
+        }
+
+        if (excluir != null && excluir.getId() != null) {
+            for (MovimientoStockLote fila : movimientoStockLoteService
+                    .findByMovimientoStock(excluir.getId(), excluir.getSucursalId())) {
+                if (fila.getLote() == null || fila.getLote().getId() == null || fila.getCantidad() == null) {
+                    // Las filas SIN LOTE no están en el mapa: no son stock atribuido a un lote.
+                    continue;
+                }
+                saldos.merge(fila.getLote().getId(), -fila.getCantidad(), Double::sum);
+            }
+        }
+        return saldos;
+    }
+
+    /**
+     * Lo contado en toda la toma, por producto y por lote, en unidades base.
+     *
+     * Se recorre el inventario entero —no una zona— porque el mismo lote puede estar en góndola y
+     * en depósito, y los dos conteos suman contra el mismo saldo.
+     *
+     * Los renglones sin lote no entran: el desglose solo puede hablar de lo que tiene lote. Lo que
+     * esos renglones aportan al total ya está en el movimiento agregado, y la fila {@code SIN LOTE}
+     * del plan se encarga del resto.
+     */
+    public Map<Long, Map<Long, Double>> contadoPorProductoYLote(Long inventarioId) {
+        Map<Long, Map<Long, Double>> porProducto = new HashMap<>();
+
+        for (InventarioProducto ip : inventarioProductoService.findByInventarioId(inventarioId)) {
+            for (InventarioProductoItem ipi : inventarioProductoItemService
+                    .findByInventarioProductoId(ip.getId())) {
+                // Mismo criterio que la finalización: sin cantidad nadie contó, y saltear no es
+                // tomar como cero.
+                if (ipi.getCantidad() == null || ipi.getLote() == null
+                        || ipi.getLote().getId() == null || ipi.getPresentacion() == null) {
+                    continue;
+                }
+                Producto producto = ipi.getPresentacion().getProducto();
+                if (producto == null || !Boolean.TRUE.equals(producto.getLote())) {
+                    continue;
+                }
+                double enUnidades = ipi.getCantidad() * ipi.getPresentacion().getCantidad();
+                porProducto
+                        .computeIfAbsent(producto.getId(), id -> new HashMap<>())
+                        .merge(ipi.getLote().getId(), enUnidades, Double::sum);
+            }
+        }
+        return porProducto;
+    }
+
+    /**
+     * Los lotes con saldo que ningún renglón de la toma contó.
+     *
+     * Existe para poder avisarlo ANTES de finalizar: la finalización deja esos productos enteros
+     * fuera del ajuste, y sin este aviso el operador se entera después de cerrar la toma.
+     *
+     * Solo mira los productos que la toma incluye: un lote de un producto que nadie puso en el
+     * conteo no es un lote sin contar, es un producto fuera del alcance.
+     */
+    public List<LoteSinContarDto> lotesSinContar(Long inventarioId) {
+        Inventario inventario = inventarioService.findById(inventarioId).orElse(null);
+        if (inventario == null || inventario.getSucursal() == null) {
+            return Collections.emptyList();
+        }
+        Long sucursalId = inventario.getSucursal().getId();
+
+        Map<Long, Map<Long, Double>> contado = contadoPorProductoYLote(inventarioId);
+        List<LoteSinContarDto> faltantes = new ArrayList<>();
+
+        for (Producto producto : productosConLoteDeLaToma(inventarioId)) {
+            Map<Long, Double> contadoDelProducto =
+                    contado.getOrDefault(producto.getId(), Collections.emptyMap());
+
+            for (StockLoteDto fila : movimientoStockLoteService.stockPorLote(producto.getId(), sucursalId)) {
+                double saldo = fila.getCantidadDisponible() != null ? fila.getCantidadDisponible() : 0.0;
+                if (fila.getLoteId() == null || Math.abs(saldo) <= EPSILON
+                        || contadoDelProducto.containsKey(fila.getLoteId())) {
+                    continue;
+                }
+                faltantes.add(new LoteSinContarDto(fila.getLoteId(), fila.getNumeroLote(),
+                        producto.getId(), producto.getDescripcion(), fila.getFechaVencimiento(),
+                        fila.getFechaRetiro(), saldo));
+            }
+        }
+        return faltantes;
+    }
+
+    /** Los productos con control de lote que la toma incluye, sin repetir. */
+    private List<Producto> productosConLoteDeLaToma(Long inventarioId) {
+        Map<Long, Producto> productos = new LinkedHashMap<>();
+        for (InventarioProducto ip : inventarioProductoService.findByInventarioId(inventarioId)) {
+            for (InventarioProductoItem ipi : inventarioProductoItemService
+                    .findByInventarioProductoId(ip.getId())) {
+                if (ipi.getPresentacion() == null) {
+                    continue;
+                }
+                Producto producto = ipi.getPresentacion().getProducto();
+                if (producto != null && Boolean.TRUE.equals(producto.getLote())) {
+                    productos.putIfAbsent(producto.getId(), producto);
+                }
+            }
+        }
+        return new ArrayList<>(productos.values());
+    }
+
+    /**
+     * Escribe el desglose por lote de un ajuste de finalización.
+     *
+     * ⚠️ **Borra primero las filas que ese movimiento ya tenía.** La finalización REUSA el
+     * {@code MovimientoStock} de AJUSTE cuando la toma se vuelve a cerrar —lo busca por
+     * (tipo, referencia, sucursal, producto) y le pisa la cantidad—, así que sin este borrado las
+     * hijas viejas quedarían colgando y se sumarían a las nuevas. El padre se pisa; las hijas no,
+     * porque son filas nuevas con su propia PK.
+     */
+    public void escribirDesglose(MovimientoStock movimiento, Producto producto,
+                                 PlanConteoLote plan, Usuario usuario) {
+        if (movimiento == null || movimiento.getId() == null || plan == null || plan.isOmitido()) {
+            return;
+        }
+
+        movimientoStockLoteService.limpiarDesglose(movimiento);
+        if (plan.isVacio()) {
+            return;
+        }
+
+        List<MovimientoStockLote> filas = new ArrayList<>();
+        for (Map.Entry<Long, Double> entrada : plan.getCantidadPorLote().entrySet()) {
+            if (Math.abs(entrada.getValue()) <= EPSILON) {
+                continue;
+            }
+            Lote lote = loteService.findById(entrada.getKey()).orElse(null);
+            if (lote == null) {
+                continue;
+            }
+            filas.add(crearFila(movimiento, producto, lote, lote.getNumeroLote(),
+                    entrada.getValue(), usuario));
+        }
+        if (Math.abs(plan.getCantidadSinTrazar()) > EPSILON) {
+            filas.add(crearFila(movimiento, producto, null, LoteFefoService.NUMERO_LOTE_SIN_TRAZAR,
+                    plan.getCantidadSinTrazar(), usuario));
+        }
+
+        for (MovimientoStockLote fila : filas) {
+            movimientoStockLoteService.save(fila);
+        }
+    }
+
+    /** Misma forma que {@code AjusteStockLoteService.crearFila}: una hija nunca va suelta. */
+    private MovimientoStockLote crearFila(MovimientoStock movimiento, Producto producto, Lote lote,
+                                          String numeroLote, double cantidad, Usuario usuario) {
+        MovimientoStockLote fila = new MovimientoStockLote();
+        fila.setSucursalId(movimiento.getSucursalId());
+        fila.setMovimientoStockId(movimiento.getId());
+        fila.setLote(lote);
+        fila.setProducto(producto);
+        fila.setNumeroLote(numeroLote);
+        fila.setFechaVencimiento(lote != null ? lote.getFechaVencimiento() : null);
+        fila.setCantidad(cantidad);
+        fila.setReferencia(producto.getId());
+        fila.setEstado(true);
+        fila.setUsuario(usuario);
+        fila.setCreadoEn(movimiento.getCreadoEn());
+        return fila;
+    }
+}

--- a/src/main/java/com/franco/dev/service/operaciones/InventarioProductoItemService.java
+++ b/src/main/java/com/franco/dev/service/operaciones/InventarioProductoItemService.java
@@ -249,30 +249,52 @@ public class InventarioProductoItemService
                 toLongList(productoIdList));
     }
 
+    /**
+     * Guarda un item de conteo, rechazando el renglon duplicado.
+     *
+     * Usado en:
+     * - Desktop: Si (modulo de inventario, dialogo de agregar producto y edicion del conteo)
+     * - Mobile: Si (carga del conteo: agregar producto y guardar cantidades)
+     *
+     * <p>
+     * Un duplicado es <b>el mismo renglon dos veces en la misma zona</b>:
+     * misma zona, misma presentacion y mismo vencimiento. Ese es el unico caso
+     * que produce un dato sin sentido, porque
+     * {@code finalizarInventarioEnSucursal()} suma los dos renglones y el
+     * conteo sale doble.
+     *
+     * <p>
+     * <b>La clave era {@code (inventario, producto, vencimiento)} y estaba
+     * demasiado abierta en los tres ejes.</b> Rechazaba tres cosas legitimas:
+     *
+     * <ol>
+     * <li><b>El mismo producto en dos zonas.</b> Es el caso normal de un
+     * inventario por zona: hay stock en gondola y en deposito, y los conteos se
+     * suman. Con el alcance en todo el inventario, contar el segundo fallaba.</li>
+     * <li><b>Unidad y caja x12 del mismo producto.</b> Son dos presentaciones y
+     * dos renglones legitimos, pero para una clave por producto eran el mismo.</li>
+     * <li><b>Dos renglones sin vencimiento.</b> {@code Objects.equals} toma dos
+     * nulos por iguales, y el vencimiento es opcional en los dos frentes, asi
+     * que agregar un segundo producto sin fecha a una toma siempre fallaba.</li>
+     * </ol>
+     *
+     * <p>
+     * <b>El cambio es una relajacion, no un cambio de contrato.</b> Todo lo que
+     * la clave nueva rechaza ya lo rechazaba la anterior —una zona esta dentro
+     * de su inventario y una presentacion pertenece a su producto—, asi que
+     * ningun flujo que hoy funcione deja de funcionar. La firma, el input de
+     * GraphQL y el schema quedan igual.
+     *
+     * <p>
+     * El mensaje se arma listo para mostrar: el cliente es capa de presentacion
+     * y no tiene que interpretar el error ni reimplementar esta regla.
+     */
     @Override
     public InventarioProductoItem save(InventarioProductoItem entity) {
         if (entity.getCreadoEn() == null)
             entity.setCreadoEn(LocalDateTime.now());
 
-        Long inventarioId = null;
-        Long productoId = null;
-        if (entity.getInventarioProducto() != null && entity.getInventarioProducto().getInventario() != null) {
-            inventarioId = entity.getInventarioProducto().getInventario().getId();
-        }
-        if (entity.getPresentacion() != null && entity.getPresentacion().getProducto() != null) {
-            productoId = entity.getPresentacion().getProducto().getId();
-        }
-
-        if (inventarioId != null && productoId != null) {
-            List<InventarioProductoItem> existingItems = findByInventarioIdAndProductoId(inventarioId, productoId);
-            for (InventarioProductoItem item : existingItems) {
-                if (!Objects.equals(item.getId(), entity.getId())
-                        && Objects.equals(item.getVencimiento(), entity.getVencimiento())) {
-                    throw new IllegalStateException(
-                            "El producto ya fue registrado en este inventario con el mismo vencimiento");
-                }
-            }
-        }
+        verificarRenglonDuplicado(entity);
 
         InventarioProductoItem entidadAnterior = null;
         boolean esNuevo = (entity.getId() == null);
@@ -294,6 +316,58 @@ public class InventarioProductoItemService
         }
 
         return e;
+    }
+
+    /**
+     * Rechaza el mismo renglon repetido dentro de una zona.
+     *
+     * <p>
+     * Sin zona o sin presentacion no se puede decidir, y se deja pasar: es lo
+     * que hacia la version anterior cuando no podia resolver el inventario o el
+     * producto, y cambiarlo ahora rechazaria altas que hoy entran.
+     */
+    private void verificarRenglonDuplicado(InventarioProductoItem entity) {
+        Long inventarioProductoId = entity.getInventarioProducto() != null
+                ? entity.getInventarioProducto().getId()
+                : null;
+        Long presentacionId = entity.getPresentacion() != null ? entity.getPresentacion().getId() : null;
+
+        if (inventarioProductoId == null || presentacionId == null) {
+            return;
+        }
+
+        for (InventarioProductoItem item : findByInventarioProductoId(inventarioProductoId)) {
+            boolean esOtroRenglon = !Objects.equals(item.getId(), entity.getId());
+            boolean mismaPresentacion = item.getPresentacion() != null
+                    && Objects.equals(item.getPresentacion().getId(), presentacionId);
+            // Dos vencimientos nulos son iguales a proposito: dos renglones de
+            // la misma presentacion sin fecha son el mismo renglon dos veces.
+            boolean mismoVencimiento = Objects.equals(item.getVencimiento(), entity.getVencimiento());
+
+            if (esOtroRenglon && mismaPresentacion && mismoVencimiento) {
+                throw new IllegalStateException(mensajeDeRenglonDuplicado(entity));
+            }
+        }
+    }
+
+    /**
+     * El texto que ve el operador. Se arma aca —y no en cada cliente— para que
+     * el escritorio y el telefono digan lo mismo, y para que el frontend siga
+     * siendo capa de presentacion.
+     */
+    private String mensajeDeRenglonDuplicado(InventarioProductoItem entity) {
+        String zona = null;
+        if (entity.getInventarioProducto() != null && entity.getInventarioProducto().getZona() != null) {
+            zona = entity.getInventarioProducto().getZona().getDescripcion();
+        }
+        String donde = (zona != null && !zona.trim().isEmpty()) ? "la zona " + zona.trim() : "esta zona";
+
+        if (entity.getVencimiento() == null) {
+            return "Esa presentacion ya esta en " + donde
+                    + " sin vencimiento. Carguele la fecha a la que ya esta, o conte las dos juntas en ese renglon.";
+        }
+        return "Esa presentacion ya esta en " + donde + " con el mismo vencimiento. "
+                + "Un lote distinto va con otra fecha; el mismo lote se cuenta en un solo renglon.";
     }
 
     @Override

--- a/src/main/java/com/franco/dev/service/operaciones/InventarioProductoItemService.java
+++ b/src/main/java/com/franco/dev/service/operaciones/InventarioProductoItemService.java
@@ -343,8 +343,12 @@ public class InventarioProductoItemService
             // Dos vencimientos nulos son iguales a proposito: dos renglones de
             // la misma presentacion sin fecha son el mismo renglon dos veces.
             boolean mismoVencimiento = Objects.equals(item.getVencimiento(), entity.getVencimiento());
+            // Con control de lote un renglon ES un lote, y dos lotes del mismo producto pueden
+            // vencer el mismo dia: sin esto, contar el segundo fallaba. Dos nulos vuelven a ser
+            // iguales, asi que el renglon sin lote sigue teniendo la clave de siempre.
+            boolean mismoLote = Objects.equals(idDeLote(item), idDeLote(entity));
 
-            if (esOtroRenglon && mismaPresentacion && mismoVencimiento) {
+            if (esOtroRenglon && mismaPresentacion && mismoVencimiento && mismoLote) {
                 throw new IllegalStateException(mensajeDeRenglonDuplicado(entity));
             }
         }
@@ -362,12 +366,24 @@ public class InventarioProductoItemService
         }
         String donde = (zona != null && !zona.trim().isEmpty()) ? "la zona " + zona.trim() : "esta zona";
 
+        // Con lote, la fecha no es lo que distingue los renglones: nombrar el lote es lo unico que
+        // le dice al operador cual de los dos renglones ya esta cargado.
+        if (entity.getLote() != null && entity.getLote().getNumeroLote() != null) {
+            return "El lote " + entity.getLote().getNumeroLote() + " de esa presentacion ya esta en "
+                    + donde + ". Cada lote se cuenta en un solo renglon.";
+        }
+
         if (entity.getVencimiento() == null) {
             return "Esa presentacion ya esta en " + donde
                     + " sin vencimiento. Carguele la fecha a la que ya esta, o conte las dos juntas en ese renglon.";
         }
         return "Esa presentacion ya esta en " + donde + " con el mismo vencimiento. "
                 + "Un lote distinto va con otra fecha; el mismo lote se cuenta en un solo renglon.";
+    }
+
+    /** El id del lote del renglon, o null si no tiene. Aisla el null-check de la comparacion. */
+    private Long idDeLote(InventarioProductoItem item) {
+        return item != null && item.getLote() != null ? item.getLote().getId() : null;
     }
 
     @Override

--- a/src/main/java/com/franco/dev/service/operaciones/LoteService.java
+++ b/src/main/java/com/franco/dev/service/operaciones/LoteService.java
@@ -135,6 +135,152 @@ public class LoteService extends CrudService<Lote, LoteRepository, Long> {
     }
 
     /**
+     * Las dos fechas de un lote después de aplicar una corrección. Ver {@link #resolverFechas}.
+     */
+    public static final class FechasLote {
+
+        private final LocalDate fechaVencimiento;
+        private final LocalDate fechaRetiro;
+
+        FechasLote(LocalDate fechaVencimiento, LocalDate fechaRetiro) {
+            this.fechaVencimiento = fechaVencimiento;
+            this.fechaRetiro = fechaRetiro;
+        }
+
+        public LocalDate getFechaVencimiento() {
+            return fechaVencimiento;
+        }
+
+        public LocalDate getFechaRetiro() {
+            return fechaRetiro;
+        }
+    }
+
+    /**
+     * Qué fechas quedan cuando alguien corrige un lote.
+     *
+     * Es la regla más delicada del módulo: la fecha de retiro ordena FEFO en TODA la red, así que
+     * lo que se escriba acá reordena stock que ya está en góndola en otras sucursales.
+     *
+     * <ul>
+     * <li><b>Un nulo no borra.</b> El input no puede distinguir "no lo mandé" de "borralo", y
+     * borrar un vencimiento no es un caso real del negocio.</li>
+     * <li><b>Al cambiar el vencimiento se recalcula el retiro, pero solo si nadie lo había
+     * cargado.</b> No hay forma de distinguir un retiro derivado de uno tipeado a mano, así que se
+     * respeta el que está: pisarlo reordenaría el FEFO sin que nadie lo pidiera. Es la misma
+     * decisión que ya toma {@link #obtenerOCrear}.</li>
+     * <li><b>El retiro no puede ser posterior al vencimiento.</b> Hasta ahora lo garantizaba el
+     * cálculo automático —una resta—, pero con carga manual deja de estar garantizado.</li>
+     * </ul>
+     *
+     * @param diasVencimiento los del producto, para derivar el retiro. Puede ser nulo.
+     * @throws IllegalArgumentException si el retiro resultante es posterior al vencimiento. El
+     *                                  resolver lo traduce a un error de GraphQL.
+     */
+    public static FechasLote resolverFechas(LocalDate vencimientoActual, LocalDate retiroActual,
+                                            LocalDate vencimientoNuevo, LocalDate retiroNuevo,
+                                            Integer diasVencimiento) {
+        LocalDate vencimiento = vencimientoNuevo != null ? vencimientoNuevo : vencimientoActual;
+
+        LocalDate retiro;
+        if (retiroNuevo != null) {
+            retiro = retiroNuevo;
+        } else if (retiroActual != null) {
+            retiro = retiroActual;
+        } else if (vencimiento != null && diasVencimiento != null && diasVencimiento > 0) {
+            retiro = vencimiento.minusDays(diasVencimiento);
+        } else {
+            retiro = null;
+        }
+
+        if (vencimiento != null && retiro != null && retiro.isAfter(vencimiento)) {
+            throw new IllegalArgumentException(
+                    "La fecha de retiro no puede ser posterior al vencimiento del lote.");
+        }
+
+        return new FechasLote(vencimiento, retiro);
+    }
+
+    /**
+     * Alta manual de un lote, sin tocar stock.
+     *
+     * Hasta ahora un lote solo nacía al recibir mercadería o desde {@code ajustarStockLote}, que
+     * además mueve existencia. Eso deja sin camino el caso real del conteo: el operador tiene el
+     * envase en la mano, el lote no está en el sistema y lo único que quiere es registrarlo para
+     * poder contarlo. El stock lo pone después la finalización de la toma.
+     *
+     * El lote nace con saldo CERO —solo el maestro, ninguna fila del ledger— y en estado
+     * {@code LIBERADO}.
+     *
+     * ⚠️ **Si el número ya existe para ese producto, devuelve el existente.** No es un error:
+     * la unicidad es (producto, número) y ese lote ES el que el operador tiene en la mano.
+     * Rechazarlo lo dejaría sin forma de seguir.
+     */
+    @Transactional
+    public Lote crear(Producto producto, String numeroLote, LocalDate fechaVencimiento,
+                      LocalDate fechaRetiro, String observacion, Usuario usuario) {
+        if (producto == null || producto.getId() == null) {
+            throw new IllegalArgumentException("Falta el producto del lote.");
+        }
+        if (!Boolean.TRUE.equals(producto.getLote())) {
+            // Un lote de un producto que no lleva control de lote es un maestro que nadie va a
+            // consultar nunca: ni FEFO ni el conteo lo miran.
+            throw new IllegalArgumentException("El producto '" + producto.getDescripcion()
+                    + "' no tiene control de lote.");
+        }
+        String numero = normalizarNumeroLote(numeroLote);
+        if (numero == null) {
+            throw new IllegalArgumentException("El número de lote es obligatorio.");
+        }
+
+        // Misma regla que al corregir: valida retiro <= vencimiento y deriva el retiro de los días
+        // del producto cuando nadie lo carga.
+        FechasLote fechas = resolverFechas(null, null, fechaVencimiento, fechaRetiro,
+                producto.getDiasVencimiento());
+
+        Lote lote = obtenerOCrear(producto, numero, fechas.getFechaVencimiento(),
+                fechas.getFechaRetiro(), null, usuario);
+        if (lote != null && observacion != null && !observacion.trim().isEmpty()) {
+            lote.setObservacion(observacion.trim());
+            lote.setActualizadoEn(LocalDateTime.now());
+            return repository.save(lote);
+        }
+        return lote;
+    }
+
+    /**
+     * Carga o corrige las fechas del maestro de un lote.
+     *
+     * Es la puerta que faltaba: hasta ahora la fecha de retiro solo se podía setear al CREAR el
+     * lote —desde la recepción o desde el ajuste—, así que un lote viejo sin retiro no había forma
+     * de completarlo, y uno con una fecha mal tipeada no había forma de corregirlo.
+     *
+     * El cambio es GLOBAL: el maestro es uno por (producto, número de lote) y replica MAIN_TO_ALL,
+     * así que reordena el FEFO en toda la red. Quien llama tiene que haberlo dicho en pantalla.
+     */
+    @Transactional
+    public Lote actualizarFechas(Long loteId, LocalDate fechaVencimiento, LocalDate fechaRetiro,
+                                 String motivo, Usuario usuario) {
+        Lote lote = repository.findById(loteId)
+                .orElseThrow(() -> new IllegalArgumentException("Lote no encontrado: " + loteId));
+
+        Integer dias = lote.getProducto() != null ? lote.getProducto().getDiasVencimiento() : null;
+        FechasLote fechas = resolverFechas(lote.getFechaVencimiento(), lote.getFechaRetiro(),
+                fechaVencimiento, fechaRetiro, dias);
+
+        lote.setFechaVencimiento(fechas.getFechaVencimiento());
+        lote.setFechaRetiro(fechas.getFechaRetiro());
+        if (motivo != null && !motivo.trim().isEmpty()) {
+            lote.setObservacion(motivo.trim());
+        }
+        if (usuario != null) {
+            lote.setUsuario(usuario);
+        }
+        lote.setActualizadoEn(LocalDateTime.now());
+        return repository.save(lote);
+    }
+
+    /**
      * Cambia el estado de un lote. Es el mecanismo de recall: pasar a BLOQUEADO saca el lote de
      * FEFO y del mostrador en todas las sucursales, sin tocar el stock físico.
      */

--- a/src/main/java/com/franco/dev/service/operaciones/PlanConteoLote.java
+++ b/src/main/java/com/franco/dev/service/operaciones/PlanConteoLote.java
@@ -1,0 +1,89 @@
+package com.franco.dev.service.operaciones;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Qué escribe la finalización de una toma para UN producto con control de lote en UNA sucursal.
+ *
+ * Es el resultado de {@link InventarioLoteService#planificar}, separado del acto de guardar para
+ * que la decisión —que es la parte que puede salir mal en silencio— se pueda leer y probar sola.
+ *
+ * Todas las cantidades van en UNIDADES BASE, igual que el ledger.
+ *
+ * INVARIANTE: {@code suma(cantidadPorLote) + cantidadSinTrazar == cantidadMovimiento}. Es el mismo
+ * que sostiene {@link AjusteStockLoteService}: nunca una fila hija suelta, nunca un padre que no
+ * coincida con sus hijas.
+ */
+public final class PlanConteoLote {
+
+    private final boolean omitido;
+    private final List<Long> lotesSinContar;
+    private final double cantidadMovimiento;
+    private final Map<Long, Double> cantidadPorLote;
+    private final double cantidadSinTrazar;
+
+    PlanConteoLote(boolean omitido, List<Long> lotesSinContar, double cantidadMovimiento,
+                   Map<Long, Double> cantidadPorLote, double cantidadSinTrazar) {
+        this.omitido = omitido;
+        this.lotesSinContar = lotesSinContar;
+        this.cantidadMovimiento = cantidadMovimiento;
+        this.cantidadPorLote = cantidadPorLote;
+        this.cantidadSinTrazar = cantidadSinTrazar;
+    }
+
+    /**
+     * El producto queda ENTERO fuera del ajuste: ni movimiento agregado ni filas del ledger.
+     *
+     * Pasa cuando algún lote con saldo no fue contado. Es la misma regla que la finalización ya
+     * aplica al ítem con {@code cantidad == null}: un lote sin contar no es un lote en cero, y
+     * tomarlo como cero le borraría el stock a mercadería que nadie miró.
+     */
+    public boolean isOmitido() {
+        return omitido;
+    }
+
+    /** Los lotes con saldo que ningún renglón contó. Vacío si no se omitió nada. */
+    public List<Long> getLotesSinContar() {
+        return lotesSinContar;
+    }
+
+    /** Lo que va en el {@code MovimientoStock} agregado: contado − existencia. */
+    public double getCantidadMovimiento() {
+        return cantidadMovimiento;
+    }
+
+    /** Por lote contado: contado − saldo de ese lote. Puede ser cero. */
+    public Map<Long, Double> getCantidadPorLote() {
+        return cantidadPorLote;
+    }
+
+    /**
+     * Lo que las filas por lote no explican, que va a la fila sintética {@code SIN LOTE}.
+     *
+     * Contar por lote es, en el fondo, una atribución: el stock que estaba en el bucket sin trazar
+     * pasa a tener dueño. Esta cantidad es la que lo saca de ahí.
+     */
+    public double getCantidadSinTrazar() {
+        return cantidadSinTrazar;
+    }
+
+    /** No hay nada que escribir: lo contado coincide con el sistema, lote por lote. */
+    public boolean isVacio() {
+        if (Math.abs(cantidadMovimiento) > InventarioLoteService.EPSILON
+                || Math.abs(cantidadSinTrazar) > InventarioLoteService.EPSILON) {
+            return false;
+        }
+        for (Double valor : cantidadPorLote.values()) {
+            if (Math.abs(valor) > InventarioLoteService.EPSILON) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static PlanConteoLote omitir(List<Long> lotesSinContar) {
+        return new PlanConteoLote(true, lotesSinContar, 0.0, Collections.emptyMap(), 0.0);
+    }
+}

--- a/src/main/java/com/franco/dev/service/operaciones/ProductosVencidosService.java
+++ b/src/main/java/com/franco/dev/service/operaciones/ProductosVencidosService.java
@@ -115,10 +115,147 @@ public class ProductosVencidosService {
         return content;
     }
 
+    /**
+     * Los vencimientos que el central conoce de unas presentaciones, para
+     * proponerlos al contar.
+     *
+     * Usado en:
+     * - Desktop: No
+     * - Mobile: Si (carga del conteo de inventario)
+     *
+     * <p>
+     * <b>No sirve productosVencidos para esto, y ese fue el defecto.</b> Ese
+     * reporte responde «que entro desde el ultimo inventario»: ancla las cinco
+     * fuentes al ultimo inventario de la sucursal y por construccion olvida
+     * todo lo anterior. Pero <b>la toma que se esta contando es el ultimo
+     * inventario</b>, asi que mientras se cuenta el reporte no devuelve nada:
+     * la fuente INVENTARIO mira los items de esa misma toma —todavia sin
+     * fecha— y compras y transferencias exigen ser posteriores a hoy.
+     *
+     * <p>
+     * Verificado en bodega3 con COCA COLA 500ML (producto 802, sucursal 1):
+     * el central conoce 26 vencimientos de esa presentacion —6 de compras de
+     * junio de 2026— y el reporte devolvia cero, porque el ancla era la toma
+     * 7539 abierta el dia anterior.
+     *
+     * <p>
+     * Aca no hay ancla. Se recorta despues, por presentacion: <b>todas las
+     * vigentes mas las {@code maxVencidas} vencidas mas recientes</b>. Las
+     * vigentes son las que sirven para contar; unas pocas vencidas hacen falta
+     * porque puede haber mercaderia caduca en la gondola, y arrastrar la
+     * historia entera —2023 incluido— es trafico que nadie mira.
+     */
+    @Transactional(readOnly = true)
+    public List<ProductoVencidoViewDTO> vencimientosConocidos(
+            Long sucursalId,
+            @Nullable List<Long> productoIdList,
+            int maxVencidas) {
+
+        if (sucursalId == null) {
+            return new ArrayList<>();
+        }
+
+        FiltrosProductosVencidos filtros = new FiltrosProductosVencidos(
+                null, null, java.util.Collections.singletonList(sucursalId), null, null, null,
+                productoIdList, null, Boolean.FALSE);
+        filtros.historico = true;
+
+        Query query = entityManager.createNativeQuery(construirSqlBase(filtros));
+        aplicarParametros(query, filtros.parametros());
+
+        @SuppressWarnings("unchecked")
+        List<Object[]> rows = query.getResultList();
+        List<ProductoVencidoViewDTO> todas = new ArrayList<>();
+        for (Object[] row : rows) {
+            todas.add(enriquecer(mapearFila(row)));
+        }
+
+        return recortarPorPresentacion(todas, LocalDate.now(), maxVencidas);
+    }
+
+    /**
+     * Todas las vigentes, y de las vencidas solo las mas recientes.
+     *
+     * <p>
+     * El recorte es <b>por presentacion</b> y no sobre el total: si se cortara
+     * el total, una presentacion con muchos lotes se comeria el cupo de las
+     * demas y otras quedarian sin ninguna sugerencia.
+     */
+    static List<ProductoVencidoViewDTO> recortarPorPresentacion(
+            List<ProductoVencidoViewDTO> filas, LocalDate hoy, int maxVencidas) {
+
+        Map<Long, List<ProductoVencidoViewDTO>> porPresentacion = new java.util.LinkedHashMap<>();
+        for (ProductoVencidoViewDTO fila : filas) {
+            // Sin fecha no hay nada que proponer. Las cinco fuentes ya exigen
+            // vencimiento no nulo, asi que esto no deberia pasar; si pasara,
+            // la fila se colaria al cupo de las vencidas y desplazaria a una
+            // que si sirve.
+            if (fila.getVencimiento() == null || fila.getPresentacionId() == null) {
+                continue;
+            }
+            porPresentacion
+                    .computeIfAbsent(fila.getPresentacionId(), k -> new ArrayList<>())
+                    .add(fila);
+        }
+
+        List<ProductoVencidoViewDTO> recortadas = new ArrayList<>();
+        for (List<ProductoVencidoViewDTO> grupo : porPresentacion.values()) {
+            // Mas nueva primero: entre las vencidas, la ultima que se vio es la
+            // que tiene mas chance de seguir en gondola.
+            grupo.sort((a, b) -> comparar(b.getVencimiento(), a.getVencimiento()));
+            int vencidasPuestas = 0;
+            for (ProductoVencidoViewDTO fila : grupo) {
+                LocalDate vence = fila.getVencimiento() == null ? null : fila.getVencimiento().toLocalDate();
+                // Lo que vence hoy todavia no vencio: se puede vender durante el dia.
+                boolean vigente = vence != null && !vence.isBefore(hoy);
+                if (vigente) {
+                    recortadas.add(fila);
+                } else if (vencidasPuestas < maxVencidas) {
+                    recortadas.add(fila);
+                    vencidasPuestas++;
+                }
+            }
+        }
+        return recortadas;
+    }
+
+    private static int comparar(LocalDateTime a, LocalDateTime b) {
+        if (a == null && b == null) {
+            return 0;
+        }
+        if (a == null) {
+            return -1;
+        }
+        if (b == null) {
+            return 1;
+        }
+        return a.compareTo(b);
+    }
+
     private String construirSqlBase(FiltrosProductosVencidos filtros) {
         return ""
                 + "WITH ultimo_inv AS ( "
-                + "  SELECT inv.sucursal_id, MAX(inv.id) AS inventario_id, MAX(inv.fecha_inicio) AS fecha_inicio "
+                /*
+                 * Solo cuentan los inventarios CONCLUIDO. Era MAX(inv.id) a
+                 * secas, asi que una toma ABIERTA o CANCELADA se tomaba como si
+                 * fuera un inventario hecho. Como todas las fuentes se anclan
+                 * aca, abrir una toma dejaba el reporte de esa sucursal en
+                 * blanco: la fuente INVENTARIO miraba los items de la toma
+                 * recien abierta —todavia sin vencimiento— y compras y
+                 * transferencias exigian ser posteriores a su fecha_inicio, que
+                 * es hoy. En bodega3 pasaba en 5 de 26 sucursales.
+                 *
+                 * El COALESCE mantiene una fila por sucursal aunque no tenga
+                 * ningun inventario concluido: sin el, esa sucursal desaparece
+                 * del reporte por el JOIN de rankeados.
+                 */
+                + "  SELECT inv.sucursal_id, "
+                + "         MAX(inv.id) FILTER (WHERE inv.estado = 'CONCLUIDO') AS inventario_id, "
+                /* En modo historico no hay ancla: interesa todo lo que el central sepa. */
+                + (filtros.esHistorico()
+                        ? "         TIMESTAMP '1900-01-01' AS fecha_inicio "
+                        : "         COALESCE(MAX(inv.fecha_inicio) FILTER (WHERE inv.estado = 'CONCLUIDO'), "
+                                + "TIMESTAMP '1900-01-01') AS fecha_inicio ")
                 + "  FROM operaciones.inventario inv "
                 + "  GROUP BY inv.sucursal_id "
                 + "), "
@@ -175,7 +312,14 @@ public class ProductosVencidosService {
                 + "  FROM operaciones.inventario_producto_item ipi "
                 + "  JOIN operaciones.inventario_producto ip ON ip.id = ipi.inventario_producto_id "
                 + "  JOIN operaciones.inventario inv ON inv.id = ip.inventario_id "
-                + "  JOIN ultimo_inv ui ON ui.inventario_id = inv.id "
+                /*
+                 * Cualquier inventario concluido, no solo el ultimo: la fecha de
+                 * un lote sigue valiendo aunque se haya cargado en la toma
+                 * anterior.
+                 */
+                + (filtros.esHistorico()
+                        ? "  AND inv.estado = 'CONCLUIDO' "
+                        : "  JOIN ultimo_inv ui ON ui.inventario_id = inv.id ")
                 + "  JOIN empresarial.sucursal s ON s.id = inv.sucursal_id "
                 + "  JOIN productos.presentacion pre ON pre.id = ipi.presentacion_id "
                 + "  JOIN productos.producto pro ON pro.id = pre.producto_id "
@@ -467,6 +611,16 @@ public class ProductosVencidosService {
         private final List<Long> productoIdList;
         private final List<String> fuenteVerdadList;
         private final Boolean soloRealmenteVencidos;
+        /**
+         * Sin ancla: devuelve todo lo que el central sepa de la presentacion,
+         * por viejo que sea. Es lo que necesita la carga del conteo, y lo
+         * contrario de lo que necesita el reporte de vencidos.
+         */
+        private boolean historico;
+
+        private boolean esHistorico() {
+            return historico;
+        }
 
         private FiltrosProductosVencidos(
                 LocalDateTime startDate,

--- a/src/main/resources/db/migration/V203.5__add_lote_to_inventario_producto_item.sql
+++ b/src/main/resources/db/migration/V203.5__add_lote_to_inventario_producto_item.sql
@@ -1,0 +1,22 @@
+-- Lote del renglon de conteo.
+--
+-- Con control de lote un renglon ES un lote: cantidad_fisica pasa a guardar el saldo DE ESE LOTE
+-- en la sucursal, no la existencia del producto. Es lo que le permite a
+-- finalizarInventarioEnSucursal() escribir el desglose en operaciones.movimiento_stock_lote en vez
+-- de dejar el ledger sin tocar, que es lo que hacia que la mercaderia contada nunca volviera a ser
+-- asignable por FEFO.
+--
+-- Nullable a proposito: los ~8.700 productos sin control de lote siguen contando en un renglon sin
+-- lote, y el renglon sin lote tambien es valido en un producto con lote (mercaderia que todavia no
+-- se atribuyo a ninguno).
+--
+-- NO se registra en configuraciones.replication_table: ninguna tabla operaciones.inventario* se
+-- replica. El inventario vive solo en el central, que es con quien hablan el escritorio y la PWA.
+
+ALTER TABLE operaciones.inventario_producto_item
+    ADD COLUMN lote_id BIGINT NULL;
+
+ALTER TABLE operaciones.inventario_producto_item
+    ADD CONSTRAINT fk_ipi_lote FOREIGN KEY (lote_id) REFERENCES operaciones.lote (id);
+
+CREATE INDEX idx_ipi_lote ON operaciones.inventario_producto_item (lote_id) WHERE lote_id IS NOT NULL;

--- a/src/main/resources/graphql/operaciones/inventario-producto-item.graphqls
+++ b/src/main/resources/graphql/operaciones/inventario-producto-item.graphqls
@@ -14,6 +14,9 @@ type InventarioProductoItem {
     estado: InventarioProductoEstado
     creadoEn: Date
     usuario: Usuario
+    # El lote que se conto. Nulo en los productos sin control de lote y en la mercaderia que
+    # todavia no se atribuyo a ninguno. Con lote, cantidadFisica es el saldo DE ESE LOTE.
+    lote: Lote
 }
 
 input InventarioProductoItemInput {
@@ -31,6 +34,8 @@ input InventarioProductoItemInput {
     vencimiento: String
     estado: InventarioProductoEstado
     usuarioId: Int
+    # Opcional y aditivo: el escritorio no lo manda y sigue funcionando igual.
+    loteId: Int
 }
 
 type InventarioProductoItemPage {

--- a/src/main/resources/graphql/operaciones/inventario-producto-item.graphqls
+++ b/src/main/resources/graphql/operaciones/inventario-producto-item.graphqls
@@ -111,6 +111,21 @@ extend type Query {
         size: Int
     ): ProductoVencidoViewPage
 
+    """
+    Los vencimientos que el central conoce de unas presentaciones en una
+    sucursal, para proponerlos al contar.
+
+    NO es productosVencidos: ese reporte ancla al ultimo inventario de la
+    sucursal, y la toma que se esta contando ES el ultimo inventario, asi que
+    mientras se cuenta devuelve cero. Aca no hay ancla; se recorta a las
+    vigentes mas las `maxVencidas` vencidas mas recientes, por presentacion.
+    """
+    vencimientosConocidos(
+        sucursalId: ID!,
+        productoIdList: [ID],
+        maxVencidas: Int
+    ): [ProductoVencidoView]
+
     reporteProductosVencidos(
         startDate: String,
         endDate: String,

--- a/src/main/resources/graphql/operaciones/movimiento-stock-lote.graphqls
+++ b/src/main/resources/graphql/operaciones/movimiento-stock-lote.graphqls
@@ -266,9 +266,66 @@ extend type Query {
         page: Int = 0
         size: Int = 20
     ): ClienteLotePage
+
+    # Los lotes con saldo que ningun renglon de la toma conto.
+    #
+    # La finalizacion deja esos productos ENTEROS fuera del ajuste —ni movimiento agregado ni filas
+    # del ledger—, con la misma regla que ya aplica al item con cantidad nula: un lote sin contar no
+    # es un lote en cero, y tomarlo como cero le borraria el stock a mercaderia que nadie miro.
+    #
+    # Esta consulta existe para poder AVISARLO antes de finalizar, en vez de que el operador
+    # descubra despues que su producto no se ajusto. La finalizacion aplica la regla igual, mire
+    # alguien esta pantalla o no.
+    lotesSinContar(inventarioId: ID!): [LoteSinContar]
+}
+
+type LoteSinContar {
+    loteId: ID
+    numeroLote: String
+    productoId: ID
+    productoDescripcion: String
+    fechaVencimiento: Date
+    fechaRetiro: Date
+    # Saldo en unidades base en la sucursal de la toma.
+    saldo: Float
 }
 
 extend type Mutation {
+    # Alta manual de un lote, SIN mover stock. El lote nace con saldo cero y estado LIBERADO; la
+    # existencia se la pone despues el conteo o la recepcion.
+    #
+    # Es el camino que faltaba para el inventario: el operador tiene el envase en la mano, el lote
+    # no esta en el sistema y necesita registrarlo para poder contarlo.
+    #
+    # Si el numero ya existe para ese producto devuelve el existente, no falla: la unicidad es
+    # (producto, numero) y ese lote ES el que el operador tiene en la mano. Fechas en yyyy-MM-dd.
+    crearLote(
+        productoId: ID!
+        numeroLote: String!
+        fechaVencimiento: String
+        fechaRetiro: String
+        observacion: String
+        usuarioId: ID
+    ): Lote
+
+    # Carga o corrige las fechas del MAESTRO del lote. Es la puerta que faltaba: hasta ahora la
+    # fecha de retiro solo se podia setear al CREAR el lote, asi que un lote viejo sin retiro no
+    # habia forma de completarlo ni uno mal tipeado forma de corregirlo.
+    #
+    # OJO: el cambio es GLOBAL. El maestro es uno por (producto, numero de lote) y replica
+    # MAIN_TO_ALL, asi que reordena el FEFO en todas las sucursales. La pantalla tiene que decirlo.
+    #
+    # Un nulo NO borra: el input no puede distinguir "no lo mande" de "borralo". Si cambia el
+    # vencimiento y nadie habia cargado el retiro, el retiro se recalcula con los dias de
+    # vencimiento del producto; si ya estaba cargado, se respeta. Fechas en yyyy-MM-dd.
+    actualizarFechasLote(
+        loteId: ID!
+        fechaVencimiento: String
+        fechaRetiro: String
+        motivo: String
+        usuarioId: ID
+    ): Lote
+
     # Cambia el estado de un lote. Es el mecanismo de recall: pasar a BLOQUEADO lo saca de FEFO y
     # del mostrador en todas las sucursales, sin tocar el stock fisico.
     cambiarEstadoLote(loteId: ID!, estado: EstadoLote!, observacion: String, usuarioId: ID): Lote

--- a/src/test/java/com/franco/dev/graphql/operaciones/InventarioGraphQLFinalizarTest.java
+++ b/src/test/java/com/franco/dev/graphql/operaciones/InventarioGraphQLFinalizarTest.java
@@ -4,10 +4,12 @@ import com.franco.dev.domain.empresarial.Sucursal;
 import com.franco.dev.domain.operaciones.Inventario;
 import com.franco.dev.domain.operaciones.InventarioProducto;
 import com.franco.dev.domain.operaciones.InventarioProductoItem;
+import com.franco.dev.domain.operaciones.Lote;
 import com.franco.dev.domain.operaciones.MovimientoStock;
 import com.franco.dev.domain.operaciones.enums.InventarioEstado;
 import com.franco.dev.domain.productos.Presentacion;
 import com.franco.dev.domain.productos.Producto;
+import com.franco.dev.service.operaciones.InventarioLoteService;
 import com.franco.dev.service.operaciones.InventarioProductoItemService;
 import com.franco.dev.service.operaciones.InventarioProductoService;
 import com.franco.dev.service.operaciones.InventarioService;
@@ -23,6 +25,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -31,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -57,6 +62,7 @@ class InventarioGraphQLFinalizarTest {
     private InventarioProductoItemService itemService;
     private ProductoService productoService;
     private MovimientoStockService movimientoStockService;
+    private InventarioLoteService inventarioLoteService;
     private InventarioGraphQL resolver;
 
     private InventarioProductoItem item(Long productoId, Double cantidadContada, double porPresentacion) {
@@ -111,12 +117,45 @@ class InventarioGraphQLFinalizarTest {
         when(movimientoStockService.save(any(MovimientoStock.class)))
                 .thenAnswer(invocacion -> invocacion.getArgument(0));
 
+        inventarioLoteService = mock(InventarioLoteService.class);
+        when(inventarioLoteService.contadoPorProductoYLote(INVENTARIO)).thenReturn(new HashMap<>());
+
         resolver = new InventarioGraphQL();
         ReflectionTestUtils.setField(resolver, "service", service);
         ReflectionTestUtils.setField(resolver, "inventarioProductoService", inventarioProductoService);
         ReflectionTestUtils.setField(resolver, "inventarioProductoItemService", itemService);
         ReflectionTestUtils.setField(resolver, "productoService", productoService);
         ReflectionTestUtils.setField(resolver, "movimientoStockService", movimientoStockService);
+        ReflectionTestUtils.setField(resolver, "inventarioLoteService", inventarioLoteService);
+    }
+
+    /** El mismo item, pero de un producto CON control de lote y atribuido a un lote. */
+    private InventarioProductoItem itemConLote(Long productoId, Double cantidadContada,
+                                               double porPresentacion, Long loteId) {
+        InventarioProductoItem item = item(productoId, cantidadContada, porPresentacion);
+        item.getPresentacion().getProducto().setLote(true);
+        Lote lote = new Lote();
+        lote.setId(loteId);
+        lote.setNumeroLote("L-" + loteId);
+        item.setLote(lote);
+        return item;
+    }
+
+    private void conProductoConLote(Long productoId) {
+        when(productoService.findById(eq(productoId))).thenAnswer(invocacion -> {
+            Producto p = new Producto();
+            p.setId(invocacion.getArgument(0));
+            p.setLote(true);
+            return Optional.of(p);
+        });
+    }
+
+    private void conContadoPorLote(Long productoId, Long loteId, Double unidades) {
+        Map<Long, Double> porLote = new HashMap<>();
+        porLote.put(loteId, unidades);
+        Map<Long, Map<Long, Double>> porProducto = new HashMap<>();
+        porProducto.put(productoId, porLote);
+        when(inventarioLoteService.contadoPorProductoYLote(INVENTARIO)).thenReturn(porProducto);
     }
 
     private void conItems(List<InventarioProductoItem> items) {
@@ -184,6 +223,60 @@ class InventarioGraphQLFinalizarTest {
         ArgumentCaptor<MovimientoStock> guardados = ArgumentCaptor.forClass(MovimientoStock.class);
         verify(movimientoStockService).save(guardados.capture());
         assertEquals(-10.0, guardados.getValue().getCantidad());
+    }
+
+    @Test
+    @DisplayName("un producto con lote escribe el desglose en el ledger, no solo el agregado")
+    void productoConLoteEscribeDesglose() {
+        // Es el punto entero del cambio: sin esto el ajuste queda en el agregado y la mercaderia
+        // contada nunca vuelve a ser asignable por FEFO.
+        conProductoConLote(CONTADO);
+        conContadoPorLote(CONTADO, 41L, 7.0);
+        when(inventarioLoteService.saldosPorLote(eq(CONTADO), eq(SUCURSAL), any()))
+                .thenReturn(saldos(41L, 10.0));
+        conItems(Collections.singletonList(itemConLote(CONTADO, 7.0, 1.0, 41L)));
+
+        resolver.finalizarInventarioEnSucursal(INVENTARIO);
+
+        verify(inventarioLoteService).escribirDesglose(any(MovimientoStock.class), any(Producto.class),
+                any(), any());
+    }
+
+    @Test
+    @DisplayName("un lote con saldo que nadie conto deja al producto ENTERO fuera del ajuste")
+    void loteSinContarDejaAlProductoAfuera() {
+        // Ni movimiento agregado ni filas del ledger: la misma regla que rige para el item con
+        // cantidad nula. Tomar el lote como cero le borraria el stock a mercaderia que nadie miro.
+        conProductoConLote(CONTADO);
+        conContadoPorLote(CONTADO, 41L, 7.0);
+        // El lote 42 tiene 20 unidades y ningun renglon lo conto.
+        when(inventarioLoteService.saldosPorLote(eq(CONTADO), eq(SUCURSAL), any()))
+                .thenReturn(saldos(41L, 10.0, 42L, 20.0));
+        conItems(Collections.singletonList(itemConLote(CONTADO, 7.0, 1.0, 41L)));
+
+        resolver.finalizarInventarioEnSucursal(INVENTARIO);
+
+        verify(movimientoStockService, never()).save(any(MovimientoStock.class));
+    }
+
+    @Test
+    @DisplayName("un producto sin control de lote no toca el ledger por lote")
+    void productoSinLoteNoTocaElLedger() {
+        // Regresion cero para los ~8.700 productos que no llevan lote.
+        conItems(Collections.singletonList(item(CONTADO, 7.0, 1.0)));
+
+        resolver.finalizarInventarioEnSucursal(INVENTARIO);
+
+        verify(movimientoStockService).save(any(MovimientoStock.class));
+        verify(inventarioLoteService, never()).escribirDesglose(any(), any(), any(), any());
+    }
+
+    private static Map<Long, Double> saldos(Object... pares) {
+        Map<Long, Double> mapa = new HashMap<>();
+        for (int i = 0; i < pares.length; i += 2) {
+            mapa.put(((Number) pares[i]).longValue(), ((Number) pares[i + 1]).doubleValue());
+        }
+        return mapa;
     }
 
     @Test

--- a/src/test/java/com/franco/dev/graphql/operaciones/InventarioGraphQLFinalizarTest.java
+++ b/src/test/java/com/franco/dev/graphql/operaciones/InventarioGraphQLFinalizarTest.java
@@ -1,0 +1,209 @@
+package com.franco.dev.graphql.operaciones;
+
+import com.franco.dev.domain.empresarial.Sucursal;
+import com.franco.dev.domain.operaciones.Inventario;
+import com.franco.dev.domain.operaciones.InventarioProducto;
+import com.franco.dev.domain.operaciones.InventarioProductoItem;
+import com.franco.dev.domain.operaciones.MovimientoStock;
+import com.franco.dev.domain.operaciones.enums.InventarioEstado;
+import com.franco.dev.domain.productos.Presentacion;
+import com.franco.dev.domain.productos.Producto;
+import com.franco.dev.service.operaciones.InventarioProductoItemService;
+import com.franco.dev.service.operaciones.InventarioProductoService;
+import com.franco.dev.service.operaciones.InventarioService;
+import com.franco.dev.service.operaciones.MovimientoStockService;
+import com.franco.dev.service.productos.ProductoService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Finalizar una toma con items que nadie conto.
+ *
+ * `cantidad` —lo contado— es nullable: un item que se sumo a la toma y que
+ * nadie fue a contar la tiene en null. Al finalizar se la multiplicaba sin
+ * mirar, asi que reventaba con un NullPointerException al desempaquetar el
+ * Double y NINGUNA toma con un item sin contar se podia finalizar. En bodega3
+ * era el caso de la toma 7540: dos items, uno sin contar.
+ */
+class InventarioGraphQLFinalizarTest {
+
+    private static final Long INVENTARIO = 7540L;
+    private static final Long SUCURSAL = 3L;
+    private static final Long CONTADO = 800L;
+    private static final Long SIN_CONTAR = 900L;
+
+    private InventarioService service;
+    private InventarioProductoService inventarioProductoService;
+    private InventarioProductoItemService itemService;
+    private ProductoService productoService;
+    private MovimientoStockService movimientoStockService;
+    private InventarioGraphQL resolver;
+
+    private InventarioProductoItem item(Long productoId, Double cantidadContada, double porPresentacion) {
+        Producto producto = new Producto();
+        producto.setId(productoId);
+
+        Presentacion presentacion = new Presentacion();
+        presentacion.setId(productoId * 10);
+        presentacion.setCantidad(porPresentacion);
+        presentacion.setProducto(producto);
+
+        InventarioProductoItem item = new InventarioProductoItem();
+        item.setId(productoId + 1);
+        item.setPresentacion(presentacion);
+        item.setCantidad(cantidadContada);
+        return item;
+    }
+
+    @BeforeEach
+    void setUp() {
+        Sucursal sucursal = new Sucursal();
+        sucursal.setId(SUCURSAL);
+
+        Inventario inventario = new Inventario();
+        inventario.setId(INVENTARIO);
+        inventario.setSucursal(sucursal);
+        inventario.setEstado(InventarioEstado.ABIERTO);
+
+        InventarioProducto zona = new InventarioProducto();
+        zona.setId(91L);
+
+        service = mock(InventarioService.class);
+        when(service.findById(INVENTARIO)).thenReturn(Optional.of(inventario));
+
+        inventarioProductoService = mock(InventarioProductoService.class);
+        when(inventarioProductoService.findByInventarioId(INVENTARIO))
+                .thenReturn(Collections.singletonList(zona));
+
+        itemService = mock(InventarioProductoItemService.class);
+
+        productoService = mock(ProductoService.class);
+        when(productoService.findById(anyLong())).thenAnswer(invocacion -> {
+            Producto p = new Producto();
+            p.setId(invocacion.getArgument(0));
+            return Optional.of(p);
+        });
+
+        movimientoStockService = mock(MovimientoStockService.class);
+        when(movimientoStockService.findByTipoMovimientoAndReferenciaAndSucursalIdAndProductoId(
+                any(), anyLong(), anyLong(), anyLong())).thenReturn(null);
+        when(movimientoStockService.stockByProductoIdAndSucursalId(anyLong(), anyLong())).thenReturn(10.0);
+        when(movimientoStockService.save(any(MovimientoStock.class)))
+                .thenAnswer(invocacion -> invocacion.getArgument(0));
+
+        resolver = new InventarioGraphQL();
+        ReflectionTestUtils.setField(resolver, "service", service);
+        ReflectionTestUtils.setField(resolver, "inventarioProductoService", inventarioProductoService);
+        ReflectionTestUtils.setField(resolver, "inventarioProductoItemService", itemService);
+        ReflectionTestUtils.setField(resolver, "productoService", productoService);
+        ReflectionTestUtils.setField(resolver, "movimientoStockService", movimientoStockService);
+    }
+
+    private void conItems(List<InventarioProductoItem> items) {
+        when(itemService.findByInventarioProductoId(91L)).thenReturn(new ArrayList<>(items));
+    }
+
+    @Test
+    @DisplayName("un item sin contar no impide finalizar la toma")
+    void itemSinContarNoRompe() {
+        // Es el caso de la toma 7540 de bodega3: dos items, uno sin contar.
+        conItems(Arrays.asList(item(CONTADO, 7.0, 1.0), item(SIN_CONTAR, null, 1.0)));
+
+        assertDoesNotThrow(() -> resolver.finalizarInventarioEnSucursal(INVENTARIO));
+    }
+
+    @Test
+    @DisplayName("el producto sin contar no entra en el ajuste, y NO se le lleva el stock a cero")
+    void elSinContarNoAjusta() {
+        // Tomarlo como cero contra un stock de 10 daria una diferencia de -10:
+        // una perdida de stock muda, sin que nadie hubiera contado nada.
+        conItems(Arrays.asList(item(CONTADO, 7.0, 1.0), item(SIN_CONTAR, null, 1.0)));
+
+        resolver.finalizarInventarioEnSucursal(INVENTARIO);
+
+        ArgumentCaptor<MovimientoStock> guardados = ArgumentCaptor.forClass(MovimientoStock.class);
+        verify(movimientoStockService).save(guardados.capture());
+        MovimientoStock unico = guardados.getValue();
+        assertEquals(CONTADO, unico.getProducto().getId());
+        // 7 contados contra 10 del sistema: faltan 3.
+        assertEquals(-3.0, unico.getCantidad());
+    }
+
+    @Test
+    @DisplayName("una toma con todos sus items sin contar no mueve stock")
+    void todosSinContarNoMueveNada() {
+        conItems(Collections.singletonList(item(SIN_CONTAR, null, 1.0)));
+
+        resolver.finalizarInventarioEnSucursal(INVENTARIO);
+
+        verify(movimientoStockService, never()).save(any(MovimientoStock.class));
+    }
+
+    @Test
+    @DisplayName("lo contado se convierte a unidades del producto por la presentacion")
+    void seConvierteAUnidades() {
+        // Una caja x 6 contada 2 veces son 12 unidades, no 2.
+        conItems(Collections.singletonList(item(CONTADO, 2.0, 6.0)));
+
+        resolver.finalizarInventarioEnSucursal(INVENTARIO);
+
+        ArgumentCaptor<MovimientoStock> guardados = ArgumentCaptor.forClass(MovimientoStock.class);
+        verify(movimientoStockService).save(guardados.capture());
+        assertEquals(2.0, guardados.getValue().getCantidad());
+    }
+
+    @Test
+    @DisplayName("contar cero SI ajusta: cero es un conteo, null no")
+    void ceroSiCuenta() {
+        // Es la distincion que hace todo esto: cero dice «no hay nada en la
+        // gondola», null dice «nadie fue a mirar».
+        conItems(Collections.singletonList(item(CONTADO, 0.0, 1.0)));
+
+        resolver.finalizarInventarioEnSucursal(INVENTARIO);
+
+        ArgumentCaptor<MovimientoStock> guardados = ArgumentCaptor.forClass(MovimientoStock.class);
+        verify(movimientoStockService).save(guardados.capture());
+        assertEquals(-10.0, guardados.getValue().getCantidad());
+    }
+
+    @Test
+    @DisplayName("un inventario que no existe lo dice, en vez de reventar con un NullPointer")
+    void inventarioInexistente() {
+        when(service.findById(anyLong())).thenReturn(Optional.empty());
+
+        Exception error = assertThrows(Exception.class,
+                () -> resolver.finalizarInventarioEnSucursal(123L));
+        assertTrue(error.getMessage().contains("123"), error.getMessage());
+    }
+
+    @Test
+    @DisplayName("la toma queda concluida y cerrada")
+    void quedaConcluida() {
+        conItems(Collections.singletonList(item(CONTADO, 7.0, 1.0)));
+
+        Inventario finalizado = resolver.finalizarInventarioEnSucursal(INVENTARIO);
+
+        assertEquals(InventarioEstado.CONCLUIDO, finalizado.getEstado());
+        assertEquals(Boolean.FALSE, finalizado.getAbierto());
+    }
+}

--- a/src/test/java/com/franco/dev/service/operaciones/InventarioLoteServiceTest.java
+++ b/src/test/java/com/franco/dev/service/operaciones/InventarioLoteServiceTest.java
@@ -1,0 +1,146 @@
+package com.franco.dev.service.operaciones;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Prueba la decisión de la finalización de una toma para un producto CON control de lote: qué se
+ * escribe en el movimiento agregado, cuánto en cada fila del ledger y cuándo el producto queda
+ * afuera del ajuste.
+ *
+ * Es una función pura a propósito —mismo criterio que {@link AjusteStockLoteServiceTest}—, así que
+ * no hace falta levantar Spring ni tocar la base.
+ *
+ * Las cantidades van SIEMPRE en unidades base: el conteo llega por presentación y la finalización
+ * lo convierte antes de llamar acá, igual que hace hoy con el agregado.
+ */
+class InventarioLoteServiceTest {
+
+    /**
+     * El caso normal: todo lo contado tiene lote, así que el total sale de sumarlos.
+     * Los casos donde NO es así llaman a planificar() con el total explícito.
+     */
+    private static PlanConteoLote plan(double existencia, Map<Long, Double> saldos,
+                                       Map<Long, Double> contado) {
+        double total = 0.0;
+        for (Double valor : contado.values()) {
+            total += valor;
+        }
+        return InventarioLoteService.planificar(existencia, total, saldos, contado);
+    }
+
+    private static Map<Long, Double> saldos(Object... pares) {
+        Map<Long, Double> mapa = new HashMap<>();
+        for (int i = 0; i < pares.length; i += 2) {
+            mapa.put(((Number) pares[i]).longValue(), ((Number) pares[i + 1]).doubleValue());
+        }
+        return mapa;
+    }
+
+    @Test
+    void omiteElProductoCuandoUnLoteConSaldoNoSeConto() {
+        // L2 tiene 20 unidades y ningún renglón lo contó: nadie fue a mirar esa mercadería.
+        PlanConteoLote plan = plan(50.0, saldos(1L, 30.0, 2L, 20.0), saldos(1L, 28.0));
+
+        assertTrue(plan.isOmitido());
+        assertEquals(Collections.singletonList(2L), plan.getLotesSinContar());
+    }
+
+    @Test
+    void noOmiteCuandoElLoteSinContarTieneSaldoCero() {
+        // Un lote agotado no es mercadería que alguien debió contar.
+        PlanConteoLote plan = plan(30.0, saldos(1L, 30.0, 2L, 0.0), saldos(1L, 30.0));
+
+        assertFalse(plan.isOmitido());
+    }
+
+    @Test
+    void elMovimientoAgregadoEsLoContadoMenosLaExistencia() {
+        PlanConteoLote plan = plan(50.0, saldos(1L, 30.0), saldos(1L, 28.0));
+
+        assertEquals(-22.0, plan.getCantidadMovimiento());
+    }
+
+    @Test
+    void laFilaDelLoteEsLoContadoMenosSuSaldo() {
+        PlanConteoLote plan = plan(50.0, saldos(1L, 30.0), saldos(1L, 28.0));
+
+        assertEquals(-2.0, plan.getCantidadPorLote().get(1L));
+    }
+
+    @Test
+    void elRestoNoExplicadoPorLosLotesVaALaFilaSinTrazar() {
+        // Existencia 50 con un solo lote de 30: había 20 sin atribuir. Contar 28 del lote deja el
+        // bucket sin trazar en cero, que es el punto de contar por lote.
+        PlanConteoLote plan = plan(50.0, saldos(1L, 30.0), saldos(1L, 28.0));
+
+        assertEquals(-20.0, plan.getCantidadSinTrazar());
+    }
+
+    @Test
+    void unLoteNuevoEnGondolaAtribuyeSinCambiarLaExistencia() {
+        // Aparece el lote 3, que el sistema no tenía, y explica justo las 20 sin trazar.
+        PlanConteoLote plan = plan(50.0, saldos(1L, 30.0), saldos(1L, 30.0, 3L, 20.0));
+
+        assertEquals(0.0, plan.getCantidadMovimiento());
+        assertEquals(20.0, plan.getCantidadPorLote().get(3L));
+        assertEquals(-20.0, plan.getCantidadSinTrazar());
+    }
+
+    @Test
+    void lasHijasSumanExactamenteElPadre() {
+        PlanConteoLote plan = plan(50.0, saldos(1L, 30.0, 2L, 5.0), saldos(1L, 28.0, 2L, 4.0, 3L, 9.0));
+
+        double hijas = plan.getCantidadSinTrazar();
+        for (Double valor : plan.getCantidadPorLote().values()) {
+            hijas += valor;
+        }
+        assertEquals(plan.getCantidadMovimiento(), hijas, 0.0001);
+    }
+
+    @Test
+    void loContadoSinLoteVaAlBucketSinTrazar() {
+        // Un producto con control de lote puede tener un renglon contado SIN lote: es la mercaderia
+        // que todavia no se atribuyo a ninguno. Cuenta para el total —y por lo tanto para el
+        // movimiento agregado—, pero no puede generar una fila de lote: cae en SIN LOTE.
+        // Existencia 50, lote L1 con 30. Se cuentan 30 de L1 y 15 sueltas: total 45.
+        PlanConteoLote plan = InventarioLoteService.planificar(
+                50.0, 45.0, saldos(1L, 30.0), saldos(1L, 30.0));
+
+        assertEquals(-5.0, plan.getCantidadMovimiento());
+        assertEquals(0.0, plan.getCantidadPorLote().get(1L));
+        assertEquals(-5.0, plan.getCantidadSinTrazar());
+    }
+
+    @Test
+    void sinDiferenciasNoHayNadaQueEscribir() {
+        PlanConteoLote plan = plan(30.0, saldos(1L, 30.0), saldos(1L, 30.0));
+
+        assertTrue(plan.isVacio());
+    }
+
+    @Test
+    void sinNadaContadoYSinLotesNoAjustaNada() {
+        // Sin esta guarda el movimiento saldría en -50 y la finalización le llevaría la existencia
+        // a cero a un producto que nadie contó.
+        PlanConteoLote plan = plan(50.0, Collections.emptyMap(), Collections.emptyMap());
+
+        assertTrue(plan.isOmitido());
+    }
+
+    @Test
+    void sinRenglonesContadosElProductoNoEntraAlAjuste() {
+        // Ningún renglón contado no es "contado cero": es exactamente el caso que la finalización
+        // ya saltea para el agregado, y llevaría el stock a cero sin que nadie mirara.
+        PlanConteoLote plan = plan(50.0, saldos(1L, 30.0), Collections.emptyMap());
+
+        assertTrue(plan.isOmitido());
+    }
+}

--- a/src/test/java/com/franco/dev/service/operaciones/InventarioProductoItemServiceDuplicadoTest.java
+++ b/src/test/java/com/franco/dev/service/operaciones/InventarioProductoItemServiceDuplicadoTest.java
@@ -3,6 +3,7 @@ package com.franco.dev.service.operaciones;
 import com.franco.dev.domain.operaciones.Inventario;
 import com.franco.dev.domain.operaciones.InventarioProducto;
 import com.franco.dev.domain.operaciones.InventarioProductoItem;
+import com.franco.dev.domain.operaciones.Lote;
 import com.franco.dev.domain.productos.Presentacion;
 import com.franco.dev.domain.productos.Producto;
 import com.franco.dev.domain.empresarial.Zona;
@@ -84,6 +85,17 @@ class InventarioProductoItemServiceDuplicadoTest {
         return item;
     }
 
+    /** El mismo renglon, pero atribuido a un lote. */
+    private InventarioProductoItem itemConLote(Long id, Long zonaId, Long presentacionId,
+                                               LocalDateTime vencimiento, Long loteId, String numeroLote) {
+        InventarioProductoItem item = item(id, zonaId, presentacionId, vencimiento);
+        Lote lote = new Lote();
+        lote.setId(loteId);
+        lote.setNumeroLote(numeroLote);
+        item.setLote(lote);
+        return item;
+    }
+
     @Test
     @DisplayName("el mismo renglon repetido en la zona se rechaza: el conteo saldria doble")
     void mismoRenglonRepetido() {
@@ -150,6 +162,45 @@ class InventarioProductoItemServiceDuplicadoTest {
                 .thenReturn(Arrays.asList(item(1L, ZONA_GONDOLA, UNIDAD, NOVIEMBRE)));
 
         assertDoesNotThrow(() -> service.save(item(1L, ZONA_GONDOLA, UNIDAD, NOVIEMBRE)));
+    }
+
+    @Test
+    @DisplayName("dos lotes distintos de la misma presentacion conviven aunque compartan vencimiento")
+    void dosLotesDistintosConLaMismaFecha() {
+        // Con control de lote un renglon ES un lote, y dos lotes del mismo producto pueden vencer
+        // el mismo dia. Sin el lote en la clave, contar el segundo fallaba.
+        when(repository.findByInventarioProductoId(ZONA_GONDOLA))
+                .thenReturn(Collections.singletonList(
+                        itemConLote(1L, ZONA_GONDOLA, UNIDAD, NOVIEMBRE, 41L, "L-2026-88")));
+
+        assertDoesNotThrow(() -> service.save(
+                itemConLote(null, ZONA_GONDOLA, UNIDAD, NOVIEMBRE, 42L, "L-2026-91")));
+    }
+
+    @Test
+    @DisplayName("el mismo lote repetido en la zona se rechaza y el mensaje lo nombra")
+    void mismoLoteRepetido() {
+        when(repository.findByInventarioProductoId(ZONA_GONDOLA))
+                .thenReturn(Collections.singletonList(
+                        itemConLote(1L, ZONA_GONDOLA, UNIDAD, NOVIEMBRE, 41L, "L-2026-88")));
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+                () -> service.save(
+                        itemConLote(null, ZONA_GONDOLA, UNIDAD, NOVIEMBRE, 41L, "L-2026-88")));
+
+        assertTrue(error.getMessage().contains("L-2026-88"), error.getMessage());
+    }
+
+    @Test
+    @DisplayName("un renglon con lote y otro sin lote no son el mismo renglon")
+    void conLoteYSinLoteConviven() {
+        // El renglon sin lote es la mercaderia que todavia no se atribuyo a ninguno: es
+        // exactamente el caso que hay que poder contar aparte.
+        when(repository.findByInventarioProductoId(ZONA_GONDOLA))
+                .thenReturn(Collections.singletonList(item(1L, ZONA_GONDOLA, UNIDAD, NOVIEMBRE)));
+
+        assertDoesNotThrow(() -> service.save(
+                itemConLote(null, ZONA_GONDOLA, UNIDAD, NOVIEMBRE, 41L, "L-2026-88")));
     }
 
     @Test

--- a/src/test/java/com/franco/dev/service/operaciones/InventarioProductoItemServiceDuplicadoTest.java
+++ b/src/test/java/com/franco/dev/service/operaciones/InventarioProductoItemServiceDuplicadoTest.java
@@ -1,0 +1,169 @@
+package com.franco.dev.service.operaciones;
+
+import com.franco.dev.domain.operaciones.Inventario;
+import com.franco.dev.domain.operaciones.InventarioProducto;
+import com.franco.dev.domain.operaciones.InventarioProductoItem;
+import com.franco.dev.domain.productos.Presentacion;
+import com.franco.dev.domain.productos.Producto;
+import com.franco.dev.domain.empresarial.Zona;
+import com.franco.dev.repository.operaciones.InventarioProductoItemRepository;
+import com.franco.dev.service.configuraciones.ModificacionService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Que es un renglon duplicado en un conteo de inventario.
+ *
+ * La clave era (inventario, producto, vencimiento) y rechazaba tres cosas
+ * legitimas: el mismo producto contado en dos zonas —el caso normal de un
+ * inventario por zona—, unidad y caja x12 del mismo producto, y dos renglones
+ * sin vencimiento, porque Objects.equals toma dos nulos por iguales.
+ *
+ * Los datos de cada caso se eligen para que no coincidan entre si: si el codigo
+ * leyera un campo por otro, el test lo delata en vez de pasar de casualidad.
+ */
+class InventarioProductoItemServiceDuplicadoTest {
+
+    private static final Long ZONA_GONDOLA = 91L;
+    private static final Long ZONA_DEPOSITO = 92L;
+    private static final Long UNIDAD = 9L;
+    private static final Long CAJA_X12 = 8L;
+    private static final Long PRODUCTO = 200L;
+    private static final LocalDateTime NOVIEMBRE = LocalDateTime.of(2026, 11, 20, 0, 0);
+    private static final LocalDateTime ENERO = LocalDateTime.of(2027, 1, 5, 0, 0);
+
+    private InventarioProductoItemRepository repository;
+    private InventarioProductoItemService service;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(InventarioProductoItemRepository.class);
+        when(repository.save(any(InventarioProductoItem.class)))
+                .thenAnswer(invocacion -> invocacion.getArgument(0));
+
+        service = new InventarioProductoItemService(repository, mock(ModificacionService.class));
+    }
+
+    private InventarioProductoItem item(Long id, Long zonaId, Long presentacionId, LocalDateTime vencimiento) {
+        Zona zona = new Zona();
+        zona.setId(zonaId);
+        zona.setDescripcion(zonaId.equals(ZONA_GONDOLA) ? "gondola 1" : "deposito");
+
+        Inventario inventario = new Inventario();
+        inventario.setId(5L);
+
+        InventarioProducto inventarioProducto = new InventarioProducto();
+        inventarioProducto.setId(zonaId);
+        inventarioProducto.setZona(zona);
+        inventarioProducto.setInventario(inventario);
+
+        Producto producto = new Producto();
+        producto.setId(PRODUCTO);
+
+        Presentacion presentacion = new Presentacion();
+        presentacion.setId(presentacionId);
+        presentacion.setProducto(producto);
+
+        InventarioProductoItem item = new InventarioProductoItem();
+        item.setId(id);
+        item.setInventarioProducto(inventarioProducto);
+        item.setPresentacion(presentacion);
+        item.setVencimiento(vencimiento);
+        return item;
+    }
+
+    @Test
+    @DisplayName("el mismo renglon repetido en la zona se rechaza: el conteo saldria doble")
+    void mismoRenglonRepetido() {
+        when(repository.findByInventarioProductoId(ZONA_GONDOLA))
+                .thenReturn(Collections.singletonList(item(1L, ZONA_GONDOLA, UNIDAD, NOVIEMBRE)));
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+                () -> service.save(item(null, ZONA_GONDOLA, UNIDAD, NOVIEMBRE)));
+
+        // El mensaje se arma aca porque el frontend es capa de presentacion:
+        // sin la zona adentro, el operador no sabe adonde ir.
+        assertTrue(error.getMessage().contains("gondola 1"), error.getMessage());
+    }
+
+    @Test
+    @DisplayName("dos renglones de la misma presentacion SIN vencimiento son el mismo renglon")
+    void mismaPresentacionSinVencimiento() {
+        when(repository.findByInventarioProductoId(ZONA_GONDOLA))
+                .thenReturn(Collections.singletonList(item(1L, ZONA_GONDOLA, UNIDAD, null)));
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+                () -> service.save(item(null, ZONA_GONDOLA, UNIDAD, null)));
+
+        // Sin fecha que las distinga, el mensaje tiene que decir que hay que
+        // cargarsela, no repetir el texto del caso con fecha.
+        assertTrue(error.getMessage().contains("sin vencimiento"), error.getMessage());
+    }
+
+    @Test
+    @DisplayName("unidad y caja x12 del mismo producto conviven aunque ninguna tenga fecha")
+    void dosPresentacionesDelMismoProducto() {
+        // Era el error reportado: la clave miraba el producto, asi que las dos
+        // presentaciones eran el mismo renglon para la validacion.
+        when(repository.findByInventarioProductoId(ZONA_GONDOLA))
+                .thenReturn(Collections.singletonList(item(1L, ZONA_GONDOLA, UNIDAD, null)));
+
+        assertDoesNotThrow(() -> service.save(item(null, ZONA_GONDOLA, CAJA_X12, null)));
+    }
+
+    @Test
+    @DisplayName("el mismo producto contado en dos zonas es el caso normal, no un duplicado")
+    void mismoProductoEnDosZonas() {
+        // Hay stock en gondola y en deposito, y los conteos se suman. Con el
+        // alcance en todo el inventario, guardar el segundo fallaba.
+        when(repository.findByInventarioProductoId(ZONA_DEPOSITO)).thenReturn(Collections.emptyList());
+
+        assertDoesNotThrow(() -> service.save(item(null, ZONA_DEPOSITO, UNIDAD, NOVIEMBRE)));
+    }
+
+    @Test
+    @DisplayName("dos lotes de la misma presentacion se distinguen por su fecha")
+    void dosLotesConFechasDistintas() {
+        when(repository.findByInventarioProductoId(ZONA_GONDOLA))
+                .thenReturn(Collections.singletonList(item(1L, ZONA_GONDOLA, UNIDAD, NOVIEMBRE)));
+
+        assertDoesNotThrow(() -> service.save(item(null, ZONA_GONDOLA, UNIDAD, ENERO)));
+    }
+
+    @Test
+    @DisplayName("editar un renglon no choca contra si mismo")
+    void editarNoChocaConsigoMismo() {
+        // Es lo que corre en cada Guardar conteo del telefono y del escritorio.
+        when(repository.findByInventarioProductoId(ZONA_GONDOLA))
+                .thenReturn(Arrays.asList(item(1L, ZONA_GONDOLA, UNIDAD, NOVIEMBRE)));
+
+        assertDoesNotThrow(() -> service.save(item(1L, ZONA_GONDOLA, UNIDAD, NOVIEMBRE)));
+    }
+
+    @Test
+    @DisplayName("sin zona o sin presentacion no se decide, y se deja pasar")
+    void sinDatosNoDecide() {
+        // Es lo que hacia la version anterior cuando no podia resolver el
+        // inventario o el producto. Endurecerlo ahora rechazaria altas que hoy
+        // entran, y este cambio tiene que ser solo una relajacion.
+        InventarioProductoItem sinZona = item(null, ZONA_GONDOLA, UNIDAD, NOVIEMBRE);
+        sinZona.setInventarioProducto(null);
+        assertDoesNotThrow(() -> service.save(sinZona));
+
+        InventarioProductoItem sinPresentacion = item(null, ZONA_GONDOLA, UNIDAD, NOVIEMBRE);
+        sinPresentacion.setPresentacion(null);
+        assertDoesNotThrow(() -> service.save(sinPresentacion));
+    }
+}

--- a/src/test/java/com/franco/dev/service/operaciones/LoteFechasTest.java
+++ b/src/test/java/com/franco/dev/service/operaciones/LoteFechasTest.java
@@ -1,0 +1,128 @@
+package com.franco.dev.service.operaciones;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Qué fechas quedan cuando alguien corrige un lote desde el conteo.
+ *
+ * Es la regla más delicada del cambio: la fecha de retiro es la que ordena FEFO en TODA la red, así
+ * que un tipeo acá reordena stock que ya está en góndola en otras sucursales.
+ *
+ * Función pura, sin Spring, igual que {@link AjusteStockLoteServiceTest}.
+ */
+class LoteFechasTest {
+
+    private static final LocalDate VENCE_DICIEMBRE = LocalDate.of(2026, 12, 1);
+    private static final LocalDate VENCE_ENERO = LocalDate.of(2027, 1, 10);
+    private static final LocalDate RETIRO_NOVIEMBRE = LocalDate.of(2026, 11, 1);
+
+    @Test
+    void cargaLaFechaDeRetiroQueFaltaba() {
+        LoteService.FechasLote fechas = LoteService.resolverFechas(
+                VENCE_DICIEMBRE, null, null, RETIRO_NOVIEMBRE, null);
+
+        assertEquals(RETIRO_NOVIEMBRE, fechas.getFechaRetiro());
+        assertEquals(VENCE_DICIEMBRE, fechas.getFechaVencimiento());
+    }
+
+    @Test
+    void corrigeUnaFechaDeRetiroYaCargada() {
+        LocalDate corregida = LocalDate.of(2026, 10, 15);
+
+        LoteService.FechasLote fechas = LoteService.resolverFechas(
+                VENCE_DICIEMBRE, RETIRO_NOVIEMBRE, null, corregida, null);
+
+        assertEquals(corregida, fechas.getFechaRetiro());
+    }
+
+    @Test
+    void unNuloNoBorraLoQueYaEstabaCargado() {
+        // El input no puede distinguir "no lo mandé" de "borralo", y borrar un vencimiento no es
+        // un caso real del negocio.
+        LoteService.FechasLote fechas = LoteService.resolverFechas(
+                VENCE_DICIEMBRE, RETIRO_NOVIEMBRE, null, null, null);
+
+        assertEquals(VENCE_DICIEMBRE, fechas.getFechaVencimiento());
+        assertEquals(RETIRO_NOVIEMBRE, fechas.getFechaRetiro());
+    }
+
+    @Test
+    void alCambiarElVencimientoRecalculaElRetiroSiNadieLoHabiaCargado() {
+        LoteService.FechasLote fechas = LoteService.resolverFechas(
+                VENCE_DICIEMBRE, null, VENCE_ENERO, null, 30);
+
+        assertEquals(VENCE_ENERO, fechas.getFechaVencimiento());
+        assertEquals(LocalDate.of(2026, 12, 11), fechas.getFechaRetiro());
+    }
+
+    @Test
+    void noPisaElRetiroYaCargadoAlCambiarElVencimiento() {
+        // No hay forma de distinguir un retiro derivado de uno tipeado a mano, así que se respeta
+        // el que está: pisarlo reordenaría el FEFO sin que nadie lo pidiera.
+        LoteService.FechasLote fechas = LoteService.resolverFechas(
+                VENCE_DICIEMBRE, RETIRO_NOVIEMBRE, VENCE_ENERO, null, 30);
+
+        assertEquals(RETIRO_NOVIEMBRE, fechas.getFechaRetiro());
+    }
+
+    @Test
+    void sinDiasDeVencimientoNoInventaUnRetiro() {
+        LoteService.FechasLote fechas = LoteService.resolverFechas(
+                VENCE_DICIEMBRE, null, VENCE_ENERO, null, null);
+
+        assertNull(fechas.getFechaRetiro());
+    }
+
+    @Test
+    void alCrearUnLoteDerivaElRetiroDeLosDiasDelProducto() {
+        // Es el caso de «Crear nuevo lote» desde el conteo: el operador carga el número y el
+        // vencimiento que dice el envase, y la fecha de retiro sale sola.
+        LoteService.FechasLote fechas = LoteService.resolverFechas(
+                null, null, VENCE_ENERO, null, 30);
+
+        assertEquals(VENCE_ENERO, fechas.getFechaVencimiento());
+        assertEquals(LocalDate.of(2026, 12, 11), fechas.getFechaRetiro());
+    }
+
+    @Test
+    void alCrearSinVencimientoNoHayNingunaFecha() {
+        // Un lote sin vencimiento es válido: hay productos con control de lote y sin fecha.
+        LoteService.FechasLote fechas = LoteService.resolverFechas(null, null, null, null, 30);
+
+        assertNull(fechas.getFechaVencimiento());
+        assertNull(fechas.getFechaRetiro());
+    }
+
+    @Test
+    void rechazaUnRetiroPosteriorAlVencimiento() {
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+                () -> LoteService.resolverFechas(
+                        VENCE_DICIEMBRE, null, null, LocalDate.of(2026, 12, 2), null));
+
+        assertEquals("La fecha de retiro no puede ser posterior al vencimiento del lote.",
+                error.getMessage());
+    }
+
+    @Test
+    void aceptaUnRetiroElMismoDiaDelVencimiento() {
+        LoteService.FechasLote fechas = LoteService.resolverFechas(
+                VENCE_DICIEMBRE, null, null, VENCE_DICIEMBRE, null);
+
+        assertEquals(VENCE_DICIEMBRE, fechas.getFechaRetiro());
+    }
+
+    @Test
+    void validaContraElVencimientoNuevoYNoContraElViejo() {
+        // Se adelanta el vencimiento a octubre: un retiro de noviembre que antes era válido deja
+        // de serlo, y el error tiene que salir en la misma operación.
+        assertThrows(IllegalArgumentException.class,
+                () -> LoteService.resolverFechas(
+                        VENCE_DICIEMBRE, null, LocalDate.of(2026, 10, 1), RETIRO_NOVIEMBRE, null));
+    }
+}

--- a/src/test/java/com/franco/dev/service/operaciones/LoteNumeroTest.java
+++ b/src/test/java/com/franco/dev/service/operaciones/LoteNumeroTest.java
@@ -1,0 +1,34 @@
+package com.franco.dev.service.operaciones;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * La normalizacion del numero de lote.
+ *
+ * Es lo unico que evita que " lote2026101 " y "LOTE2026101" terminen siendo dos lotes distintos con
+ * el mismo stock repartido. Vive en el backend y no solo en la UI porque el conteo del telefono, la
+ * recepcion del escritorio y una llamada directa al GraphQL son tres puertas independientes.
+ */
+class LoteNumeroTest {
+
+    @Test
+    void colapsaEspaciosYMinusculas() {
+        assertEquals("LOTE2026101", LoteService.normalizarNumeroLote("  lote2026101 "));
+    }
+
+    @Test
+    void unNumeroVacioNoEsUnLote() {
+        // Crear un lote llamado "" dejaria un maestro que nadie puede volver a encontrar.
+        assertNull(LoteService.normalizarNumeroLote("   "));
+        assertNull(LoteService.normalizarNumeroLote(null));
+    }
+
+    @Test
+    void respetaLosGuionesYLosCeros() {
+        // Un numero de lote no es un numero: "L-007" y "L-7" son lotes distintos.
+        assertEquals("L-007", LoteService.normalizarNumeroLote("l-007"));
+    }
+}

--- a/src/test/java/com/franco/dev/service/operaciones/VencimientosConocidosSqlTest.java
+++ b/src/test/java/com/franco/dev/service/operaciones/VencimientosConocidosSqlTest.java
@@ -1,0 +1,200 @@
+package com.franco.dev.service.operaciones;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * La forma del SQL de vencimientosConocidos.
+ *
+ * No se usa productosVencidos para proponer el vencimiento al contar porque
+ * ese reporte ancla las cinco fuentes al ultimo inventario de la sucursal, y
+ * la toma que se esta contando ES el ultimo inventario: mientras se cuenta
+ * devuelve cero. Lo que estas pruebas fijan es que el modo historico no lleve
+ * ese ancla, y que el reporte si la siga llevando.
+ */
+class VencimientosConocidosSqlTest {
+
+    private String capturarSql(boolean historico) {
+        EntityManager em = mock(EntityManager.class);
+        Query query = mock(Query.class);
+        when(em.createNativeQuery(anyString())).thenReturn(query);
+        when(query.getResultList()).thenReturn(Collections.emptyList());
+        when(query.getSingleResult()).thenReturn(0L);
+        when(query.setParameter(anyString(), org.mockito.ArgumentMatchers.any())).thenReturn(query);
+        when(query.setFirstResult(org.mockito.ArgumentMatchers.anyInt())).thenReturn(query);
+        when(query.setMaxResults(org.mockito.ArgumentMatchers.anyInt())).thenReturn(query);
+
+        ProductosVencidosService service = new ProductosVencidosService();
+        ReflectionTestUtils.setField(service, "entityManager", em);
+
+        if (historico) {
+            service.vencimientosConocidos(1L, Arrays.asList(802L), 3);
+        } else {
+            service.buscarProductosVencidos(null, null, Collections.singletonList(1L), null, null, null,
+                    Arrays.asList(802L), null, Boolean.FALSE,
+                    org.springframework.data.domain.PageRequest.of(0, 50));
+        }
+
+        ArgumentCaptor<String> sql = ArgumentCaptor.forClass(String.class);
+        org.mockito.Mockito.verify(em, org.mockito.Mockito.atLeastOnce()).createNativeQuery(sql.capture());
+        return sql.getAllValues().get(sql.getAllValues().size() - 1);
+    }
+
+    @Test
+    @DisplayName("el modo historico no ancla al ultimo inventario, en ninguna de las cinco fuentes")
+    void historicoSinAncla() throws IOException {
+        String sql = capturarSql(true);
+
+        /*
+         * El texto "> ui.fecha_inicio" sigue en las cuatro fuentes de compra y
+         * transferencia, y esta bien: lo que se neutraliza es el ANCLA, que en
+         * modo historico vale 1900, asi que el filtro pasa siempre. Afirmar el
+         * ancla y no la ausencia del filtro es lo que hace que este test siga
+         * valiendo si manana el SQL se reordena.
+         */
+        assertTrue(sql.contains("TIMESTAMP '1900-01-01' AS fecha_inicio"), sql);
+        assertFalse(sql.contains("COALESCE(MAX(inv.fecha_inicio)"), sql);
+
+        // Era el filtro que dejaba fuera las 8 compras de COCA COLA 500ML en
+        // bodega3: todas anteriores a la toma que se estaba contando.
+        // La fuente INVENTARIO mira cualquier toma concluida, no solo la ultima.
+        assertTrue(sql.contains("AND inv.estado = 'CONCLUIDO'"), sql);
+        assertFalse(sql.contains("JOIN ultimo_inv ui ON ui.inventario_id = inv.id   JOIN empresarial.sucursal"), sql);
+
+        // Se deja el SQL a mano para poder correrlo contra la base.
+        Files.write(Path.of("target", "vencimientos-conocidos.sql"), sql.getBytes());
+    }
+
+    @Test
+    @DisplayName("el reporte de vencidos conserva su ancla: sigue siendo lo que entro desde el ultimo inventario")
+    void reporteConservaElAncla() throws IOException {
+        String sql = capturarSql(false);
+
+        assertTrue(sql.contains("> ui.fecha_inicio"), sql);
+        assertTrue(sql.contains("JOIN ultimo_inv ui ON ui.inventario_id = inv.id"), sql);
+        // El ancla real, no la neutralizada del modo historico.
+        assertTrue(sql.contains("COALESCE(MAX(inv.fecha_inicio)"), sql);
+
+        Files.write(Path.of("target", "productos-vencidos.sql"), sql.getBytes());
+    }
+
+    @Test
+    @DisplayName("el ancla solo cuenta inventarios concluidos, en los dos modos")
+    void anclaSoloConcluidos() {
+        // Una toma ABIERTA o CANCELADA no es un inventario hecho. Tomarla como
+        // ancla dejaba el reporte en blanco para esa sucursal: en bodega3
+        // pasaba en 5 de 26.
+        for (boolean historico : new boolean[] { true, false }) {
+            String sql = capturarSql(historico);
+            assertTrue(sql.contains("MAX(inv.id) FILTER (WHERE inv.estado = 'CONCLUIDO')"), sql);
+            // Ninguna sucursal puede desaparecer del reporte por no tener
+            // ningun inventario concluido.
+            assertTrue(sql.contains("TIMESTAMP '1900-01-01'"), sql);
+        }
+    }
+
+    // ── el recorte ──────────────────────────────────────────────────────
+
+    private static com.franco.dev.graphql.operaciones.dto.ProductoVencidoViewDTO fila(
+            Long presentacionId, String vencimiento) {
+        com.franco.dev.graphql.operaciones.dto.ProductoVencidoViewDTO dto =
+                new com.franco.dev.graphql.operaciones.dto.ProductoVencidoViewDTO();
+        dto.setPresentacionId(presentacionId);
+        dto.setVencimiento(java.time.LocalDate.parse(vencimiento).atStartOfDay());
+        return dto;
+    }
+
+    private static java.util.List<String> fechas(
+            java.util.List<com.franco.dev.graphql.operaciones.dto.ProductoVencidoViewDTO> filas) {
+        java.util.List<String> salida = new java.util.ArrayList<>();
+        for (com.franco.dev.graphql.operaciones.dto.ProductoVencidoViewDTO f : filas) {
+            salida.add(f.getVencimiento().toLocalDate().toString());
+        }
+        return salida;
+    }
+
+    private static final java.time.LocalDate HOY = java.time.LocalDate.of(2026, 8, 26);
+
+    @Test
+    @DisplayName("todas las vigentes entran, por muchas que sean")
+    void todasLasVigentes() {
+        // Son las que sirven para contar: recortarlas dejaria renglones sin
+        // lote que proponer.
+        java.util.List<com.franco.dev.graphql.operaciones.dto.ProductoVencidoViewDTO> filas = Arrays.asList(
+                fila(1212L, "2026-09-10"), fila(1212L, "2026-10-01"),
+                fila(1212L, "2026-11-20"), fila(1212L, "2027-01-05"));
+
+        assertTrue(ProductosVencidosService.recortarPorPresentacion(filas, HOY, 3).size() == 4);
+    }
+
+    @Test
+    @DisplayName("de las vencidas solo las mas recientes, que son las que pueden seguir en gondola")
+    void soloLasVencidasMasRecientes() {
+        java.util.List<com.franco.dev.graphql.operaciones.dto.ProductoVencidoViewDTO> filas = Arrays.asList(
+                fila(1212L, "2026-08-25"), fila(1212L, "2026-07-22"), fila(1212L, "2026-07-13"),
+                fila(1212L, "2026-07-11"), fila(1212L, "2023-06-25"));
+
+        // Las de 2023 no le sirven a nadie frente a la gondola.
+        org.junit.jupiter.api.Assertions.assertEquals(
+                Arrays.asList("2026-08-25", "2026-07-22", "2026-07-13"),
+                fechas(ProductosVencidosService.recortarPorPresentacion(filas, HOY, 3)));
+    }
+
+    @Test
+    @DisplayName("lo que vence hoy todavia no vencio")
+    void loQueVenceHoyEsVigente() {
+        // La mercaderia esta en gondola y se puede vender durante el dia.
+        java.util.List<com.franco.dev.graphql.operaciones.dto.ProductoVencidoViewDTO> filas =
+                Collections.singletonList(fila(1212L, "2026-08-26"));
+
+        org.junit.jupiter.api.Assertions.assertEquals(
+                Arrays.asList("2026-08-26"),
+                fechas(ProductosVencidosService.recortarPorPresentacion(filas, HOY, 0)));
+    }
+
+    @Test
+    @DisplayName("el recorte es por presentacion: una con muchos lotes no se come el cupo de la otra")
+    void elRecorteEsPorPresentacion() {
+        // Es el caso real de COCA COLA 500ML en bodega3: la caja x 6 tiene 81
+        // fechas conocidas y la unidad 21. Cortando sobre el total, la unidad
+        // se quedaba sin ninguna.
+        java.util.List<com.franco.dev.graphql.operaciones.dto.ProductoVencidoViewDTO> filas = Arrays.asList(
+                fila(1212L, "2026-08-25"), fila(1212L, "2026-07-22"), fila(1212L, "2026-07-13"),
+                fila(1212L, "2026-07-11"), fila(1211L, "2026-04-15"));
+
+        java.util.List<com.franco.dev.graphql.operaciones.dto.ProductoVencidoViewDTO> recortadas =
+                ProductosVencidosService.recortarPorPresentacion(filas, HOY, 3);
+
+        assertTrue(fechas(recortadas).contains("2026-04-15"), fechas(recortadas).toString());
+        org.junit.jupiter.api.Assertions.assertEquals(4, recortadas.size());
+    }
+
+    @Test
+    @DisplayName("sin fecha de vencimiento no es una sugerencia")
+    void sinFechaNoEsSugerencia() {
+        com.franco.dev.graphql.operaciones.dto.ProductoVencidoViewDTO sinFecha =
+                new com.franco.dev.graphql.operaciones.dto.ProductoVencidoViewDTO();
+        sinFecha.setPresentacionId(1212L);
+
+        org.junit.jupiter.api.Assertions.assertTrue(
+                fechas(ProductosVencidosService.recortarPorPresentacion(
+                        Arrays.asList(sinFecha, fila(1212L, "2026-09-10")), HOY, 3))
+                        .contains("2026-09-10"));
+    }
+}


### PR DESCRIPTION
## Qué resuelve

Cuatro cosas del módulo de inventario, acumuladas en esta rama. Las tres primeras son arreglos que ya estaban acá; la cuarta es el trabajo nuevo.

| Commit | Qué |
|---|---|
| `02b7ee35` | El duplicado de renglón era `(inventario, producto, vencimiento)` y rechazaba el mismo producto contado en **dos zonas** —el caso normal de un inventario por zona—, unidad y caja x12 del mismo producto, y dos renglones sin vencimiento. Pasa a `(zona, presentación, vencimiento)`. |
| `ed8ff9ad` | El vencimiento sugerido nunca salía: la consulta se anclaba al **último inventario** de la sucursal, y la toma que se está contando *es* el último inventario. |
| `9f0857de` | Una toma con un ítem sin contar no se podía finalizar: `cantidad` es nullable y se multiplicaba sin mirar → `NullPointerException`. |
| `ab0b0475` | **Conteo por lote** (abajo). |

## Conteo por lote — `ab0b0475`

`finalizarInventarioEnSucursal()` escribía **solo** el `MovimientoStock` agregado. Para un producto con control de lote eso deja el ledger sin tocar, con lo que la mercadería contada **nunca vuelve a ser asignable por FEFO** — el mismo agujero que `AjusteStockLoteService` cerró para el ajuste manual.

- **`V203.5`** — `inventario_producto_item.lote_id`, nullable + FK + índice parcial.
- **`InventarioLoteService` + `PlanConteoLote`** — la decisión del desglose como función pura, con el invariante `SUM(hijas) = padre`. Contar por lote es una **atribución**, así que el plan incluye la fila sintética `SIN LOTE` con lo que las filas por lote no explican.
- **Guarda de lotes sin contar** — si un lote con saldo no se contó, el producto queda **entero** fuera del ajuste. Misma regla que ya rige para el ítem con `cantidad == null`: un lote sin contar no es un lote en cero.
- **`crearLote`** — alta manual del maestro, sin mover stock. Un lote solo nacía al recibir mercadería o desde `ajustarStockLote`, que además mueve existencia.
- **`actualizarFechasLote`** — cargar o corregir vencimiento y fecha de retiro. El retiro solo se podía setear al **crear** el lote. Valida `retiro <= vencimiento`, que hasta ahora lo garantizaba la resta del cálculo automático.
- **`lotesSinContar`** — consulta de apoyo.
- La clave de duplicado suma el lote: dos lotes del mismo producto pueden vencer el mismo día.

### Dos bugs que el desglose obligó a arreglar

1. **El bucle de escritura estaba anidado dentro del de zonas** y `cantidadesPorProducto` nunca se limpia: con N zonas cada movimiento agregado se escribía **N veces** con acumulados parciales. Terminaba bien de casualidad porque la última pasada pisaba con el total correcto — las filas hijas son `INSERT` con PK propia y ahí no hay pisada que valga.
2. **Re-finalizar duplicaba el desglose.** Se reusa el `MovimientoStock` de AJUSTE existente; ahora se borra el desglose viejo antes de escribir el nuevo, y el saldo por lote se calcula descontando las filas del propio movimiento para que no se descuente a sí mismo.

## Cómo probarlo

```bash
./mvnw clean verify -B -DskipFlyway=true
```

**394 tests, 0 fallas.** La migración se validó contra `bodega3` dentro de una transacción revertida. Los tests de la guarda y del desglose se verificaron con mutantes (romper la producción y confirmar que fallan).

Funcional: marcar un producto con `lote = true`, contarlo por lote desde la PWA y verificar en *Stock por lotes* que después de finalizar el saldo de cada lote es lo contado y `SIN LOTE` quedó en cero.

## Impacto en DB

`V203.5`, **solo central**. `ADD COLUMN` nullable + FK + índice: retrocompatible, la versión anterior del backend ignora la columna.

**No se registra en `replication_table`**: verificado en `bodega3` que ninguna tabla `operaciones.inventario*` se replica. El inventario vive solo en el central, así que no hay orden de despliegue filial/central que respetar.

## Rollback

El JAR vuelve solo. La columna queda —Flyway no baja— pero es nullable y el código viejo no la mira. Las filas de `movimiento_stock_lote` que haya escrito una finalización quedan: son ledger, y borrarlas descuadraría el stock por lote de esa sucursal.

## Riesgo

**Medio.** Toca el camino crítico de finalización de inventarios, que es el que ajusta stock. Toda la lógica nueva va detrás de `if (producto.getLote())` — regresión cero para los ~8.700 productos sin control de lote; en `bodega3` hay **3** con el flag en `true`.

## Nota sobre la regla 5

`finalizarInventarioEnSucursal()` **la usa el escritorio** y se modifica **compartida**, no forkeada con sufijo `Mobile`. Forkearla dejaría dos finalizaciones que ajustan el stock distinto según desde dónde se cierre la toma, y la del escritorio seguiría escribiendo un agregado sin desglose — que es justo el agujero que esto cierra.

## Antes de mergear

⚠️ **El PR de la PWA (`GabFrank/frc-mobile-pwa`) depende de este.** Sin `V203.5` desplegada, agregar un producto con lote falla al guardar el renglón. **Este va primero.**

⚠️ **El bloque 47 del plan de testeo manual de la PWA —32 casos— sigue sin ejecutarse.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)