### PR TITLE
fix(sifen): tratar "Aprobado con observacion" como aprobado y no como rechazo

### DIFF
--- a/src/main/java/com/franco/dev/service/sifen/SifenService.java
+++ b/src/main/java/com/franco/dev/service/sifen/SifenService.java
@@ -643,9 +643,7 @@ public class SifenService {
 
             if (estadoResultado == null) {
                 // Sin dEstRes no se toca el estado, pero el código de respuesta sí se persiste.
-            } else if ("Aprobado".equalsIgnoreCase(estadoResultado) ||
-                estadoResultado.toLowerCase().contains("aprobado con observación") ||
-                estadoResultado.toLowerCase().contains("aprobado con observacion")) {
+            } else if (mapearEstadoResultadoSifen(estadoResultado) == EstadoDE.APROBADO) {
 
                 // Solo actualizar a APROBADO si no está ya en un estado final más específico
                 if (de.getEstado() != EstadoDE.APROBADO &&
@@ -654,7 +652,7 @@ public class SifenService {
                     log.info("   ✅ DE aprobado por SIFEN");
                 }
 
-            } else if ("Rechazado".equalsIgnoreCase(estadoResultado)) {
+            } else if (mapearEstadoResultadoSifen(estadoResultado) == EstadoDE.RECHAZADO) {
 
                 // Actualizar a RECHAZADO si no está ya en ese estado
                 if (de.getEstado() != EstadoDE.RECHAZADO) {
@@ -1145,11 +1143,19 @@ public class SifenService {
             
             if (detalle != null) {
                 // Determinar estado basado en detalle individual
-                EstadoDE estadoIndividual = "Aprobado".equalsIgnoreCase(detalle.estado) 
-                    ? EstadoDE.APROBADO 
-                    : EstadoDE.RECHAZADO;
-            
-            documento.setEstado(estadoIndividual);
+                EstadoDE estadoIndividual = mapearEstadoResultadoSifen(detalle.estado);
+
+                if (estadoIndividual == null) {
+                    // dEstRes ausente o desconocido: no se infiere nada, igual que cuando
+                    // SIFEN no devuelve resultado para el CDC.
+                    sinConfirmar++;
+                    log.error("      ❌ Documento {} con dEstRes no reconocido ('{}') en el lote {} "
+                            + "- se mantiene en estado {} (no confirmado por SIFEN)",
+                        documento.getCdc(), detalle.estado, lote.getId(), documento.getEstado());
+                    continue;
+                }
+
+                documento.setEstado(estadoIndividual);
                 documento.setCodigoRespuestaSifen(detalle.codigo);
                 documento.setMensajeRespuestaSifen(detalle.mensaje);
                 
@@ -1220,7 +1226,7 @@ public class SifenService {
         
         if (startIndex > 13 && endIndex > startIndex) {
             String estadoResultado = xmlRespuesta.substring(startIndex, endIndex).trim();
-            return "Aprobado".equalsIgnoreCase(estadoResultado);
+            return mapearEstadoResultadoSifen(estadoResultado) == EstadoDE.APROBADO;
         }
         
         return false;
@@ -1270,6 +1276,30 @@ public class SifenService {
     /**
      * Extrae un valor específico de un bloque XML.
      */
+    /**
+     * Mapea el <dEstRes> que devuelve SIFEN a nuestro {@link EstadoDE}.
+     *
+     * <p>SIFEN responde con tres valores: "Aprobado", "Aprobado con observación" y
+     * "Rechazado". <b>"Aprobado con observación" es una aprobación</b> — la observación
+     * típica es la transmisión fuera del plazo, y el documento queda válido igual.
+     *
+     * <p>Se compara por prefijo y no por la frase completa a propósito: el texto llega
+     * con tilde o sin tilde según el ambiente, y a veces HTML-escapado
+     * ("observaci&amp;#243;n"), porque {@code extraerValorXML} no decodifica entidades
+     * y {@code decodeHtmlEntities} no cubre las numéricas. Comparar la frase entera
+     * hacía caer "Aprobado con observación" en el {@code else} de rechazo.
+     *
+     * @return el estado correspondiente, o {@code null} si no se reconoce — en ese caso
+     *         el llamador no debe inferir nada y tiene que dejar el documento sin confirmar.
+     */
+    static EstadoDE mapearEstadoResultadoSifen(String dEstRes) {
+        if (dEstRes == null) return null;
+        String estado = dEstRes.trim().toLowerCase();
+        if (estado.startsWith("aprobado")) return EstadoDE.APROBADO;
+        if (estado.startsWith("rechazado")) return EstadoDE.RECHAZADO;
+        return null;
+    }
+
     private String extraerValorXML(String xml, String tagInicio, String tagFin) {
         try {
             int inicio = xml.indexOf(tagInicio);

--- a/src/test/java/com/franco/dev/service/sifen/SifenEstadoResultadoTest.java
+++ b/src/test/java/com/franco/dev/service/sifen/SifenEstadoResultadoTest.java
@@ -1,0 +1,65 @@
+package com.franco.dev.service.sifen;
+
+import com.franco.dev.domain.financiero.enums.EstadoDE;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * SIFEN responde el dEstRes con tres valores: "Aprobado", "Aprobado con observación"
+ * y "Rechazado". El segundo ES una aprobación — la observación típica es la transmisión
+ * fuera de plazo.
+ *
+ * El mapeo comparaba contra la frase completa, así que "Aprobado con observación" caía
+ * en el else de rechazo. El 2026-08-20 venció el certificado de firma de la red bodega
+ * y al recuperarse la cola, 5.467 documentos aprobados quedaron marcados RECHAZADO.
+ */
+class SifenEstadoResultadoTest {
+
+    @Test
+    void aprobadoEsAprobado() {
+        assertEquals(EstadoDE.APROBADO, SifenService.mapearEstadoResultadoSifen("Aprobado"));
+    }
+
+    @Test
+    void aprobadoConObservacionTambienEsAprobado() {
+        assertEquals(EstadoDE.APROBADO,
+            SifenService.mapearEstadoResultadoSifen("Aprobado con observación"));
+    }
+
+    @Test
+    void aprobadoConObservacionSinTilde() {
+        assertEquals(EstadoDE.APROBADO,
+            SifenService.mapearEstadoResultadoSifen("Aprobado con observacion"));
+    }
+
+    /**
+     * El caso que se vio en produccion: extraerValorXML no decodifica entidades y
+     * decodeHtmlEntities no cubre las numericas, asi que el texto llega escapado.
+     */
+    @Test
+    void aprobadoConObservacionHtmlEscapado() {
+        assertEquals(EstadoDE.APROBADO,
+            SifenService.mapearEstadoResultadoSifen("Aprobado con observaci&#243;n"));
+    }
+
+    @Test
+    void toleraEspaciosYMayusculas() {
+        assertEquals(EstadoDE.APROBADO, SifenService.mapearEstadoResultadoSifen("  APROBADO  "));
+        assertEquals(EstadoDE.RECHAZADO, SifenService.mapearEstadoResultadoSifen(" rechazado "));
+    }
+
+    @Test
+    void rechazadoEsRechazado() {
+        assertEquals(EstadoDE.RECHAZADO, SifenService.mapearEstadoResultadoSifen("Rechazado"));
+    }
+
+    /** Sin dEstRes o con un valor desconocido no se infiere nada: el llamador no toca el estado. */
+    @Test
+    void desconocidoDevuelveNull() {
+        assertNull(SifenService.mapearEstadoResultadoSifen(null));
+        assertNull(SifenService.mapearEstadoResultadoSifen(""));
+        assertNull(SifenService.mapearEstadoResultadoSifen("En proceso"));
+    }
+}


### PR DESCRIPTION
Cierra #247.

## Qué arregla

SIFEN devuelve `Aprobado`, `Aprobado con observación` o `Rechazado` en el `dEstRes`. El segundo **es una aprobación** (la observación típica es la transmisión fuera de plazo), pero el mapeo comparaba contra la frase exacta `"Aprobado"` y todo lo demás caía en el `else` de rechazo.

En producción: tras el vencimiento del certificado de firma de bodega el 2026-08-20, la cola acumulada se transmitió y la SET la aprobó con código `0260` — **5.467 documentos quedaron marcados `RECHAZADO` estando aprobados**. Verificado en ekuatia.

## Cómo

Un solo helper, `mapearEstadoResultadoSifen()`, usado en los tres puntos que deciden el estado del documento:

- vía de lote
- vía individual por CDC
- fallback `determinarAprobacionLoteDesdeXML`

**La comparación es por prefijo, no por la frase completa.** Es deliberado: el texto llega con tilde, sin tilde, o HTML-escapado (`observaci&#243;n`), porque `extraerValorXML` no decodifica entidades y `decodeHtmlEntities` no cubre las numéricas. Por eso el `contains()` que ya tenía la vía individual tampoco alcanzaba. `dEstRes` solo tiene tres valores posibles y dos empiezan con "Aprobado".

Además, un `dEstRes` ausente o desconocido ahora devuelve `null` y deja el documento **sin confirmar**, en vez de asumir rechazo por descarte.

## Tests

7 casos, incluido el que se vio en producción (`"Aprobado con observaci&#243;n"`), tildes, mayúsculas, espacios y el desconocido.

## Notas para el reviewer

- **Va en paralelo con el PR del filial** — el código SIFEN está duplicado en los dos backends (ver #189). Mismo cambio, mismo test.
- Hoy el central corre con `SIFEN_SCHEDULER_ENABLED=false` y no consulta lotes, así que acá el fix es preventivo: evita que los dos backends diverjan.
- **Fuera de alcance:** el mismo patrón de comparación existe en el flujo de eventos (cancelación/inutilización), líneas `860/889/940/1003`. No se tocó porque no se verificó qué vocabulario responde SIFEN para eventos.
- ⚠️ Si se implementa el **Fix 1 de #189** (reintento automático de rechazados), este PR tiene que estar mergeado antes — o la lista blanca debe excluir el `0260` — o el reintentador reenviaría documentos ya aprobados y generaría duplicados `1001`/`1002`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)