### PR TITLE
fix(inventario): crearLote chocaba con el de SIFEN y no llegaba al schema

### DIFF
--- a/src/main/java/com/franco/dev/graphql/operaciones/MovimientoStockLoteGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/MovimientoStockLoteGraphQL.java
@@ -187,9 +187,15 @@ public class MovimientoStockLoteGraphQL implements GraphQLQueryResolver, GraphQL
      * Es el camino que faltaba para el conteo: el operador tiene el envase en la mano, el lote no
      * está en el sistema y necesita registrarlo para poder contarlo. Nace con saldo cero; el stock
      * se lo pone la finalización de la toma.
+     *
+     * ⚠️ <b>El nombre lleva el sufijo del dominio a propósito.</b> Se llamó {@code crearLote} y
+     * chocó con {@link com.franco.dev.graphql.financiero.LoteDEGraphQL#crearLote()}, que crea un
+     * lote de documentos electrónicos para SIFEN y no lleva argumentos. GraphQL fusiona los
+     * {@code extend type Mutation} por nombre de campo: ganaba el de SIFEN, el arranque no se
+     * quejaba y la app recibía {@code Unknown field argument productoId @ 'crearLote'}.
      */
-    public Lote crearLote(Long productoId, String numeroLote, String fechaVencimiento,
-                          String fechaRetiro, String observacion, Long usuarioId) {
+    public Lote crearLoteProducto(Long productoId, String numeroLote, String fechaVencimiento,
+                                  String fechaRetiro, String observacion, Long usuarioId) {
         if (productoId == null) {
             throw new GraphQLException("productoId es requerido");
         }

--- a/src/main/resources/graphql/operaciones/movimiento-stock-lote.graphqls
+++ b/src/main/resources/graphql/operaciones/movimiento-stock-lote.graphqls
@@ -299,7 +299,13 @@ extend type Mutation {
     #
     # Si el numero ya existe para ese producto devuelve el existente, no falla: la unicidad es
     # (producto, numero) y ese lote ES el que el operador tiene en la mano. Fechas en yyyy-MM-dd.
-    crearLote(
+    #
+    # OJO CON EL NOMBRE: se llamo "crearLote" y choco con el crearLote() de SIFEN
+    # (financiero/lote-de.graphqls), que es un lote de DOCUMENTOS ELECTRONICOS y no lleva
+    # argumentos. Los "extend type Mutation" se fusionan por nombre de campo: ganaba el de SIFEN y
+    # el central respondia "Unknown field argument productoId @ 'crearLote'" a la app, sin que
+    # nada fallara al arrancar. Por eso este lleva el sufijo del dominio.
+    crearLoteProducto(
         productoId: ID!
         numeroLote: String!
         fechaVencimiento: String

--- a/src/test/java/com/franco/dev/graphql/SchemaSinCamposDuplicadosTest.java
+++ b/src/test/java/com/franco/dev/graphql/SchemaSinCamposDuplicadosTest.java
@@ -1,0 +1,156 @@
+package com.franco.dev.graphql;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Dos archivos que declaran el MISMO campo de Query o Mutation con firmas distintas se fusionan
+ * en silencio: gana uno, el otro desaparece del schema y el arranque no dice nada. El cliente que
+ * llama al perdedor recibe "Unknown field argument X" por cada argumento, como si la mutation
+ * nunca se hubiera escrito.
+ *
+ * Historial: crearLote(productoId, numeroLote, ...) de inventario contra el crearLote() de SIFEN
+ * —lote de documentos electronicos, sin argumentos—. La app no podia crear un lote durante el
+ * conteo y el hallazgo costo una pasada entera de testeo manual contra alpha. Se renombro a
+ * crearLoteProducto.
+ *
+ * Un duplicado con la firma IDENTICA no rompe nada: declara dos veces lo mismo. Se tolera, para
+ * que el test hable solo del defecto que puede tumbar una pantalla.
+ */
+class SchemaSinCamposDuplicadosTest {
+
+    private static final Pattern BLOQUE =
+            Pattern.compile("(?:extend\\s+)?type\\s+(Query|Mutation|Subscription)\\s*\\{(.*?)\\n\\}", Pattern.DOTALL);
+    private static final Pattern NOMBRE_CAMPO = Pattern.compile("^([A-Za-z_][A-Za-z0-9_]*)\\s*[(:]");
+
+    @Test
+    void ningunCampoDeQueryOMutationSeDeclaraDosVecesConFirmasDistintas() {
+        Map<String, List<Declaracion>> porCampo = camposDelSchema();
+
+        List<String> problemas = new ArrayList<>();
+        for (Map.Entry<String, List<Declaracion>> e : porCampo.entrySet()) {
+            List<Declaracion> ds = e.getValue();
+            if (ds.size() < 2) {
+                continue;
+            }
+            boolean todasIguales = ds.stream().allMatch(d -> d.firma.equals(ds.get(0).firma));
+            if (todasIguales) {
+                continue;
+            }
+            StringBuilder sb = new StringBuilder("  " + e.getKey() + " declarado en:");
+            for (Declaracion d : ds) {
+                sb.append("\n      ").append(d.archivo).append(" -> ").append(d.firma);
+            }
+            problemas.add(sb.toString());
+        }
+
+        if (!problemas.isEmpty()) {
+            fail("Campos de GraphQL duplicados con firmas distintas: gana uno y el otro se pierde "
+                    + "sin error al arrancar. Renombra el nuevo con el sufijo de su dominio.\n"
+                    + String.join("\n", problemas));
+        }
+    }
+
+    private static class Declaracion {
+        final String firma;
+        final Path archivo;
+
+        Declaracion(String firma, Path archivo) {
+            this.firma = firma;
+            this.archivo = archivo;
+        }
+    }
+
+    /** Campos de primer nivel de cada bloque, con su firma completa (los argumentos van en varias lineas). */
+    private Map<String, List<Declaracion>> camposDelSchema() {
+        Map<String, List<Declaracion>> res = new LinkedHashMap<>();
+        for (Path f : archivos(Paths.get("src", "main", "resources", "graphql"))) {
+            String txt = leer(f);
+            Matcher bloque = BLOQUE.matcher(txt);
+            while (bloque.find()) {
+                String tipo = bloque.group(1);
+                for (Map.Entry<String, String> campo : camposDe(bloque.group(2)).entrySet()) {
+                    res.computeIfAbsent(tipo + "." + campo.getKey(), k -> new ArrayList<>())
+                            .add(new Declaracion(campo.getValue(), f));
+                }
+            }
+        }
+        return res;
+    }
+
+    private Map<String, String> camposDe(String cuerpo) {
+        Map<String, String> res = new LinkedHashMap<>();
+        int profundidad = 0;
+        String nombreActual = null;
+        StringBuilder firma = new StringBuilder();
+        for (String linea : cuerpo.split("\n")) {
+            String l = linea.trim();
+            if (l.isEmpty() || l.startsWith("#")) {
+                continue;
+            }
+            if (profundidad == 0) {
+                if (nombreActual != null) {
+                    res.put(nombreActual, normalizar(firma.toString()));
+                }
+                Matcher m = NOMBRE_CAMPO.matcher(l);
+                nombreActual = m.find() ? m.group(1) : null;
+                firma.setLength(0);
+            }
+            firma.append(l).append(' ');
+            profundidad += contar(l, '(') - contar(l, ')');
+        }
+        if (nombreActual != null) {
+            res.put(nombreActual, normalizar(firma.toString()));
+        }
+        return res;
+    }
+
+    private String normalizar(String firma) {
+        return firma.replaceAll("\\s+", " ").trim();
+    }
+
+    private int contar(String s, char c) {
+        int n = 0;
+        for (int i = 0; i < s.length(); i++) {
+            if (s.charAt(i) == c) {
+                n++;
+            }
+        }
+        return n;
+    }
+
+    private List<Path> archivos(Path raiz) {
+        try (Stream<Path> s = Files.walk(raiz)) {
+            return s.filter(Files::isRegularFile)
+                    .filter(p -> p.toString().endsWith(".graphqls"))
+                    .sorted()
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private String leer(Path p) {
+        try {
+            return new String(Files.readAllBytes(p), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}


### PR DESCRIPTION
## El defecto

`crearLote(productoId, numeroLote, ...)` —el alta manual de lote para el conteo— **compartía nombre** con el `crearLote()` de SIFEN (`financiero/lote-de.graphqls`), que crea un lote de **documentos electrónicos**, no lleva argumentos y devuelve `LoteDE`.

GraphQL fusiona los `extend type Mutation` **por nombre de campo**: ganaba el de SIFEN, el otro desaparecía del schema y **el arranque no decía nada**. La `frc-mobile-pwa` recibía un error de validación por cada argumento:

```
Validation error of type UnknownArgument: Unknown field argument productoId @ 'crearLote'
Validation error of type UnknownArgument: Unknown field argument numeroLote @ 'crearLote'
...
Validation error of type FieldUndefined: Field 'numeroLote' in type 'LoteDE' is undefined @ 'crearLote/numeroLote'
```

Crear un lote durante el conteo **nunca funcionó**, y no había forma de verlo sin probarlo contra un central levantado: compila, arranca y pasa el CI.

## El arreglo

Renombrada a **`crearLoteProducto`** en el `.graphqls` y en el resolver. Se renombra la nueva y **no** la de SIFEN, que ya está en producción en el escritorio.

## El guardrail

`SchemaSinCamposDuplicadosTest` falla cuando dos archivos declaran el mismo campo de `Query`/`Mutation`/`Subscription` **con firmas distintas**, y nombra los dos archivos. Verificado reintroduciendo el defecto: falla, y con el renombre pasa.

Los duplicados de **firma idéntica** se toleran a propósito: declaran dos veces lo mismo y no rompen nada. Hoy hay uno — `enviarNotificacionPersonalizada`, igual en `ConfiguracionNotificaciones.graphqls` y `NotificacionPush.graphqls`—; no se tocó.

## Verificación

- `./mvnw compile` en verde.
- `SchemaSinCamposDuplicadosTest`: pasa con el arreglo, falla con el defecto puesto.
- **Sin probar contra un central levantado**: la resolución de `crearLoteProducto` la hace graphql-java-tools en runtime, así que el caso 47.11 del plan de la PWA recién se puede correr cuando esto esté desplegado en alpha.

## Va junto con

`GabFrank/frc-mobile-pwa#29` — las dos mitades se publican juntas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAF3xeXJL9ohncAY81FBtS
