### PR TITLE
feat(financiero): verificacion de retiros con veredicto y cambio de divisa bancario

### DIFF
--- a/src/main/java/com/franco/dev/domain/financiero/MovimientoCajaVirtual.java
+++ b/src/main/java/com/franco/dev/domain/financiero/MovimientoCajaVirtual.java
@@ -69,6 +69,18 @@ public class MovimientoCajaVirtual implements Serializable {
     @Column(name = "origen_id")
     private Long origenId;
 
+    /**
+     * Segunda mitad de la PK del documento de origen, cuando es compuesta. Null para los de
+     * PK simple.
+     *
+     * Hace falta porque {@code origenId} solo no identifica un documento: Retiro tiene PK
+     * (id, sucursalId) y el id no es global — cada filial numera desde 1, así que el mismo id
+     * lo comparten decenas de sucursales. Una caja mayor recibe retiros de varias sucursales
+     * por diseño, con lo cual buscar por (origenTipo, origenId) devuelve movimientos ajenos.
+     */
+    @Column(name = "origen_sucursal_id")
+    private Long origenSucursalId;
+
     private String descripcion;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/franco/dev/domain/financiero/RetiroCaso.java
+++ b/src/main/java/com/franco/dev/domain/financiero/RetiroCaso.java
@@ -1,0 +1,105 @@
+package com.franco.dev.domain.financiero;
+
+import com.franco.dev.domain.financiero.enums.EstadoCasoRetiro;
+import com.franco.dev.domain.financiero.enums.VeredictoCasoRetiro;
+import com.franco.dev.domain.personas.Persona;
+import com.franco.dev.domain.personas.Usuario;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+/**
+ * Un retiro que no cerró y hay que investigar.
+ *
+ * Existe separado de la verificación a propósito: <b>el que recibe no investiga</b>. Tesorería
+ * cuenta, registra y abre el caso; otro lo toma y lo cierra. Si la diferencia quedara solo como
+ * una observación dentro de la verificación, nadie la miraría — que es exactamente lo que pasa
+ * hoy con {@code retiro.observacion}.
+ *
+ * No lleva categoría propia: esa vive en el detalle de la verificación, por moneda, porque un
+ * mismo retiro puede ser faltante en una y sobrante en otra. El caso agrupa.
+ *
+ * Central-only, no replicado.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "retiro_caso", schema = "financiero")
+public class RetiroCaso implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "retiro_id", nullable = false)
+    private Long retiroId;
+
+    @Column(name = "sucursal_id", nullable = false)
+    private Long sucursalId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "verificacion_id")
+    private RetiroVerificacion verificacion;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "estado", length = 20, nullable = false)
+    private EstadoCasoRetiro estado = EstadoCasoRetiro.ABIERTO;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "abierto_por")
+    private Usuario abiertoPor;
+
+    /** No puede ser el mismo que contó: quien verifica también puede ser el problema. */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "asignado_a")
+    private Usuario asignadoA;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "resuelto_por")
+    private Usuario resueltoPor;
+
+    @Column(name = "creado_en", nullable = false)
+    private LocalDateTime creadoEn;
+
+    @Column(name = "resuelto_en")
+    private LocalDateTime resueltoEn;
+
+    @Column(name = "resolucion")
+    private String resolucion;
+
+    /**
+     * Qué se determinó. Se llena al resolver: un caso abierto no tiene veredicto, y esa es la
+     * diferencia entre "hay una diferencia" y "sabemos qué pasó".
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "veredicto", length = 40)
+    private VeredictoCasoRetiro veredicto;
+
+    /**
+     * A quién se le atribuye. Apunta a persona y no a funcionario ni a usuario porque el
+     * responsable puede estar de cualquiera de los dos lados — el cajero del PDV o el que contó
+     * en tesorería — y persona es lo único que los dos comparten.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "responsable_persona_id")
+    private Persona responsablePersona;
+
+    /**
+     * Solo con veredicto REINTEGRADO: el retiro por el que volvió la plata.
+     *
+     * Lleva la sucursal al lado porque el id de retiro no es único entre filiales: sin ella,
+     * el número no identifica ningún documento.
+     */
+    @Column(name = "reintegro_retiro_id")
+    private Long reintegroRetiroId;
+
+    @Column(name = "reintegro_sucursal_id")
+    private Long reintegroSucursalId;
+}

--- a/src/main/java/com/franco/dev/domain/financiero/RetiroVerificacion.java
+++ b/src/main/java/com/franco/dev/domain/financiero/RetiroVerificacion.java
@@ -1,0 +1,78 @@
+package com.franco.dev.domain.financiero;
+
+import com.franco.dev.domain.financiero.enums.ResultadoVerificacionRetiro;
+import com.franco.dev.domain.personas.Usuario;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Lo que tesorería contó al recibir un retiro de PDV.
+ *
+ * El retiro del PDV es inmutable: es la declaración del origen y es la evidencia. Esta entidad
+ * es un documento aparte, central-only, que registra qué se contó de verdad. A la caja mayor
+ * entra <b>lo contado</b>, no lo declarado.
+ *
+ * No se replica a las filiales (no lleva fila en {@code configuraciones.replication_table}).
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "retiro_verificacion", schema = "financiero")
+public class RetiroVerificacion implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** Mitad del retiro verificado. La PK del retiro es compuesta: hace falta también la sucursal. */
+    @Column(name = "retiro_id", nullable = false)
+    private Long retiroId;
+
+    @Column(name = "sucursal_id", nullable = false)
+    private Long sucursalId;
+
+    /** Quién contó. Importa: el que cuenta no puede ser después el que investiga. */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "usuario_id")
+    private Usuario usuario;
+
+    @Column(name = "creado_en", nullable = false)
+    private LocalDateTime creadoEn;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "resultado", length = 20, nullable = false)
+    private ResultadoVerificacionRetiro resultado;
+
+    /**
+     * Se confirmó lo declarado sin contar por denominación. Queda marcado a propósito: si más
+     * adelante aparece una diferencia, hay que poder saber que ese retiro nunca se contó
+     * billete por billete.
+     */
+    @Column(name = "rapida", nullable = false)
+    private Boolean rapida = false;
+
+    @Column(name = "observacion")
+    private String observacion;
+
+    /** Una verificación anulada libera el índice único y deja hacer otra sobre el mismo retiro. */
+    @Column(name = "anulada", nullable = false)
+    private Boolean anulada = false;
+
+    @OneToMany(mappedBy = "verificacion", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<RetiroVerificacionDetalle> detalles = new ArrayList<>();
+
+    public void agregarDetalle(RetiroVerificacionDetalle d) {
+        d.setVerificacion(this);
+        this.detalles.add(d);
+    }
+}

--- a/src/main/java/com/franco/dev/domain/financiero/RetiroVerificacionDetalle.java
+++ b/src/main/java/com/franco/dev/domain/financiero/RetiroVerificacionDetalle.java
@@ -1,0 +1,59 @@
+package com.franco.dev.domain.financiero;
+
+import com.franco.dev.domain.financiero.enums.CategoriaDiferenciaRetiro;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.io.Serializable;
+import java.math.BigDecimal;
+
+/**
+ * Una moneda dentro de una verificación: qué declaró el PDV, qué contó tesorería y la
+ * diferencia.
+ *
+ * La comparación es <b>por moneda</b> y nunca por total convertido. Un retiro puede cerrar en
+ * el total y tener 100 R$ de menos con su equivalente de más en guaraníes: eso no es un retiro
+ * correcto, es un cambio informal hecho en el camino.
+ *
+ * La categoría vive acá y no en la cabecera porque un mismo retiro puede ser FALTANTE en una
+ * moneda y SOBRANTE en otra a la vez.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "retiro_verificacion_detalle", schema = "financiero")
+public class RetiroVerificacionDetalle implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "verificacion_id", nullable = false)
+    private RetiroVerificacion verificacion;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "moneda_id", nullable = false)
+    private Moneda moneda;
+
+    /** Lo que dice el retiro_detalle del PDV. Se copia acá para que quede congelado. */
+    @Column(name = "declarado", nullable = false)
+    private BigDecimal declarado;
+
+    /** Lo que contó tesorería. Es lo que se acredita en la caja mayor. */
+    @Column(name = "contado", nullable = false)
+    private BigDecimal contado;
+
+    /** contado − declarado. Negativo = faltante, positivo = sobrante. */
+    @Column(name = "diferencia", nullable = false)
+    private BigDecimal diferencia;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "categoria", length = 30)
+    private CategoriaDiferenciaRetiro categoria;
+}

--- a/src/main/java/com/franco/dev/domain/financiero/enums/CategoriaDiferenciaRetiro.java
+++ b/src/main/java/com/franco/dev/domain/financiero/enums/CategoriaDiferenciaRetiro.java
@@ -1,0 +1,21 @@
+package com.franco.dev.domain.financiero.enums;
+
+/**
+ * Por qué no coincidió lo contado con lo declarado, en una moneda.
+ *
+ * Tipificada y no texto libre: es lo que después permite preguntar "cuántos faltantes en
+ * dólares tuvo la sucursal 3 este mes". Un campo de texto no responde eso.
+ *
+ * Vive en el detalle y no en la cabecera porque un mismo retiro puede ser FALTANTE en una
+ * moneda y SOBRANTE en otra a la vez.
+ */
+public enum CategoriaDiferenciaRetiro {
+    DIFERENCIA_CONTEO,
+    FALTANTE,
+    SOBRANTE,
+    /** El monto está pero la pieza no sirve: billete falso o roto. No se trata igual. */
+    BILLETE_NO_RECIBIBLE,
+    /** El retiro existe en el sistema y físicamente nunca llegó. */
+    NO_RECIBIDO,
+    OTRO
+}

--- a/src/main/java/com/franco/dev/domain/financiero/enums/EstadoCasoRetiro.java
+++ b/src/main/java/com/franco/dev/domain/financiero/enums/EstadoCasoRetiro.java
@@ -1,0 +1,8 @@
+package com.franco.dev.domain.financiero.enums;
+
+/** Ciclo de vida del caso a investigar. Lo abre tesorería; lo cierra otro. */
+public enum EstadoCasoRetiro {
+    ABIERTO,
+    EN_INVESTIGACION,
+    RESUELTO
+}

--- a/src/main/java/com/franco/dev/domain/financiero/enums/ResultadoVerificacionRetiro.java
+++ b/src/main/java/com/franco/dev/domain/financiero/enums/ResultadoVerificacionRetiro.java
@@ -1,0 +1,7 @@
+package com.franco.dev.domain.financiero.enums;
+
+/** Resultado de contar un retiro contra lo que declaró el PDV. */
+public enum ResultadoVerificacionRetiro {
+    SIN_DIFERENCIA,
+    CON_DIFERENCIA
+}

--- a/src/main/java/com/franco/dev/domain/financiero/enums/VeredictoCasoRetiro.java
+++ b/src/main/java/com/franco/dev/domain/financiero/enums/VeredictoCasoRetiro.java
@@ -1,0 +1,39 @@
+package com.franco.dev.domain.financiero.enums;
+
+/**
+ * Conclusión del que investiga un caso de retiro.
+ *
+ * <p>No confundir con {@link CategoriaDiferenciaRetiro}: esa es lo que <b>cree</b> el que recibe,
+ * anotada por moneda en el momento de contar y sin haber averiguado nada. El veredicto es lo que
+ * se <b>determinó</b> después, y es uno solo para todo el caso.
+ *
+ * <p>La diferencia entre lo declarado y lo contado no dice de qué lado está el error: el cajero
+ * pudo contar mal o retener, y el de tesorería también. Cada veredicto nombra un lado.
+ */
+public enum VeredictoCasoRetiro {
+
+    /**
+     * Contó mal el que recibe. La acreditación en la caja mayor quedó equivocada, así que este
+     * veredicto pide además anular la verificación y volver a contar: es el único que obliga a
+     * tocar plata ya asentada.
+     */
+    ERROR_DE_CONTEO_TESORERIA,
+
+    /**
+     * Al sobre le faltó plata: vino menos de lo declarado.
+     *
+     * <p>Se mide <b>desde el sobre</b>, no desde la caja del cajero. El mismo hecho visto desde
+     * la caja se ve al revés — si el cajero declaró 120 y mandó 110, al sobre le faltan 10 y a
+     * su caja le sobran 10 — y confundir el punto de referencia invierte la clasificación.
+     */
+    FALTANTE_PDV,
+
+    /** Al sobre le sobró plata: vino más de lo declarado. Mismo punto de referencia. */
+    SOBRANTE_PDV,
+
+    /** La diferencia se repuso después, normalmente en un retiro posterior. */
+    REINTEGRADO,
+
+    /** No se pudo determinar de qué lado estuvo; la empresa la asume. */
+    ASUMIDO_SIN_RESPONSABLE
+}

--- a/src/main/java/com/franco/dev/graphql/financiero/RetiroVerificacionGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/RetiroVerificacionGraphQL.java
@@ -1,0 +1,273 @@
+package com.franco.dev.graphql.financiero;
+
+import com.franco.dev.domain.financiero.RetiroCaso;
+import com.franco.dev.domain.financiero.RetiroVerificacionDetalle;
+import com.franco.dev.domain.financiero.RetiroVerificacion;
+import com.franco.dev.domain.financiero.enums.CategoriaDiferenciaRetiro;
+import com.franco.dev.domain.financiero.enums.EstadoCasoRetiro;
+import com.franco.dev.domain.financiero.enums.VeredictoCasoRetiro;
+import com.franco.dev.domain.personas.Usuario;
+import com.franco.dev.repository.financiero.RetiroCasoRepository;
+import com.franco.dev.repository.financiero.RetiroVerificacionRepository;
+import com.franco.dev.service.financiero.RetiroVerificacionService;
+import com.franco.dev.service.financiero.TesoreriaSecurityService;
+import com.franco.dev.service.personas.PersonaService;
+import com.franco.dev.service.personas.UsuarioService;
+import graphql.GraphQLException;
+import graphql.kickstart.tools.GraphQLMutationResolver;
+import graphql.kickstart.tools.GraphQLQueryResolver;
+import lombok.AllArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@AllArgsConstructor
+public class RetiroVerificacionGraphQL implements GraphQLQueryResolver, GraphQLMutationResolver {
+
+    private final RetiroVerificacionService service;
+    private final RetiroVerificacionRepository verificacionRepository;
+    private final RetiroCasoRepository casoRepository;
+    private final UsuarioService usuarioService;
+    private final PersonaService personaService;
+    private final TesoreriaSecurityService seg;
+
+    public RetiroVerificacion verificacionDeRetiro(Long retiroId, Long sucursalId) {
+        seg.requireVer();
+        return verificacionRepository.findVigente(retiroId, sucursalId).orElse(null);
+    }
+
+    public Page<RetiroCaso> retiroCasos(EstadoCasoRetiro estado, Long sucursalId, Long retiroId,
+                                       String desde, String hasta, Boolean soloMios,
+                                       int page, int size) {
+        seg.requireVer();
+        Long usuarioId = Boolean.TRUE.equals(soloMios) && seg.currentUsuario() != null
+                ? seg.currentUsuario().getId() : null;
+        return casoRepository.filter(
+                estado != null ? estado.name() : null,
+                sucursalId, retiroId,
+                parseFechaInicio(desde), parseFechaFin(hasta),
+                usuarioId,
+                PageRequest.of(page, size));
+    }
+
+    /**
+     * El rango se toma por día completo, de 00:00:00 a 23:59:59.
+     *
+     * El front manda la fecha con la hora en que se tocó el filtro. Sin normalizar, filtrar
+     * "desde hoy" a las 14:38 dejaría afuera un caso abierto hoy a las 13:39 — y el operador
+     * no tendría forma de entender por qué no aparece.
+     */
+    private LocalDateTime parseFechaInicio(String f) {
+        LocalDateTime d = parseFechaCruda(f);
+        return d != null ? d.toLocalDate().atStartOfDay() : null;
+    }
+
+    private LocalDateTime parseFechaFin(String f) {
+        LocalDateTime d = parseFechaCruda(f);
+        return d != null ? d.toLocalDate().atTime(23, 59, 59) : null;
+    }
+
+    private LocalDateTime parseFechaCruda(String f) {
+        if (f == null || f.trim().isEmpty()) return null;
+        return com.franco.dev.utilitarios.DateUtils.stringToDate(f);
+    }
+
+    public Integer retiroCasosAbiertos() {
+        seg.requireVer();
+        return (int) casoRepository.countByEstado(EstadoCasoRetiro.ABIERTO);
+    }
+
+    /**
+     * Verifica un retiro y lo acredita. El ACL de caja lo aplica {@code TesoreriaService.registrar},
+     * que es el choke point por donde pasa toda la plata — no hace falta duplicarlo acá.
+     */
+    public RetiroVerificacion verificarRetiro(Long retiroId, Long sucursalId, Long cajaVirtualId,
+                                              List<Map<String, Object>> conteos, Boolean rapida,
+                                              String observacion) {
+        seg.requireGestionar();
+        return service.verificar(retiroId, sucursalId, cajaVirtualId,
+                mapearConteos(conteos), Boolean.TRUE.equals(rapida), observacion, seg.currentUsuario());
+    }
+
+    /** Mismo rol que verificar: el que contó mal puede corregirlo en el momento. */
+    public RetiroVerificacion anularVerificacionRetiro(Long verificacionId, String motivo) {
+        seg.requireGestionar();
+        return service.anular(verificacionId, motivo, seg.currentUsuario());
+    }
+
+    public RetiroCaso asignarRetiroCaso(Long casoId, Long usuarioId) {
+        seg.requireGestionar();
+        RetiroCaso caso = casoRepository.findById(casoId)
+                .orElseThrow(() -> new GraphQLException("Caso no encontrado: " + casoId));
+        Usuario asignado = usuarioService.findById(usuarioId)
+                .orElseThrow(() -> new GraphQLException("Usuario no encontrado: " + usuarioId));
+
+        // El que contó no puede investigarse a sí mismo: quien verifica también puede ser el
+        // problema, y esa es justamente una de las hipótesis que el caso deja abiertas.
+        Usuario conto = caso.getVerificacion() != null ? caso.getVerificacion().getUsuario() : null;
+        if (conto != null && conto.getId().equals(usuarioId)) {
+            throw new GraphQLException("El caso no puede asignarse a quien hizo la verificación");
+        }
+
+        caso.setAsignadoA(asignado);
+        caso.setEstado(EstadoCasoRetiro.EN_INVESTIGACION);
+        return casoRepository.save(caso);
+    }
+
+    /**
+     * Devuelve el caso a ABIERTO. Sin esto, tomarlo por error lo deja trabado a nombre de uno
+     * para siempre.
+     */
+    public RetiroCaso soltarRetiroCaso(Long casoId) {
+        seg.requireGestionar();
+        RetiroCaso caso = casoRepository.findById(casoId)
+                .orElseThrow(() -> new GraphQLException("Caso no encontrado: " + casoId));
+        if (caso.getEstado() == EstadoCasoRetiro.RESUELTO) {
+            throw new GraphQLException("El caso ya está resuelto");
+        }
+        caso.setEstado(EstadoCasoRetiro.ABIERTO);
+        caso.setAsignadoA(null);
+        return casoRepository.save(caso);
+    }
+
+    /**
+     * Cierra el caso con un veredicto tipado.
+     *
+     * El veredicto es obligatorio porque es la única parte del cierre que se puede contar
+     * después: cuántos faltantes tuvo una sucursal, cuántas veces contó mal el mismo receptor.
+     * El informe explica; el veredicto clasifica.
+     *
+     * Cuando se determinó que contó mal tesorería, lo acreditado en la caja mayor quedó
+     * equivocado, así que se ofrece anular la verificación en el mismo acto — cerrar el caso
+     * dejando la caja con el monto errado sería documentar el problema y conservarlo.
+     */
+    public RetiroCaso resolverRetiroCaso(Long casoId, VeredictoCasoRetiro veredicto, String resolucion,
+                                         Long responsablePersonaId, Long reintegroRetiroId,
+                                         Boolean anularVerificacion) {
+        seg.requireGestionar();
+        RetiroCaso caso = casoRepository.findById(casoId)
+                .orElseThrow(() -> new GraphQLException("Caso no encontrado: " + casoId));
+        if (caso.getEstado() == EstadoCasoRetiro.RESUELTO) {
+            throw new GraphQLException("El caso ya está resuelto");
+        }
+
+        // Cierra el que investigó, no cualquiera con el rol. Si no, "tomar" no significa nada
+        // y el informe lo puede firmar alguien que no habló con nadie. El ADMIN pasa por encima
+        // para destrabar casos de gente que ya no está.
+        Usuario actual = seg.currentUsuario();
+        Usuario asignado = caso.getAsignadoA();
+        boolean esMio = asignado != null && actual != null && asignado.getId().equals(actual.getId());
+        if (!esMio && !seg.esSuperusuario()) {
+            throw new GraphQLException(asignado != null
+                    ? "El caso lo está investigando " + nombreDe(asignado) + ". Que lo cierre esa persona, o que lo suelte."
+                    : "Tomá el caso antes de resolverlo");
+        }
+
+        if (veredicto == null) {
+            throw new GraphQLException("Falta el veredicto: sin él el caso no se puede clasificar");
+        }
+        VeredictoCasoRetiro v = veredicto;
+
+        // Un responsable sin nombre no sirve para nada: el veredicto que apunta a un lado tiene
+        // que decir a quién. Los otros dos veredictos existen justamente porque no hay a quién.
+        boolean exigeResponsable = v == VeredictoCasoRetiro.FALTANTE_PDV
+                || v == VeredictoCasoRetiro.SOBRANTE_PDV
+                || v == VeredictoCasoRetiro.ERROR_DE_CONTEO_TESORERIA;
+        if (exigeResponsable && responsablePersonaId == null) {
+            throw new GraphQLException("Este veredicto necesita un responsable identificado");
+        }
+        if (v == VeredictoCasoRetiro.REINTEGRADO && reintegroRetiroId == null) {
+            throw new GraphQLException("Indicá el retiro por el que se repuso la diferencia");
+        }
+        validarSigno(caso, v);
+        if (Boolean.TRUE.equals(anularVerificacion) && v != VeredictoCasoRetiro.ERROR_DE_CONTEO_TESORERIA) {
+            throw new GraphQLException("Solo se anula la verificación cuando el error fue del conteo de tesorería");
+        }
+
+        caso.setEstado(EstadoCasoRetiro.RESUELTO);
+        caso.setVeredicto(v);
+        caso.setResolucion(resolucion != null ? resolucion.toUpperCase() : null);
+        caso.setReintegroRetiroId(v == VeredictoCasoRetiro.REINTEGRADO ? reintegroRetiroId : null);
+        // El reintegro se busca en la misma sucursal del caso: un retiro de otra filial no
+        // repone el faltante de esta.
+        caso.setReintegroSucursalId(v == VeredictoCasoRetiro.REINTEGRADO ? caso.getSucursalId() : null);
+        caso.setResponsablePersona(responsablePersonaId != null
+                ? personaService.findById(responsablePersonaId).orElse(null) : null);
+        caso.setResueltoPor(seg.currentUsuario());
+        caso.setResueltoEn(LocalDateTime.now());
+        RetiroCaso guardado = casoRepository.save(caso);
+
+        // Después de guardar: anular() ve el caso ya RESUELTO y lo deja intacto en vez de
+        // cerrarlo por su cuenta, con lo cual el veredicto del investigador sobrevive.
+        if (Boolean.TRUE.equals(anularVerificacion) && caso.getVerificacion() != null) {
+            service.anular(caso.getVerificacion().getId(),
+                    "ERROR DE CONTEO - CASO " + caso.getId(), seg.currentUsuario());
+        }
+        return guardado;
+    }
+
+    /**
+     * El veredicto tiene que coincidir con el signo de lo que se contó.
+     *
+     * "Vino menos" y "vino más" se miden siempre <b>desde el sobre</b> (contado − declarado), no
+     * desde la caja del cajero, donde el mismo hecho se ve al revés: si al sobre le faltaron 10,
+     * a esa caja le sobran 10. Sin este control, la mitad de los casos termina clasificada con el
+     * signo invertido y el veredicto deja de servir para contar nada, que es su único propósito.
+     *
+     * Un retiro puede faltar en una moneda y sobrar en otra: alcanza con que exista una moneda
+     * del signo elegido.
+     */
+    private void validarSigno(RetiroCaso caso, VeredictoCasoRetiro v) {
+        if (v != VeredictoCasoRetiro.FALTANTE_PDV && v != VeredictoCasoRetiro.SOBRANTE_PDV) return;
+        if (caso.getVerificacion() == null) return;
+
+        boolean hayFaltante = false, haySobrante = false;
+        for (RetiroVerificacionDetalle d : caso.getVerificacion().getDetalles()) {
+            if (d.getDiferencia() == null) continue;
+            int signo = d.getDiferencia().compareTo(java.math.BigDecimal.ZERO);
+            if (signo < 0) hayFaltante = true;
+            if (signo > 0) haySobrante = true;
+        }
+
+        if (v == VeredictoCasoRetiro.FALTANTE_PDV && !hayFaltante) {
+            throw new GraphQLException(haySobrante
+                    ? "El conteo dice que vino de más, no de menos. Revisá el veredicto."
+                    : "Este retiro no tiene faltante registrado");
+        }
+        if (v == VeredictoCasoRetiro.SOBRANTE_PDV && !haySobrante) {
+            throw new GraphQLException(hayFaltante
+                    ? "El conteo dice que vino de menos, no de más. Si la plata quedó en la caja del cajero, igual al sobre le faltó."
+                    : "Este retiro no tiene sobrante registrado");
+        }
+    }
+
+    /** Nombre legible del usuario, para que el rechazo diga a quién reclamarle. */
+    private String nombreDe(Usuario u) {
+        if (u == null) return "otra persona";
+        if (u.getPersona() != null && u.getPersona().getNombre() != null) return u.getPersona().getNombre();
+        return u.getNickname() != null ? u.getNickname() : "otra persona";
+    }
+
+    private List<RetiroVerificacionService.ConteoMoneda> mapearConteos(List<Map<String, Object>> conteos) {
+        List<RetiroVerificacionService.ConteoMoneda> res = new ArrayList<>();
+        if (conteos == null) return res;
+        for (Map<String, Object> m : conteos) {
+            RetiroVerificacionService.ConteoMoneda c = new RetiroVerificacionService.ConteoMoneda();
+            Object monedaId = m.get("monedaId");
+            if (monedaId != null) c.setMonedaId(Long.valueOf(monedaId.toString()));
+            Object contado = m.get("contado");
+            if (contado != null) c.setContado(new BigDecimal(contado.toString()));
+            Object categoria = m.get("categoria");
+            if (categoria != null) c.setCategoria(CategoriaDiferenciaRetiro.valueOf(categoria.toString()));
+            res.add(c);
+        }
+        return res;
+    }
+}

--- a/src/main/java/com/franco/dev/graphql/financiero/resolver/RetiroCasoResolver.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/resolver/RetiroCasoResolver.java
@@ -1,0 +1,28 @@
+package com.franco.dev.graphql.financiero.resolver;
+
+import com.franco.dev.domain.financiero.Retiro;
+import com.franco.dev.domain.financiero.RetiroCaso;
+import com.franco.dev.service.financiero.RetiroService;
+import graphql.kickstart.tools.GraphQLResolver;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * El caso guarda {@code retiroId} suelto, no la entidad: el retiro es un documento replicado
+ * desde la filial y engancharlo por FK ataría una tabla central-only al ciclo de replicación.
+ *
+ * <p>Pero el que investiga necesita ver el otro lado — quién hizo el retiro y de qué caja salió —
+ * porque la diferencia es entre dos versiones y el caso solo trae la de tesorería. Se resuelve
+ * acá, bajo demanda, en vez de duplicar los datos del cajero dentro del caso.
+ */
+@Component
+public class RetiroCasoResolver implements GraphQLResolver<RetiroCaso> {
+
+    @Autowired
+    private RetiroService retiroService;
+
+    public Retiro retiro(RetiroCaso e) {
+        if (e.getRetiroId() == null || e.getSucursalId() == null) return null;
+        return retiroService.findByIdAndSucursalId(e.getRetiroId(), e.getSucursalId());
+    }
+}

--- a/src/main/java/com/franco/dev/repository/financiero/MovimientoCajaVirtualRepository.java
+++ b/src/main/java/com/franco/dev/repository/financiero/MovimientoCajaVirtualRepository.java
@@ -26,6 +26,17 @@ public interface MovimientoCajaVirtualRepository extends JpaRepository<Movimient
     List<MovimientoCajaVirtual> findByOrigenTipoAndOrigenIdAndActivoTrue(OrigenMovimientoTipo origenTipo, Long origenId);
 
     /**
+     * Igual que el anterior pero acotado a la sucursal del documento de origen.
+     *
+     * <p>Hace falta cuando el origen tiene PK compuesta: el id de un Retiro no es global —cada
+     * filial numera desde 1— y una caja mayor recibe retiros de varias sucursales, así que
+     * buscar solo por (origenTipo, origenId) devuelve movimientos de retiros ajenos que
+     * casualmente comparten el número.</p>
+     */
+    List<MovimientoCajaVirtual> findByOrigenTipoAndOrigenIdAndOrigenSucursalIdAndActivoTrue(
+            OrigenMovimientoTipo origenTipo, Long origenId, Long origenSucursalId);
+
+    /**
      * Filtro combinado de movimientos (todos opcionales salvo la caja). soloActivos=true oculta anulados.
      * {@code tipo} llega como String (name del enum) y se compara contra la columna casteada a texto:
      * el enum es nativo de Postgres y un bind param nulo de enum rompe con 42P18. Castear a texto lo evita.

--- a/src/main/java/com/franco/dev/repository/financiero/RetiroCasoRepository.java
+++ b/src/main/java/com/franco/dev/repository/financiero/RetiroCasoRepository.java
@@ -1,0 +1,54 @@
+package com.franco.dev.repository.financiero;
+
+import com.franco.dev.domain.financiero.RetiroCaso;
+import com.franco.dev.domain.financiero.enums.EstadoCasoRetiro;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RetiroCasoRepository extends JpaRepository<RetiroCaso, Long> {
+
+    Optional<RetiroCaso> findByRetiroIdAndSucursalId(Long retiroId, Long sucursalId);
+
+    /**
+     * El caso de una verificación puntual.
+     *
+     * Un mismo retiro puede acumular varios casos: si se anula la verificación, el retiro
+     * vuelve a flotar y al recontarlo con diferencia se abre otro. Buscar por (retiro,
+     * sucursal) devolvía más de una fila y reventaba con IncorrectResultSizeDataAccessException,
+     * dejando la anulación rota para ese retiro hasta tocar la base a mano.
+     */
+    Optional<RetiroCaso> findByVerificacionId(Long verificacionId);
+
+    /**
+     * La bandeja, con sus filtros. Todos opcionales.
+     *
+     * El estado llega como String y se compara contra la columna casteada a texto: es el
+     * mismo patrón que usa el filtro de movimientos de caja, para que un bind nulo no rompa.
+     * Las fechas van con cast a timestamp por la misma razón.
+     */
+    @Query("select c from RetiroCaso c where (:estado is null or cast(c.estado as string) = :estado) "
+            + "and (:sucursalId is null or c.sucursalId = :sucursalId) "
+            + "and (:retiroId is null or c.retiroId = :retiroId) "
+            + "and (cast(:desde as timestamp) is null or c.creadoEn >= :desde) "
+            + "and (cast(:hasta as timestamp) is null or c.creadoEn <= :hasta) "
+            // "Solo los míos": en investigación son los asignados a uno; en resueltos, los que
+            // uno cerró. Un único parámetro cubre las dos tabs sin lógica extra del lado del front.
+            + "and (:usuarioId is null or c.asignadoA.id = :usuarioId or c.resueltoPor.id = :usuarioId) "
+            + "order by c.creadoEn desc")
+    Page<RetiroCaso> filter(@Param("estado") String estado,
+                            @Param("sucursalId") Long sucursalId,
+                            @Param("retiroId") Long retiroId,
+                            @Param("desde") java.time.LocalDateTime desde,
+                            @Param("hasta") java.time.LocalDateTime hasta,
+                            @Param("usuarioId") Long usuarioId,
+                            Pageable pageable);
+
+    long countByEstado(EstadoCasoRetiro estado);
+}

--- a/src/main/java/com/franco/dev/repository/financiero/RetiroRepository.java
+++ b/src/main/java/com/franco/dev/repository/financiero/RetiroRepository.java
@@ -27,6 +27,23 @@ public interface RetiroRepository extends HelperRepository<Retiro, EmbebedPrimar
 
     public Retiro findByIdAndSucursalId(Long id, Long sucId);
 
+    /**
+     * Toma el retiro con lock pesimista para verificarlo.
+     *
+     * <p>Sin esto, dos tesoreros verificando el mismo retiro a la vez (o un doble click, o un
+     * reintento de red) leen los dos que no hay verificación, cuentan cada uno lo suyo y
+     * acreditan dos veces la misma plata en la caja mayor. El índice único sobre
+     * {@code retiro_verificacion} es la red de abajo, pero falla con un error feo; el lock
+     * serializa antes y el segundo ve la verificación que dejó el primero.</p>
+     *
+     * <p>Mismo patrón que {@code asegurarSolicitud} en RRHH, documentado ahí por la misma
+     * razón: un doble click pagaba dos veces el mismo sueldo.</p>
+     */
+    @org.springframework.data.jpa.repository.Lock(javax.persistence.LockModeType.PESSIMISTIC_WRITE)
+    @org.springframework.data.jpa.repository.Query("select r from Retiro r where r.id = :id and r.sucursalId = :sucId")
+    java.util.Optional<Retiro> lockByIdAndSucursalId(@org.springframework.data.repository.query.Param("id") Long id,
+                                                     @org.springframework.data.repository.query.Param("sucId") Long sucId);
+
     public List<Retiro> findByCajaSalidaId(Long id);
 
     /** Retiros destinados a una caja mayor, aún no posteados y ya concluidos (poller de tesorería, F3). */

--- a/src/main/java/com/franco/dev/repository/financiero/RetiroVerificacionRepository.java
+++ b/src/main/java/com/franco/dev/repository/financiero/RetiroVerificacionRepository.java
@@ -1,0 +1,29 @@
+package com.franco.dev.repository.financiero;
+
+import com.franco.dev.domain.financiero.RetiroVerificacion;
+import com.franco.dev.domain.financiero.enums.ResultadoVerificacionRetiro;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface RetiroVerificacionRepository extends JpaRepository<RetiroVerificacion, Long> {
+
+    /** La verificación vigente de un retiro, si tiene. Las anuladas no cuentan. */
+    @Query("select v from RetiroVerificacion v where v.retiroId = :retiroId "
+            + "and v.sucursalId = :sucId and v.anulada = false")
+    Optional<RetiroVerificacion> findVigente(@Param("retiroId") Long retiroId, @Param("sucId") Long sucId);
+
+    /**
+     * Verificaciones con diferencia, para la bandeja.
+     *
+     * Se filtra por resultado y no por la existencia de un caso: un caso puede haberse
+     * resuelto y la verificación sigue siendo el registro de que hubo diferencia.
+     */
+    List<RetiroVerificacion> findByResultadoAndAnuladaFalseOrderByCreadoEnDesc(
+            ResultadoVerificacionRetiro resultado);
+}

--- a/src/main/java/com/franco/dev/service/financiero/OperacionFinancieraService.java
+++ b/src/main/java/com/franco/dev/service/financiero/OperacionFinancieraService.java
@@ -47,24 +47,57 @@ public class OperacionFinancieraService {
     @Transactional
     public OperacionFinanciera registrar(OperacionFinanciera op, Usuario usuario) {
         req(op.getTipoOperacion() != null, "Tipo de operación requerido");
+        derivarMonedasDeCuentas(op);
+        validarDestinoDeDiferencia(op);
         op.setUsuario(usuario);
         op.setAnulado(false);
         OperacionFinanciera saved = repository.save(op);
 
         TipoOperacionFinanciera t = op.getTipoOperacion();
         switch (t) {
-            case CAMBIO_DIVISA:
-                req(op.getCajaMayorOrigen() != null && op.getCajaMayorDestino() != null,
-                        "Cambio de divisa requiere caja origen y destino");
-                // Orden canónico de lock (id de caja ascendente) para evitar deadlock A→B / B→A.
-                if (op.getCajaMayorOrigen().getId() <= op.getCajaMayorDestino().getId()) {
-                    cajaMov(op.getCajaMayorOrigen(), CajaVirtualTipoMovimiento.EGRESO, op.getMontoOrigen(), op.getMonedaOrigen(), saved, usuario);
-                    cajaMov(op.getCajaMayorDestino(), CajaVirtualTipoMovimiento.INGRESO, op.getMontoDestino(), op.getMonedaDestino(), saved, usuario);
-                } else {
-                    cajaMov(op.getCajaMayorDestino(), CajaVirtualTipoMovimiento.INGRESO, op.getMontoDestino(), op.getMonedaDestino(), saved, usuario);
-                    cajaMov(op.getCajaMayorOrigen(), CajaVirtualTipoMovimiento.EGRESO, op.getMontoOrigen(), op.getMonedaOrigen(), saved, usuario);
-                }
+            case CAMBIO_DIVISA: {
+                // Cada lado puede ser una caja mayor o una cuenta bancaria: los cambios entre
+                // cuentas son tan comunes como los de mostrador, y antes había que registrarlos
+                // como dos operaciones sueltas, perdiendo la relación entre las dos patas.
+                boolean cajaOrig = op.getCajaMayorOrigen() != null;
+                boolean bancoOrig = op.getCuentaBancariaOrigen() != null;
+                boolean cajaDest = op.getCajaMayorDestino() != null;
+                boolean bancoDest = op.getCuentaBancariaDestino() != null;
+                req(cajaOrig ^ bancoOrig, "Elegí una caja mayor o una cuenta bancaria de origen, no las dos");
+                req(cajaDest ^ bancoDest, "Elegí una caja mayor o una cuenta bancaria de destino, no las dos");
+                req(!(bancoOrig && bancoDest
+                                && op.getCuentaBancariaOrigen().getId().equals(op.getCuentaBancariaDestino().getId())),
+                        "La cuenta de origen y la de destino no pueden ser la misma");
+
+                Runnable salida = () -> {
+                    if (cajaOrig) {
+                        cajaMov(op.getCajaMayorOrigen(), CajaVirtualTipoMovimiento.EGRESO,
+                                montoOrigen(op), op.getMonedaOrigen(), saved, usuario);
+                    } else {
+                        bancoLedgerService.registrar(op.getCuentaBancariaOrigen().getId(),
+                                MovimientoBancarioTipo.SALIDA_MANUAL, montoOrigen(op),
+                                "Cambio de divisa (op #" + saved.getId() + ")",
+                                OrigenMovimientoTipo.OPERACION_FINANCIERA.name(), saved.getId(), usuario);
+                    }
+                };
+                Runnable entrada = () -> {
+                    if (cajaDest) {
+                        cajaMov(op.getCajaMayorDestino(), CajaVirtualTipoMovimiento.INGRESO,
+                                montoDestino(op), op.getMonedaDestino(), saved, usuario);
+                    } else {
+                        bancoLedgerService.registrar(op.getCuentaBancariaDestino().getId(),
+                                MovimientoBancarioTipo.ENTRADA_MANUAL, montoDestino(op),
+                                "Cambio de divisa (op #" + saved.getId() + ")",
+                                OrigenMovimientoTipo.OPERACION_FINANCIERA.name(), saved.getId(), usuario);
+                    }
+                };
+                ejecutarEnOrden(
+                        new Pata(salida, cajaOrig ? op.getCajaMayorOrigen().getId() : null,
+                                bancoOrig ? op.getCuentaBancariaOrigen().getId() : null),
+                        new Pata(entrada, cajaDest ? op.getCajaMayorDestino().getId() : null,
+                                bancoDest ? op.getCuentaBancariaDestino().getId() : null));
                 break;
+            }
             case DEPOSITO_BANCARIO:
                 req(op.getCajaMayorOrigen() != null && op.getCuentaBancariaDestino() != null,
                         "Depósito requiere caja origen y cuenta bancaria destino");
@@ -76,10 +109,14 @@ public class OperacionFinancieraService {
             case RETIRO_BANCARIO:
                 req(op.getCuentaBancariaOrigen() != null && op.getCajaMayorDestino() != null,
                         "Retiro bancario requiere cuenta origen y caja destino");
+                // Caja ANTES que banco, igual que el depósito. Antes era al revés, y con el
+                // cambio de divisa mixto tocando estos mismos recursos ese orden inverso
+                // alcanzaba para trabar un retiro contra un cambio simultáneo: los dos locks
+                // son SELECT FOR UPDATE, que espera, no falla rápido.
+                cajaMov(op.getCajaMayorDestino(), CajaVirtualTipoMovimiento.INGRESO, op.getMontoDestino(), op.getMonedaDestino(), saved, usuario);
                 bancoLedgerService.registrar(op.getCuentaBancariaOrigen().getId(), MovimientoBancarioTipo.SALIDA_MANUAL,
                         montoOrigen(op), "Retiro bancario (op #" + saved.getId() + ")",
                         OrigenMovimientoTipo.OPERACION_FINANCIERA.name(), saved.getId(), usuario);
-                cajaMov(op.getCajaMayorDestino(), CajaVirtualTipoMovimiento.INGRESO, op.getMontoDestino(), op.getMonedaDestino(), saved, usuario);
                 break;
             case TRANSFERENCIA_ENTRE_CAJAS:
                 req(op.getCajaMayorOrigen() != null && op.getCajaMayorDestino() != null,
@@ -116,19 +153,25 @@ public class OperacionFinancieraService {
         return saved;
     }
 
+    /** Trae una operación financiera por id (para el detalle read-only en caja mayor). */
+    @Transactional(readOnly = true)
+    public OperacionFinanciera porId(Long id) {
+        return id != null ? repository.findById(id).orElse(null) : null;
+    }
+
     /**
      * Anula una operación financiera completa desde la caja mayor: revierte TODAS sus patas
      * (ambas patas de caja de un cambio de divisa / transferencia entre cajas, la pata de caja
      * + la pata bancaria de un depósito/retiro, las dos patas bancarias de una transferencia
      * bancaria, y el AJUSTE de diferencia si lo hubo) de forma atómica. Cada pata se revierte
      * con su contra-movimiento (ledger inmutable). Idempotente por el flag {@code anulado}.
+     *
+     * El @Transactional estaba sobre porId(): alguien insertó ese método entre este javadoc y
+     * su firma y se llevó la anotación puesta. Sin transacción, cada revertir() commiteaba por
+     * su cuenta y una falla a mitad de camino —un descubierto al revertir una entrada, por
+     * ejemplo— dejaba la operación con una pata movida y el flag `anulado` todavía en false.
      */
     @Transactional
-    /** Trae una operación financiera por id (para el detalle read-only en caja mayor). */
-    public OperacionFinanciera porId(Long id) {
-        return id != null ? repository.findById(id).orElse(null) : null;
-    }
-
     public OperacionFinanciera anular(Long operacionId, String motivo, Usuario usuario) {
         OperacionFinanciera op = repository.findById(operacionId)
                 .orElseThrow(() -> new GraphQLException("Operación financiera no encontrada: " + operacionId));
@@ -158,18 +201,37 @@ public class OperacionFinancieraService {
      * (o la de origen si no hay destino). No aplica a TRANSFERENCIA_BANCARIA (no toca caja).
      * Igual que gourmet: no crea un Gasto/Vale real, solo un ajuste de caja rotulado.
      */
-    private void aplicarDiferencia(OperacionFinanciera op, OperacionFinanciera saved, Usuario usuario) {
-        // TRANSFERENCIA_BANCARIA no toca caja mayor: no hay dónde imputar la diferencia. Se ignora.
-        if (op.getTipoOperacion() == TipoOperacionFinanciera.TRANSFERENCIA_BANCARIA) return;
-
-        com.franco.dev.domain.financiero.enums.DiferenciaDestinoTipo destino = op.getDiferenciaDestinoTipo();
+    /** true si la operación trae una diferencia que hay que imputar en alguna caja mayor. */
+    private boolean pideImputarDiferencia(OperacionFinanciera op) {
         BigDecimal dif = op.getDiferencia();
-        if (dif == null || dif.signum() == 0) return;
-        if (destino == null || destino == com.franco.dev.domain.financiero.enums.DiferenciaDestinoTipo.IGNORAR) return;
+        if (dif == null || dif.signum() == 0) return false;
+        com.franco.dev.domain.financiero.enums.DiferenciaDestinoTipo destino = op.getDiferenciaDestinoTipo();
+        return destino != null
+                && destino != com.franco.dev.domain.financiero.enums.DiferenciaDestinoTipo.IGNORAR;
+    }
+
+    /**
+     * La diferencia se imputa como un AJUSTE en una caja mayor, así que si la operación no toca
+     * ninguna —una transferencia bancaria, o un cambio de divisa entre dos cuentas— no hay dónde
+     * ponerla. Se valida antes de postear: fallar después deja el rollback correcto pero un
+     * mensaje que llega cuando el usuario ya cree que grabó.
+     *
+     * El criterio es "hay caja mayor", no el tipo de operación: desde que el cambio de divisa
+     * puede ser banco a banco, atarlo al enum dejaba ese caso afuera del control.
+     */
+    private void validarDestinoDeDiferencia(OperacionFinanciera op) {
+        if (!pideImputarDiferencia(op)) return;
+        req(op.getCajaMayorOrigen() != null || op.getCajaMayorDestino() != null,
+                "Esta operación no toca ninguna caja mayor: la diferencia no tiene dónde imputarse");
+    }
+
+    private void aplicarDiferencia(OperacionFinanciera op, OperacionFinanciera saved, Usuario usuario) {
+        if (!pideImputarDiferencia(op)) return;
 
         CajaVirtual caja = op.getCajaMayorDestino() != null ? op.getCajaMayorDestino() : op.getCajaMayorOrigen();
         Moneda moneda = op.getCajaMayorDestino() != null ? op.getMonedaDestino() : op.getMonedaOrigen();
-        req(caja != null, "La diferencia requiere una caja mayor donde imputarse");
+        BigDecimal dif = op.getDiferencia();
+        com.franco.dev.domain.financiero.enums.DiferenciaDestinoTipo destino = op.getDiferenciaDestinoTipo();
 
         MovimientoCajaVirtual m = new MovimientoCajaVirtual();
         m.setCajaVirtual(caja);
@@ -184,6 +246,64 @@ public class OperacionFinancieraService {
         m.setOrigenTipo(OrigenMovimientoTipo.OPERACION_FINANCIERA);
         m.setOrigenId(saved.getId());
         tesoreriaService.registrar(m);
+    }
+
+    /**
+     * Una pata del asiento junto con los recursos que va a lockear.
+     *
+     * Solo uno de los dos ids está seteado: la pata toca una caja mayor o una cuenta bancaria.
+     */
+    private static final class Pata {
+        final Runnable accion;
+        final Long cajaId;
+        final Long cuentaId;
+
+        Pata(Runnable accion, Long cajaId, Long cuentaId) {
+            this.accion = accion;
+            this.cajaId = cajaId;
+            this.cuentaId = cuentaId;
+        }
+
+        /**
+         * Clave de ordenamiento: primero todas las cajas (por id), después todas las cuentas
+         * (por id). Los ids de caja y de cuenta viven en tablas distintas, así que compararlos
+         * entre sí no significa nada — hace falta separarlos por tipo primero.
+         */
+        long[] clave() {
+            return cajaId != null ? new long[]{0, cajaId} : new long[]{1, cuentaId != null ? cuentaId : 0};
+        }
+    }
+
+    /**
+     * Ejecuta las dos patas en orden canónico: cajas antes que bancos, y dentro de cada grupo
+     * por id ascendente.
+     *
+     * Sin un orden único y global, dos operaciones simultáneas que tocan los mismos dos
+     * recursos en sentido contrario se traban entre sí. No alcanza con ordenar dentro de una
+     * operación: el orden tiene que ser el mismo en todos los flujos que lockean caja y banco.
+     */
+    private void ejecutarEnOrden(Pata a, Pata b) {
+        long[] ka = a.clave(), kb = b.clave();
+        boolean primeroA = ka[0] != kb[0] ? ka[0] < kb[0] : ka[1] <= kb[1];
+        if (primeroA) { a.accion.run(); b.accion.run(); }
+        else { b.accion.run(); a.accion.run(); }
+    }
+
+    /**
+     * La moneda de una pata bancaria la manda la cuenta, no el formulario.
+     *
+     * {@code MovimientoBancario} no guarda moneda — la de la cuenta es la única que existe — así
+     * que el campo de la operación es exhibición. Derivarlo en vez de validarlo evita rechazar
+     * operaciones que hoy funcionan con el campo en null, y hace imposible que quede exhibida
+     * una moneda distinta de la real.
+     */
+    private void derivarMonedasDeCuentas(OperacionFinanciera op) {
+        if (op.getCuentaBancariaOrigen() != null && op.getCuentaBancariaOrigen().getMoneda() != null) {
+            op.setMonedaOrigen(op.getCuentaBancariaOrigen().getMoneda());
+        }
+        if (op.getCuentaBancariaDestino() != null && op.getCuentaBancariaDestino().getMoneda() != null) {
+            op.setMonedaDestino(op.getCuentaBancariaDestino().getMoneda());
+        }
     }
 
     private BigDecimal montoOrigen(OperacionFinanciera op) {

--- a/src/main/java/com/franco/dev/service/financiero/PagoProveedorService.java
+++ b/src/main/java/com/franco/dev/service/financiero/PagoProveedorService.java
@@ -417,7 +417,22 @@ public class PagoProveedorService {
                 g.suma = g.suma.add(l.getMonto() != null ? l.getMonto() : BigDecimal.ZERO);
             }
         }
-        for (GrupoMov g : grupos.values()) {
+        // Orden canónico de lock: primero las cajas (por id), después las cuentas bancarias (por
+        // id). Hasta acá los grupos se posteaban en el orden en que el cliente mandó las líneas,
+        // así que dos pagos simultáneos sobre la misma caja y la misma cuenta podían tomarlas en
+        // sentido contrario y trabarse — los dos locks son SELECT FOR UPDATE, que espera.
+        // Es el mismo orden que usa OperacionFinancieraService: el orden tiene que ser único
+        // entre todos los flujos que lockean caja y banco, no dentro de cada uno.
+        List<GrupoMov> gruposOrdenados = new ArrayList<>(grupos.values());
+        gruposOrdenados.sort((x, y) -> {
+            int tipoX = x.fuente == FuentePago.CAJA_MAYOR ? 0 : 1;
+            int tipoY = y.fuente == FuentePago.CAJA_MAYOR ? 0 : 1;
+            if (tipoX != tipoY) return Integer.compare(tipoX, tipoY);
+            Long idX = tipoX == 0 ? x.cajaVirtualId : x.cuentaBancariaId;
+            Long idY = tipoY == 0 ? y.cajaVirtualId : y.cuentaBancariaId;
+            return Long.compare(idX != null ? idX : 0L, idY != null ? idY : 0L);
+        });
+        for (GrupoMov g : gruposOrdenados) {
             if (g.suma.signum() <= 0) throw new GraphQLException("Monto de línea inválido");
             if (g.fuente == FuentePago.CAJA_MAYOR) {
                 Moneda moneda = g.monedaId != null ? monedaRepository.findById(g.monedaId).orElse(null) : null;

--- a/src/main/java/com/franco/dev/service/financiero/RetiroVerificacionService.java
+++ b/src/main/java/com/franco/dev/service/financiero/RetiroVerificacionService.java
@@ -1,0 +1,262 @@
+package com.franco.dev.service.financiero;
+
+import com.franco.dev.domain.financiero.*;
+import com.franco.dev.domain.financiero.enums.CajaVirtualTipoMovimiento;
+import com.franco.dev.domain.financiero.enums.CategoriaDiferenciaRetiro;
+import com.franco.dev.domain.financiero.enums.EstadoCasoRetiro;
+import com.franco.dev.domain.financiero.enums.OrigenMovimientoTipo;
+import com.franco.dev.domain.financiero.enums.ResultadoVerificacionRetiro;
+import com.franco.dev.domain.personas.Usuario;
+import com.franco.dev.repository.financiero.*;
+import graphql.GraphQLException;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.*;
+
+/**
+ * Verificación de un retiro de PDV al recibirlo en tesorería.
+ *
+ * <p>El que recibe cuenta la plata contra lo que declaró el PDV, y <b>a la caja mayor entra lo
+ * contado</b>. El retiro y su detalle no se tocan nunca: son la declaración del origen y son la
+ * evidencia. La diferencia vive en la verificación, y si la hay se abre un caso para que otro
+ * lo investigue — el que recibe no investiga.</p>
+ *
+ * <p>Todo ocurre en una transacción: verificar, acreditar y marcar el retiro. Es el mismo
+ * patrón atómico de {@link RetiroIngresoService}, y es lo que evita que el poller heredado se
+ * cuele entre la asignación de caja y el posteo.</p>
+ */
+@Service
+@AllArgsConstructor
+public class RetiroVerificacionService {
+
+    private final RetiroRepository retiroRepository;
+    private final RetiroDetalleService retiroDetalleService;
+    private final RetiroVerificacionRepository verificacionRepository;
+    private final RetiroCasoRepository casoRepository;
+    private final MovimientoCajaVirtualRepository movimientoRepository;
+    private final CajaVirtualService cajaVirtualService;
+    private final MonedaService monedaService;
+    private final TesoreriaService tesoreriaService;
+    private final TesoreriaSecurityService seguridad;
+    private final com.franco.dev.service.empresarial.SucursalService sucursalService;
+
+    /** Lo que el usuario contó de una moneda. */
+    @Data
+    public static class ConteoMoneda {
+        private Long monedaId;
+        private BigDecimal contado;
+        private CategoriaDiferenciaRetiro categoria;
+    }
+
+    /**
+     * Cuenta un retiro, lo acredita y lo cierra.
+     *
+     * @param rapida true si se confirmó lo declarado sin contar por denominación. Queda
+     *               marcado: si después aparece una diferencia, hay que poder saber que ese
+     *               retiro nunca se contó billete por billete.
+     */
+    @Transactional
+    public RetiroVerificacion verificar(Long retiroId, Long sucursalId, Long cajaVirtualId,
+                                        List<ConteoMoneda> conteos, boolean rapida,
+                                        String observacion, Usuario usuario) {
+
+        // Lock pesimista antes de mirar nada: sin esto dos tesoreros (o un doble click) leen
+        // los dos que no hay verificación y acreditan dos veces la misma plata. El índice
+        // único de retiro_verificacion es la red de abajo; el lock serializa antes.
+        // El ACL de la caja se exige acá y no solo en TesoreriaService.registrar: un retiro
+        // contado en cero no postea ningún movimiento, así que ese choke point no se ejecuta y
+        // el retiro terminaba asignado a una caja sobre la que el usuario no tiene permiso.
+        seguridad.requireEscrituraCaja(cajaVirtualId);
+
+        Retiro retiro = retiroRepository.lockByIdAndSucursalId(retiroId, sucursalId)
+                .orElseThrow(() -> new GraphQLException("Retiro no encontrado: " + retiroId + "/" + sucursalId));
+
+        if (retiro.getMovimientoCajaVirtualId() != null) {
+            throw new GraphQLException("El retiro #" + retiroId + " ya fue ingresado a una caja mayor");
+        }
+        verificacionRepository.findVigente(retiroId, sucursalId).ifPresent(v -> {
+            throw new GraphQLException("El retiro #" + retiroId + " ya fue verificado");
+        });
+
+        CajaVirtual caja = cajaVirtualService.findById(cajaVirtualId)
+                .orElseThrow(() -> new GraphQLException("Caja mayor no encontrada: " + cajaVirtualId));
+
+        Map<Long, BigDecimal> declaradoPorMoneda = declaradoPorMoneda(retiro);
+        Map<Long, ConteoMoneda> contadoPorMoneda = new LinkedHashMap<>();
+        for (ConteoMoneda c : conteos != null ? conteos : Collections.<ConteoMoneda>emptyList()) {
+            if (c.getMonedaId() == null) continue;
+            contadoPorMoneda.put(c.getMonedaId(), c);
+        }
+
+        RetiroVerificacion verificacion = new RetiroVerificacion();
+        verificacion.setRetiroId(retiroId);
+        verificacion.setSucursalId(sucursalId);
+        verificacion.setUsuario(usuario);
+        verificacion.setCreadoEn(LocalDateTime.now());
+        verificacion.setRapida(rapida);
+        verificacion.setObservacion(observacion != null ? observacion.toUpperCase() : null);
+        verificacion.setAnulada(false);
+
+        // La comparación es por moneda y nunca por total convertido: un retiro puede cerrar en
+        // el total y tener 100 R$ de menos con su equivalente de más en guaraníes. Eso es un
+        // cambio informal hecho en el camino, no un retiro correcto.
+        Set<Long> monedas = new LinkedHashSet<>();
+        monedas.addAll(declaradoPorMoneda.keySet());
+        monedas.addAll(contadoPorMoneda.keySet());
+
+        boolean hayDiferencia = false;
+        for (Long monedaId : monedas) {
+            BigDecimal declarado = declaradoPorMoneda.getOrDefault(monedaId, BigDecimal.ZERO);
+            ConteoMoneda c = contadoPorMoneda.get(monedaId);
+            BigDecimal contado = c != null && c.getContado() != null ? c.getContado() : BigDecimal.ZERO;
+            BigDecimal diferencia = contado.subtract(declarado);
+
+            RetiroVerificacionDetalle d = new RetiroVerificacionDetalle();
+            d.setMoneda(monedaService.findById(monedaId).orElse(null));
+            d.setDeclarado(declarado);
+            d.setContado(contado);
+            d.setDiferencia(diferencia);
+            if (diferencia.signum() != 0) {
+                hayDiferencia = true;
+                d.setCategoria(c != null && c.getCategoria() != null
+                        ? c.getCategoria()
+                        : (diferencia.signum() < 0 ? CategoriaDiferenciaRetiro.FALTANTE
+                                                   : CategoriaDiferenciaRetiro.SOBRANTE));
+            }
+            verificacion.agregarDetalle(d);
+        }
+
+        verificacion.setResultado(hayDiferencia
+                ? ResultadoVerificacionRetiro.CON_DIFERENCIA
+                : ResultadoVerificacionRetiro.SIN_DIFERENCIA);
+        RetiroVerificacion guardada = verificacionRepository.save(verificacion);
+
+        acreditar(retiro, caja, guardada, usuario);
+
+        // Los estados de verificación existen en el enum desde V0, en central y en toda
+        // filial: emitirlos no puede cortar la réplica. Este UPDATE sí baja a la filial
+        // (V155.1 habilitó central -> filial para la cabecera del retiro).
+        retiro.setEstado(hayDiferencia
+                ? com.franco.dev.domain.financiero.enums.EstadoRetiro.VERIFICADO_CONCLUIDO_CON_PROBLEMA
+                : com.franco.dev.domain.financiero.enums.EstadoRetiro.VERIFICADO_CONCLUIDO_SIN_PROBLEMA);
+        retiro.setCajaVirtualId(cajaVirtualId);
+        retiroRepository.save(retiro);
+
+        if (hayDiferencia) abrirCaso(guardada, usuario);
+
+        return guardada;
+    }
+
+    /** Lo que declaró el PDV, agrupado por moneda. Se lee del retiro_detalle, que es inmutable. */
+    private Map<Long, BigDecimal> declaradoPorMoneda(Retiro retiro) {
+        Map<Long, BigDecimal> porMoneda = new LinkedHashMap<>();
+        List<RetiroDetalle> detalles = retiroDetalleService.findByRetiroId(retiro.getId(), retiro.getSucursalId());
+        for (RetiroDetalle d : detalles) {
+            if (d.getMoneda() == null || d.getCantidad() == null) continue;
+            porMoneda.merge(d.getMoneda().getId(), BigDecimal.valueOf(d.getCantidad()), BigDecimal::add);
+        }
+        return porMoneda;
+    }
+
+    /**
+     * Postea en la caja mayor <b>lo contado</b>, una línea por moneda.
+     *
+     * El movimiento lleva {@code origenSucursalId} además del {@code origenId}: el id del
+     * retiro no es global (cada filial numera desde 1) y una caja mayor recibe retiros de
+     * varias sucursales, así que sin la sucursal no se puede volver a encontrar el movimiento
+     * de <i>este</i> retiro.
+     */
+    private void acreditar(Retiro retiro, CajaVirtual caja, RetiroVerificacion verificacion, Usuario usuario) {
+        // Misma descripción que arma el poller, para que el historial de caja se lea igual
+        // venga por donde venga.
+        String nombreSucursal = sucursalService.findById(retiro.getSucursalId())
+                .map(com.franco.dev.domain.empresarial.Sucursal::getNombre)
+                .orElse("Sucursal " + retiro.getSucursalId());
+        String descripcion = "Retiro #" + retiro.getId() + " - " + nombreSucursal;
+
+        Long ultimoMovId = null;
+        for (RetiroVerificacionDetalle d : verificacion.getDetalles()) {
+            if (d.getContado() == null || d.getContado().signum() <= 0) continue;
+            MovimientoCajaVirtual mov = new MovimientoCajaVirtual();
+            mov.setCajaVirtual(caja);
+            mov.setTipoMovimiento(CajaVirtualTipoMovimiento.INGRESO);
+            mov.setCantidad(d.getContado().doubleValue());
+            mov.setMoneda(d.getMoneda());
+            mov.setUsuario(usuario);
+            mov.setDescripcion(descripcion);
+            mov.setReferenciaId(retiro.getId());
+            mov.setOrigenTipo(OrigenMovimientoTipo.RETIRO_CAJA);
+            mov.setOrigenId(retiro.getId());
+            mov.setOrigenSucursalId(retiro.getSucursalId());
+            ultimoMovId = tesoreriaService.registrar(mov).getId();
+        }
+        // -1 marca "verificado y procesado, sin movimientos" (un retiro contado en cero).
+        retiro.setMovimientoCajaVirtualId(ultimoMovId != null ? ultimoMovId : -1L);
+    }
+
+    private void abrirCaso(RetiroVerificacion verificacion, Usuario usuario) {
+        RetiroCaso caso = new RetiroCaso();
+        caso.setRetiroId(verificacion.getRetiroId());
+        caso.setSucursalId(verificacion.getSucursalId());
+        caso.setVerificacion(verificacion);
+        caso.setEstado(EstadoCasoRetiro.ABIERTO);
+        caso.setAbiertoPor(usuario);
+        caso.setCreadoEn(LocalDateTime.now());
+        casoRepository.save(caso);
+    }
+
+    /**
+     * Deshace una verificación ya acreditada: el que recibe también se puede equivocar.
+     *
+     * Los movimientos se ubican por {@code (origenTipo, origenId, origenSucursalId)} — sin la
+     * sucursal se revertirían los de un retiro homónimo de otra filial.
+     */
+    @Transactional
+    public RetiroVerificacion anular(Long verificacionId, String motivo, Usuario usuario) {
+        RetiroVerificacion v = verificacionRepository.findById(verificacionId)
+                .orElseThrow(() -> new GraphQLException("Verificación no encontrada: " + verificacionId));
+        if (Boolean.TRUE.equals(v.getAnulada())) {
+            throw new GraphQLException("La verificación ya está anulada");
+        }
+        Retiro retiro = retiroRepository.lockByIdAndSucursalId(v.getRetiroId(), v.getSucursalId())
+                .orElseThrow(() -> new GraphQLException("Retiro no encontrado"));
+
+        List<MovimientoCajaVirtual> movimientos = movimientoRepository
+                .findByOrigenTipoAndOrigenIdAndOrigenSucursalIdAndActivoTrue(
+                        OrigenMovimientoTipo.RETIRO_CAJA, v.getRetiroId(), v.getSucursalId());
+        for (MovimientoCajaVirtual m : movimientos) {
+            tesoreriaService.revertir(m, motivo, usuario);
+        }
+
+        v.setAnulada(true);
+        verificacionRepository.save(v);
+
+        // Vuelve a flotar: sin caja asignada y sin movimiento, listo para verificarse de nuevo.
+        retiro.setMovimientoCajaVirtualId(null);
+        retiro.setCajaVirtualId(null);
+        retiro.setEstado(com.franco.dev.domain.financiero.enums.EstadoRetiro.CONCLUIDO);
+        retiroRepository.save(retiro);
+
+        // El caso NO se borra: es el registro de que hubo una diferencia y de quién la miró.
+        // Si todavía estaba abierto se cierra sin veredicto — nadie determinó nada, la
+        // verificación se deshizo y al recontar se abrirá uno nuevo. Si ya venía resuelto (el
+        // investigador concluyó "contó mal tesorería" y pidió anular), se deja intacto.
+        casoRepository.findByVerificacionId(v.getId())
+                .ifPresent(caso -> {
+                    if (caso.getEstado() == EstadoCasoRetiro.RESUELTO) return;
+                    caso.setEstado(EstadoCasoRetiro.RESUELTO);
+                    caso.setResolucion("CERRADO POR ANULACION DE LA VERIFICACION"
+                            + (motivo != null && !motivo.isEmpty() ? ": " + motivo.toUpperCase() : ""));
+                    caso.setResueltoPor(usuario);
+                    caso.setResueltoEn(LocalDateTime.now());
+                    casoRepository.save(caso);
+                });
+
+        return v;
+    }
+}

--- a/src/main/resources/db/migration/V214.5__financiero_retiro_verificacion.sql
+++ b/src/main/resources/db/migration/V214.5__financiero_retiro_verificacion.sql
@@ -1,0 +1,118 @@
+-- Verificacion de retiro en tesoreria: el que recibe cuenta la plata contra lo que declaro
+-- el PDV, y a la caja mayor entra LO CONTADO, no lo declarado.
+--
+-- Por que tablas nuevas y no columnas en financiero.retiro:
+--
+--   * financiero.retiro es BRANCH_TO_MAIN y ademas tiene replicate_central_to_branch_with_filter
+--     desde V155.1, o sea que replica en las dos direcciones. Meter un segundo escritor en esa
+--     fila es pedir problemas.
+--   * financiero.retiro_detalle (donde viven los montos) es BRANCH_TO_MAIN a secas: un cambio
+--     hecho en central NUNCA baja a la filial. Corregir ahi dejaria al cajero viendo su monto
+--     original, con PdvCajaService.generarBalance calculando sobre el — divergencia silenciosa.
+--   * retiro.observacion ya tiene dueño: la escribe el cajero en filial al armar el retiro.
+--
+-- El retiro del PDV queda intacto: es la declaracion del origen y es la evidencia. La
+-- correccion es un documento de tesoreria con su propia historia.
+--
+-- ⚠️ NINGUNA de estas tablas se inserta en configuraciones.replication_table.
+-- ReplicationPublicationSyncScheduler corre cada hora en produccion (replication.sync.enabled)
+-- y agrega a la publicacion cualquier tabla que aparezca ahi. El patron habitual del repo es
+-- que la migracion inserte esa fila (ver V150.1, V142.1, V144.3); acá NO va, a proposito.
+-- Son central-only, como el schema rrhh.
+--
+-- No se agrega ningun valor a financiero.estado_retiro: los cuatro estados de verificacion
+-- (NECESITA_VERIFICACION, EN_VERIFICACION, VERIFICADO_CONCLUIDO_SIN_PROBLEMA y _CON_PROBLEMA)
+-- existen desde V0 en central y en toda filial. Agregar etiquetas a un enum replicado es lo
+-- que corto la replica el 2026-08-20 con tipo_dispositivo, y lo que V154.1 ya documentaba.
+
+-- ── Trazabilidad del ledger: el origen necesita la sucursal ──────────────────────────────
+--
+-- Retiro tiene PK compuesta (id, sucursal_id) porque el id NO es global: cada filial numera
+-- desde 1. En la base real el id 1 lo comparten 23 sucursales. movimiento_caja_virtual guarda
+-- solo origen_id (RetiroTesoreriaProcesador descarta la sucursal), asi que buscar los
+-- movimientos de un retiro por (origen_tipo, origen_id) devuelve tambien los de otras
+-- sucursales. Sin esto, revertir una verificacion puede tocar la fila equivocada.
+ALTER TABLE financiero.movimiento_caja_virtual
+    ADD COLUMN IF NOT EXISTS origen_sucursal_id bigint;
+
+COMMENT ON COLUMN financiero.movimiento_caja_virtual.origen_sucursal_id IS
+    'Segunda mitad de la PK del documento de origen, cuando es compuesta (ej. Retiro). '
+    'Null para origenes de PK simple.';
+
+CREATE INDEX IF NOT EXISTS ix_mov_caja_virtual_origen
+    ON financiero.movimiento_caja_virtual (origen_tipo, origen_id, origen_sucursal_id)
+    WHERE origen_id IS NOT NULL;
+
+-- ── Cabecera de la verificacion ──────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS financiero.retiro_verificacion (
+    id              bigserial PRIMARY KEY,
+    retiro_id       bigint      NOT NULL,
+    sucursal_id     bigint      NOT NULL,
+    usuario_id      bigint,
+    creado_en       timestamp   NOT NULL DEFAULT now(),
+    -- SIN_DIFERENCIA | CON_DIFERENCIA
+    resultado       varchar(20) NOT NULL,
+    -- true = se confirmo lo declarado sin contar por denominacion. Si despues aparece una
+    -- diferencia hay que poder saber que ese retiro nunca se conto billete por billete.
+    rapida          boolean     NOT NULL DEFAULT false,
+    observacion     text,
+    anulada         boolean     NOT NULL DEFAULT false,
+    CONSTRAINT retiro_verificacion_retiro_fk
+        FOREIGN KEY (retiro_id, sucursal_id)
+        REFERENCES financiero.retiro (id, sucursal_id)
+);
+
+-- Una verificacion vigente por retiro. Es la defensa de fondo contra el doble clic: dos
+-- tesoreros verificando el mismo retiro a la vez acreditarian dos veces. El servicio ademas
+-- toma lock pesimista sobre el retiro, mismo patron que asegurarSolicitud en RRHH.
+CREATE UNIQUE INDEX IF NOT EXISTS ux_retiro_verificacion_vigente
+    ON financiero.retiro_verificacion (retiro_id, sucursal_id)
+    WHERE anulada = false;
+
+-- ── Detalle por moneda ───────────────────────────────────────────────────────────────────
+--
+-- La comparacion es por moneda y nunca por total convertido: un retiro puede cerrar en el
+-- total y tener 100 R$ de menos con su equivalente de mas en guaranies. Eso no es un retiro
+-- correcto, es un cambio informal hecho en el camino.
+--
+-- La categoria vive aca y no en la cabecera porque un mismo retiro puede ser FALTANTE en una
+-- moneda y SOBRANTE en otra a la vez.
+CREATE TABLE IF NOT EXISTS financiero.retiro_verificacion_detalle (
+    id              bigserial PRIMARY KEY,
+    verificacion_id bigint         NOT NULL REFERENCES financiero.retiro_verificacion (id) ON DELETE CASCADE,
+    moneda_id       bigint         NOT NULL,
+    declarado       numeric(19, 4) NOT NULL,
+    contado         numeric(19, 4) NOT NULL,
+    diferencia      numeric(19, 4) NOT NULL,
+    -- DIFERENCIA_CONTEO | FALTANTE | SOBRANTE | BILLETE_NO_RECIBIBLE | NO_RECIBIDO | OTRO
+    categoria       varchar(30),
+    CONSTRAINT ux_retiro_verif_detalle_moneda UNIQUE (verificacion_id, moneda_id)
+);
+
+-- ── Caso a investigar ────────────────────────────────────────────────────────────────────
+--
+-- Separado a proposito. Si la diferencia queda solo como una observacion del retiro, nadie la
+-- mira. Tesoreria abre el caso y sigue trabajando; otro lo cierra. El que recibe no investiga.
+--
+-- Sin categoria propia: la lleva el detalle, por moneda. El caso agrupa.
+CREATE TABLE IF NOT EXISTS financiero.retiro_caso (
+    id              bigserial PRIMARY KEY,
+    retiro_id       bigint      NOT NULL,
+    sucursal_id     bigint      NOT NULL,
+    verificacion_id bigint      REFERENCES financiero.retiro_verificacion (id),
+    -- ABIERTO | EN_INVESTIGACION | RESUELTO
+    estado          varchar(20) NOT NULL DEFAULT 'ABIERTO',
+    abierto_por     bigint,
+    asignado_a      bigint,
+    resuelto_por    bigint,
+    creado_en       timestamp   NOT NULL DEFAULT now(),
+    resuelto_en     timestamp,
+    resolucion      text,
+    CONSTRAINT retiro_caso_retiro_fk
+        FOREIGN KEY (retiro_id, sucursal_id)
+        REFERENCES financiero.retiro (id, sucursal_id)
+);
+
+CREATE INDEX IF NOT EXISTS ix_retiro_caso_abiertos
+    ON financiero.retiro_caso (estado, creado_en DESC)
+    WHERE estado <> 'RESUELTO';

--- a/src/main/resources/db/migration/V215.5__financiero_retiro_caso_veredicto.sql
+++ b/src/main/resources/db/migration/V215.5__financiero_retiro_caso_veredicto.sql
@@ -1,0 +1,35 @@
+-- Veredicto del caso de retiro: la conclusión del que investiga.
+--
+-- Hasta acá el caso se cerraba con `resolucion`, texto libre. Eso alcanza para dejar constancia
+-- y no alcanza para nada más: no se puede contar cuántos faltantes tuvo una sucursal, ni cuántas
+-- veces contó mal el mismo receptor, que es exactamente el dato por el que este circuito existe.
+--
+-- El veredicto NO reemplaza a `retiro_verificacion_detalle.categoria`: esa es lo que cree el que
+-- recibe, por moneda y sin haber averiguado nada. El veredicto es uno solo por caso y nombra el
+-- lado responsable después de investigar.
+--
+-- Central-only: la tabla no está replicada (ver V214.5).
+
+ALTER TABLE financiero.retiro_caso
+    ADD COLUMN IF NOT EXISTS veredicto VARCHAR(40);
+
+-- A quién se le atribuye la diferencia. Es el funcionario del PDV cuando el veredicto apunta al
+-- lado que entrega, y el usuario que contó cuando apunta a tesorería — por eso apunta a persona,
+-- que es lo único que ambos comparten.
+ALTER TABLE financiero.retiro_caso
+    ADD COLUMN IF NOT EXISTS responsable_persona_id BIGINT
+    REFERENCES personas.persona (id);
+
+-- Cuando el veredicto es REINTEGRADO, el retiro por el que volvió la plata. Sin esto, "se repuso
+-- después" es una afirmación sin respaldo.
+--
+-- Va con su sucursal por el mismo motivo que origen_sucursal_id en movimiento_caja_virtual
+-- (ver V214.5): el id de un retiro no es global — cada filial numera desde 1, así que el id
+-- suelto no identifica nada. Sin la sucursal, dentro de un año nadie sabe a qué retiro apunta.
+ALTER TABLE financiero.retiro_caso
+    ADD COLUMN IF NOT EXISTS reintegro_retiro_id BIGINT;
+ALTER TABLE financiero.retiro_caso
+    ADD COLUMN IF NOT EXISTS reintegro_sucursal_id BIGINT;
+
+CREATE INDEX IF NOT EXISTS idx_retiro_caso_veredicto
+    ON financiero.retiro_caso (veredicto);

--- a/src/main/resources/graphql/financiero/movimiento-caja-virtual.graphqls
+++ b/src/main/resources/graphql/financiero/movimiento-caja-virtual.graphqls
@@ -14,6 +14,10 @@ type MovimientoCajaVirtual {
     activo: Boolean
     creadoEn: Date
     origenTipo: OrigenMovimientoTipo
+    # Documento que originó el movimiento. Van los dos juntos porque origenId solo no
+    # identifica nada cuando el documento tiene PK compuesta (Retiro: (id, sucursalId)).
+    origenId: Int
+    origenSucursalId: Int
     # true si este movimiento es el asiento consolidado de un evento de pago (motor de CPP).
     #
     # No se puede deducir del origenTipo: RRHH_VALE / RRHH_LIQUIDACION_* / RRHH_AGUINALDO los

--- a/src/main/resources/graphql/financiero/retiro-verificacion.graphqls
+++ b/src/main/resources/graphql/financiero/retiro-verificacion.graphqls
@@ -1,0 +1,175 @@
+"""
+Verificación de un retiro de PDV al recibirlo en tesorería.
+
+El retiro del PDV es inmutable: es la declaración del origen. Esto es lo que tesorería contó
+de verdad, y es lo que se acredita en la caja mayor.
+"""
+type RetiroVerificacion {
+    id: ID!
+    retiroId: Int
+    sucursalId: Int
+    usuario: Usuario
+    creadoEn: Date
+    resultado: ResultadoVerificacionRetiro
+    "Se confirmó lo declarado sin contar por denominación."
+    rapida: Boolean
+    observacion: String
+    anulada: Boolean
+    detalles: [RetiroVerificacionDetalle]
+}
+
+"""
+Una moneda dentro de la verificación. La comparación es por moneda y nunca por total
+convertido: un retiro puede cerrar en el total y tener faltante en una moneda con sobrante
+equivalente en otra, que es un cambio informal hecho en el camino.
+"""
+type RetiroVerificacionDetalle {
+    id: ID!
+    moneda: Moneda
+    declarado: Float
+    contado: Float
+    "contado − declarado. Negativo = faltante, positivo = sobrante."
+    diferencia: Float
+    categoria: CategoriaDiferenciaRetiro
+}
+
+"El retiro que no cerró y hay que investigar. Lo abre tesorería; lo cierra otro."
+type RetiroCaso {
+    id: ID!
+    retiroId: Int
+    sucursalId: Int
+    verificacion: RetiroVerificacion
+    estado: EstadoCasoRetiro
+    abiertoPor: Usuario
+    asignadoA: Usuario
+    resueltoPor: Usuario
+    creadoEn: Date
+    resueltoEn: Date
+    resolucion: String
+    "Qué se determinó. Null en un caso abierto, y también en uno cerrado por anulación."
+    veredicto: VeredictoCasoRetiro
+    "A quién se le atribuye la diferencia. Puede estar de cualquiera de los dos lados."
+    responsablePersona: Persona
+    "Solo con veredicto REINTEGRADO: el retiro por el que volvió la plata."
+    reintegroRetiroId: Int
+    "La sucursal de ese retiro: el id solo no lo identifica entre filiales."
+    reintegroSucursalId: Int
+    "El lado que entrega: quién hizo el retiro y de qué caja salió."
+    retiro: Retiro
+}
+
+"""
+Conclusión del que investiga. No confundir con CategoriaDiferenciaRetiro, que es lo que cree
+el que recibe en el momento de contar: esto es lo que se determinó después.
+"""
+enum VeredictoCasoRetiro {
+    ERROR_DE_CONTEO_TESORERIA
+    "Al sobre le faltó: vino menos de lo declarado. Se mide desde el sobre, no desde la caja."
+    FALTANTE_PDV
+    "Al sobre le sobró: vino más de lo declarado."
+    SOBRANTE_PDV
+    REINTEGRADO
+    ASUMIDO_SIN_RESPONSABLE
+}
+
+enum ResultadoVerificacionRetiro {
+    SIN_DIFERENCIA
+    CON_DIFERENCIA
+}
+
+enum CategoriaDiferenciaRetiro {
+    DIFERENCIA_CONTEO
+    FALTANTE
+    SOBRANTE
+    BILLETE_NO_RECIBIBLE
+    NO_RECIBIDO
+    OTRO
+}
+
+enum EstadoCasoRetiro {
+    ABIERTO
+    EN_INVESTIGACION
+    RESUELTO
+}
+
+"""
+Lo que tesorería contó de una moneda al verificar un retiro.
+
+No confundir con ConteoMonedaInput, que es el conteo de la caja del PDV: son dos cosas
+distintas y el nombre corto ya estaba tomado.
+"""
+input ConteoRetiroMonedaInput {
+    monedaId: ID!
+    contado: Float!
+    "Solo si hay diferencia. Si no se indica, se deduce del signo."
+    categoria: CategoriaDiferenciaRetiro
+}
+
+type RetiroCasoPage {
+    getTotalPages: Int
+    getTotalElements: Int
+    getNumberOfElements: Int
+    isFirst: Boolean
+    isLast: Boolean
+    hasNext: Boolean
+    hasPrevious: Boolean
+    getContent: [RetiroCaso]
+}
+
+extend type Query {
+    "La verificación vigente de un retiro, si ya se verificó."
+    verificacionDeRetiro(retiroId: ID!, sucursalId: ID!): RetiroVerificacion
+    """
+    Bandeja de casos. Todos los filtros son opcionales; null = sin filtrar por ese campo.
+    El rango de fechas es sobre la apertura del caso, no sobre la fecha del retiro.
+    """
+    retiroCasos(
+        estado: EstadoCasoRetiro
+        sucursalId: ID
+        retiroId: ID
+        desde: String
+        hasta: String
+        "Solo los casos del usuario logueado: asignados a él, o resueltos por él."
+        soloMios: Boolean
+        page: Int = 0
+        size: Int = 20
+    ): RetiroCasoPage
+    retiroCasosAbiertos: Int
+}
+
+extend type Mutation {
+    """
+    Cuenta un retiro, lo acredita en la caja mayor y lo cierra. Entra lo contado, no lo
+    declarado. Si hay diferencia se abre un caso.
+    """
+    verificarRetiro(
+        retiroId: ID!
+        sucursalId: ID!
+        cajaVirtualId: ID!
+        conteos: [ConteoRetiroMonedaInput!]!
+        rapida: Boolean
+        observacion: String
+    ): RetiroVerificacion
+
+    "Deshace una verificación ya acreditada: el que recibe también se puede equivocar."
+    anularVerificacionRetiro(verificacionId: ID!, motivo: String): RetiroVerificacion
+
+    asignarRetiroCaso(casoId: ID!, usuarioId: ID!): RetiroCaso
+    "Devuelve el caso a ABIERTO: se tomó por error o no corresponde."
+    soltarRetiroCaso(casoId: ID!): RetiroCaso
+    """
+    Cierra el caso. El veredicto es obligatorio: el informe explica, el veredicto clasifica, y
+    lo único que se puede contar después es el veredicto.
+
+    `anularVerificacion` solo se acepta con ERROR_DE_CONTEO_TESORERIA — es el único caso en que
+    lo acreditado en la caja mayor quedó equivocado y hay que volver a contar.
+    """
+    resolverRetiroCaso(
+        casoId: ID!
+        veredicto: VeredictoCasoRetiro!
+        resolucion: String!
+        responsablePersonaId: ID
+        reintegroRetiroId: ID
+        anularVerificacion: Boolean
+    ): RetiroCaso
+}

--- a/src/main/resources/graphql/financiero/retiro-verificacion.graphqls
+++ b/src/main/resources/graphql/financiero/retiro-verificacion.graphqls
@@ -64,9 +64,10 @@ el que recibe en el momento de contar: esto es lo que se determinó después.
 """
 enum VeredictoCasoRetiro {
     ERROR_DE_CONTEO_TESORERIA
-    "Al sobre le faltó: vino menos de lo declarado. Se mide desde el sobre, no desde la caja."
+    # Al sobre le falto: vino menos de lo declarado. Se mide desde el sobre, no desde la
+    # caja del cajero, donde el mismo hecho se ve al reves.
     FALTANTE_PDV
-    "Al sobre le sobró: vino más de lo declarado."
+    # Al sobre le sobro: vino mas de lo declarado. Mismo punto de referencia.
     SOBRANTE_PDV
     REINTEGRADO
     ASUMIDO_SIN_RESPONSABLE

--- a/src/test/java/com/franco/dev/service/financiero/OperacionFinancieraServiceTest.java
+++ b/src/test/java/com/franco/dev/service/financiero/OperacionFinancieraServiceTest.java
@@ -10,6 +10,7 @@ import com.franco.dev.repository.financiero.OperacionFinancieraRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 
 import java.math.BigDecimal;
 
@@ -148,5 +149,126 @@ class OperacionFinancieraServiceTest {
         verify(tesoreriaService, times(2)).registrar(cap.capture());
         assertEquals(CajaVirtualTipoMovimiento.TRANSFERENCIA_SALIDA, cap.getAllValues().get(0).getTipoMovimiento());
         assertEquals(CajaVirtualTipoMovimiento.TRANSFERENCIA_ENTRADA, cap.getAllValues().get(1).getTipoMovimiento());
+    }
+    private CuentaBancaria cuentaConMoneda(long id, Moneda m) {
+        CuentaBancaria c = cuenta(id);
+        c.setMoneda(m);
+        return c;
+    }
+
+    private Moneda moneda(long id) { Moneda m = new Moneda(); m.setId(id); return m; }
+
+    /** Un cambio de divisa entre dos cuentas: no toca caja mayor, dos patas bancarias. */
+    @Test
+    void cambio_divisa_entre_cuentas_bancarias_postea_las_dos_patas() {
+        OperacionFinanciera op = new OperacionFinanciera();
+        op.setTipoOperacion(TipoOperacionFinanciera.CAMBIO_DIVISA);
+        op.setCuentaBancariaOrigen(cuenta(8)); op.setMontoOrigen(new BigDecimal("1000"));
+        op.setCuentaBancariaDestino(cuenta(9)); op.setMontoDestino(new BigDecimal("140"));
+
+        service.registrar(op, null);
+
+        verify(bancoLedgerService).registrar(eq(8L), eq(MovimientoBancarioTipo.SALIDA_MANUAL), eq(new BigDecimal("1000")), any(), any(), any(), any());
+        verify(bancoLedgerService).registrar(eq(9L), eq(MovimientoBancarioTipo.ENTRADA_MANUAL), eq(new BigDecimal("140")), any(), any(), any(), any());
+        verifyNoInteractions(tesoreriaService);
+    }
+
+    /** Mixto caja→banco: una pata de cada tipo, la de caja primero (orden canónico de lock). */
+    @Test
+    void cambio_divisa_de_caja_a_cuenta_lockea_la_caja_primero() {
+        OperacionFinanciera op = new OperacionFinanciera();
+        op.setTipoOperacion(TipoOperacionFinanciera.CAMBIO_DIVISA);
+        op.setCajaMayorOrigen(caja(1)); op.setMontoOrigen(new BigDecimal("700000"));
+        op.setCuentaBancariaDestino(cuenta(9)); op.setMontoDestino(new BigDecimal("100"));
+
+        service.registrar(op, null);
+
+        InOrder orden = inOrder(tesoreriaService, bancoLedgerService);
+        orden.verify(tesoreriaService).registrar(any());
+        orden.verify(bancoLedgerService).registrar(eq(9L), eq(MovimientoBancarioTipo.ENTRADA_MANUAL), any(), any(), any(), any(), any());
+    }
+
+    /** Mixto banco→caja: la caja se toca primero igual, aunque sea el destino. */
+    @Test
+    void cambio_divisa_de_cuenta_a_caja_tambien_lockea_la_caja_primero() {
+        OperacionFinanciera op = new OperacionFinanciera();
+        op.setTipoOperacion(TipoOperacionFinanciera.CAMBIO_DIVISA);
+        op.setCuentaBancariaOrigen(cuenta(9)); op.setMontoOrigen(new BigDecimal("100"));
+        op.setCajaMayorDestino(caja(1)); op.setMontoDestino(new BigDecimal("700000"));
+
+        service.registrar(op, null);
+
+        InOrder orden = inOrder(tesoreriaService, bancoLedgerService);
+        orden.verify(tesoreriaService).registrar(any());
+        orden.verify(bancoLedgerService).registrar(eq(9L), eq(MovimientoBancarioTipo.SALIDA_MANUAL), any(), any(), any(), any(), any());
+    }
+
+    /** El retiro bancario toca la caja antes que el banco: mismo orden que el depósito. */
+    @Test
+    void retiro_bancario_lockea_la_caja_antes_que_el_banco() {
+        OperacionFinanciera op = new OperacionFinanciera();
+        op.setTipoOperacion(TipoOperacionFinanciera.RETIRO_BANCARIO);
+        op.setCuentaBancariaOrigen(cuenta(9)); op.setMontoOrigen(new BigDecimal("300"));
+        op.setCajaMayorDestino(caja(1)); op.setMontoDestino(new BigDecimal("300"));
+
+        service.registrar(op, null);
+
+        InOrder orden = inOrder(tesoreriaService, bancoLedgerService);
+        orden.verify(tesoreriaService).registrar(any());
+        orden.verify(bancoLedgerService).registrar(eq(9L), eq(MovimientoBancarioTipo.SALIDA_MANUAL), any(), any(), any(), any(), any());
+    }
+
+    /** Un lado no puede ser caja y cuenta a la vez. */
+    @Test
+    void cambio_divisa_rechaza_caja_y_cuenta_en_el_mismo_lado() {
+        OperacionFinanciera op = new OperacionFinanciera();
+        op.setTipoOperacion(TipoOperacionFinanciera.CAMBIO_DIVISA);
+        op.setCajaMayorOrigen(caja(1)); op.setCuentaBancariaOrigen(cuenta(8));
+        op.setMontoOrigen(new BigDecimal("100"));
+        op.setCajaMayorDestino(caja(1)); op.setMontoDestino(new BigDecimal("14"));
+
+        assertThrows(RuntimeException.class, () -> service.registrar(op, null));
+    }
+
+    /** Cambiar una cuenta contra sí misma no es un cambio. */
+    @Test
+    void cambio_divisa_rechaza_la_misma_cuenta_en_los_dos_lados() {
+        OperacionFinanciera op = new OperacionFinanciera();
+        op.setTipoOperacion(TipoOperacionFinanciera.CAMBIO_DIVISA);
+        op.setCuentaBancariaOrigen(cuenta(9)); op.setMontoOrigen(new BigDecimal("100"));
+        op.setCuentaBancariaDestino(cuenta(9)); op.setMontoDestino(new BigDecimal("100"));
+
+        assertThrows(RuntimeException.class, () -> service.registrar(op, null));
+    }
+
+    /** La moneda de una pata bancaria la manda la cuenta, no lo que llegó en el formulario. */
+    @Test
+    void la_moneda_de_la_pata_bancaria_se_deriva_de_la_cuenta() {
+        Moneda real = moneda(2);
+        OperacionFinanciera op = new OperacionFinanciera();
+        op.setTipoOperacion(TipoOperacionFinanciera.CAMBIO_DIVISA);
+        op.setCajaMayorOrigen(caja(1)); op.setMontoOrigen(new BigDecimal("700000"));
+        op.setMonedaOrigen(moneda(1));
+        op.setCuentaBancariaDestino(cuentaConMoneda(9, real)); op.setMontoDestino(new BigDecimal("100"));
+        op.setMonedaDestino(moneda(3)); // el cliente mandó cualquier cosa
+
+        service.registrar(op, null);
+
+        assertEquals(real.getId(), op.getMonedaDestino().getId());
+    }
+
+    /** Sin caja mayor en ningún lado, la diferencia no tiene dónde imputarse: se rechaza antes. */
+    @Test
+    void cambio_divisa_entre_cuentas_rechaza_diferencia_imputable() {
+        OperacionFinanciera op = new OperacionFinanciera();
+        op.setTipoOperacion(TipoOperacionFinanciera.CAMBIO_DIVISA);
+        op.setCuentaBancariaOrigen(cuenta(8)); op.setMontoOrigen(new BigDecimal("1000"));
+        op.setCuentaBancariaDestino(cuenta(9)); op.setMontoDestino(new BigDecimal("140"));
+        op.setDiferencia(new BigDecimal("5"));
+        op.setDiferenciaDestinoTipo(com.franco.dev.domain.financiero.enums.DiferenciaDestinoTipo.GASTO);
+
+        assertThrows(RuntimeException.class, () -> service.registrar(op, null));
+        verifyNoInteractions(tesoreriaService);
+        verifyNoInteractions(bancoLedgerService);
     }
 }


### PR DESCRIPTION
## Qué resuelve

**Verificación de retiros.** Hasta ahora, al ingresar un retiro de PDV a la caja mayor entraba lo que el retiro *declaraba*. Ahora entra **lo que tesorería cuenta**, y si no coincide se abre un caso que investiga otra persona.

El retiro sigue siendo inmutable: su detalle solo replica filial→central, así que editarlo acá divergiría del balance que ve el cajero en su pantalla. El conteo vive en tablas nuevas.

**Cambio de divisa con cuentas bancarias.** Cada lado puede ser caja mayor o cuenta bancaria. Los cambios entre cuentas son tan comunes como los de mostrador y había que registrarlos como dos operaciones sueltas, perdiendo la relación entre las patas.

## ⚠️ Dependencia entre repos

**Este PR va primero.** El PR del desktop (`GabFrank/frc-sistemas-integrados-angular`, rama `feat/retiro-verificacion`) consume campos y mutations que este PR agrega: `verificarRetiro`, `retiroCasos`, `resolverRetiroCaso`, `anularVerificacionRetiro`, y los campos `origenId` / `origenSucursalId` en `MovimientoCajaVirtual`.

Si el desktop entra antes, esas pantallas fallan **en runtime** (Apollo no valida el schema en build). Al revés no hay problema: este PR solo, sin el desktop, no rompe nada — las mutations quedan sin usar.

## Decisiones que vale revisar

- **Lo que entra a la caja es lo contado, no lo declarado.** Si contás 900.000 sobre un millón declarado, se acreditan 900.000 y queda registrada la diferencia.
- **El que recibe no investiga.** `asignarRetiroCaso` rechaza que quien contó tome su propio caso, y solo el asignado (o un ADMIN, para destrabar) puede cerrarlo.
- **El veredicto se mide desde el sobre**, no desde la caja del cajero: el mismo hecho visto desde ahí se lee invertido. `validarSigno` rechaza un veredicto que contradiga el conteo — en la primera prueba real un caso quedó clasificado al revés y por eso existe esta validación.
- **Verificación rápida**: se puede aceptar lo declarado sin contar denominación por denominación, pero queda marcada como tal — el que investiga necesita saber si alguien contó de verdad.

## Arreglos que aparecieron en el camino

- **`OperacionFinancieraService.anular()` corría SIN transacción.** Alguien insertó `porId()` entre el javadoc de `anular()` y su firma, llevándose el `@Transactional` puesto. Una falla a mitad de la reversión dejaba la operación con una pata movida y `anulado` todavía en `false`. Preexistente en `develop`.
- **Orden de locks inconsistente en todo el módulo.** `RETIRO_BANCARIO` lockeaba banco→caja mientras el depósito hacía caja→banco; con el cambio de divisa mixto tocando los mismos recursos, alcanzaba para trabar dos operaciones entre sí (son `SELECT FOR UPDATE`, esperan). Ahora todo usa el mismo orden: cajas primero por id, después bancos por id. Mismo criterio aplicado a `PagoProveedorService`, que posteaba los grupos en el orden en que el cliente mandaba las líneas.
- **La moneda de una pata bancaria se deriva de la cuenta** en vez de confiar en el formulario. `MovimientoBancario` no guarda moneda, así que ese campo era solo exhibición y podía mostrar una distinta de la real.
- **La diferencia se valida antes de postear** y por "hay caja mayor", no por tipo de operación: atarlo al enum dejaba afuera el cambio banco↔banco.

## Replicación y filiales

- **Ninguna tabla nueva entra a `replication_table`.** El scheduler solo lee esa tabla, no descubre tablas por su cuenta, así que no pueden colarse.
- **`movimiento_caja_virtual` es central-only**: la columna nueva `origen_sucursal_id` no toca ninguna réplica.
- **`retiro_detalle` no se escribe nunca** (solo lectura). La única escritura que cruza a filial es `retiro.estado` / `caja_virtual_id` / `movimiento_caja_virtual_id`, por el canal que ya usaba la cancelación desde `V155.1`.
- **Los estados `NECESITA_VERIFICACION` / `EN_VERIFICACION` / `VERIFICADO_*` existen desde `V0`**: no hay `ALTER TYPE` de enum.
- **Filial no necesita cambios**: las columnas que central escribe ya están espejadas en `V89.5`.

## Migraciones

`V214.5` (tablas de verificación) y `V215.5` (veredicto). Aditivas, sin `DROP` ni `RENAME`. Renumeradas desde `V210.5`/`V211.5` al integrar `develop`, que ya había tomado `V210.5`–`V213.5` para RRHH.

## Cómo probarlo

1. Ingresar un retiro a una caja mayor y contar **menos** de lo declarado → se acredita lo contado y se abre un caso.
2. Intentar tomar ese caso con el mismo usuario que contó → rechazado.
3. Con otro usuario: tomar, abrir el detalle (muestra los dos lados y la jornada del PDV) y cerrar con veredicto. Elegir uno que contradiga el signo → rechazado con motivo.
4. Anular la verificación desde el historial de la caja → se revierte lo acreditado, el retiro vuelve a quedar pendiente y el caso conserva su informe.
5. Cambio de divisa: probar las cuatro combinaciones caja/cuenta, y anular una desde la lista de operaciones.

## Riesgo

**Medio.** Toca el motor de pagos (`PagoProveedorService`) solo en el orden de iteración de los grupos, sin cambiar qué se postea. `OperacionFinancieraService` cambia más, pero con 15 tests que cubren las cuatro combinaciones, el orden de locks y los rechazos.

Verificado: `mvnw compile` + `OperacionFinancieraServiceTest` y `CajaVirtualQueriesTest` (20 tests) en verde con `develop` integrado. Probado a mano en local de punta a punta, incluida la anulación de cada tipo.

## Al desplegar en alpha

Verificar en el primer ciclo del `ReplicationPublicationSyncScheduler` (corre cada hora) que `retiro_verificacion`, `retiro_verificacion_detalle` y `retiro_caso` **no** aparecen en `central_pub`. Es la prueba en runtime de que el diseño central-only se sostuvo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)