### PR TITLE
fix(rrhh): saveFuncionario preserva sueldo, credito y horario si el input no los trae

### DIFF
--- a/src/main/java/com/franco/dev/graphql/personas/FuncionarioGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/personas/FuncionarioGraphQL.java
@@ -96,11 +96,17 @@ public class FuncionarioGraphQL implements GraphQLQueryResolver, GraphQLMutation
         com.franco.dev.domain.personas.Persona personaActual = null;
         com.franco.dev.domain.empresarial.Cargo cargoActual = null;
         com.franco.dev.domain.empresarial.Sucursal sucursalActual = null;
+        com.franco.dev.domain.administrativo.Horario horarioActual = null;
+        java.math.BigDecimal sueldoActual = null;
+        Float creditoActual = null;
         if (input.getId() != null) {
             e = service.findById(input.getId()).orElse(new Funcionario());
             personaActual = e.getPersona();
             cargoActual = e.getCargo();
             sucursalActual = e.getSucursal();
+            horarioActual = e.getHorario();
+            sueldoActual = e.getSueldo();
+            creditoActual = e.getCredito();
             // Evitamos que ModelMapper intente mapear relaciones automáticamente y cause
             // errores de Hibernate
             e.setHorario(null);
@@ -120,6 +126,13 @@ public class FuncionarioGraphQL implements GraphQLQueryResolver, GraphQLMutation
                 // cascada de estado, un null accidental inactivaría usuario y cliente.
                 e.setActivo(activoPrevio != null ? activoPrevio : true);
             }
+            // Sueldo, credito y horario no los gestiona todo formulario que llama a este
+            // save (el legajo edita datos personales y deja el salario a su propio flujo
+            // con historico). Sin esto, un input que no los trae los borraba, o forzaba al
+            // cliente a reenviar una copia posiblemente vieja y pisar el valor real.
+            if (input.getSueldo() == null) e.setSueldo(sueldoActual);
+            if (input.getCredito() == null) e.setCredito(creditoActual);
+            if (input.getHorarioId() == null) e.setHorario(horarioActual);
         } else {
             e = m.map(input, Funcionario.class);
             if (input.getActivo() == null) {


### PR DESCRIPTION
Lado central de GabFrank/frc-sistemas-integrados-angular#250.

## Qué resuelve

`saveFuncionario` mapea el input con ModelMapper, que **no saltea nulls**: un update parcial que no trae `sueldo`, `credito` u `horarioId` los borraba. El `horario` además se ponía en `null` antes del map y no se restauraba nunca.

Eso obligaba a cada formulario que llama a este save a reenviar una copia de esos campos aunque no los gestione. El legajo del funcionario lo hacía desde una foto cargada al abrir la pantalla, así que guardar datos personales pisaba con un valor viejo cualquier cambio de salario hecho en el medio — el síntoma reportado era "el sueldo siempre vuelve al mínimo legal", porque el mínimo suele ser el valor anterior.

## Cambios

`FuncionarioGraphQL.saveFuncionario` preserva `sueldo`, `credito` y `horario` cuando el input no los trae, con el mismo patrón que ya existía para `persona`, `cargo`, `sucursal` y `activo` (capturar antes del map, restaurar si el input no reemplaza explícitamente).

13 líneas, un solo archivo.

## Depende de

**GabFrank/frc-sistemas-integrados-angular** rama `fix/rrhh-cambio-salario` (PR #251) — es el que deja de reenviar esos campos. **Los dos PRs tienen que desplegarse juntos**, aunque este es retrocompatible por sí solo: un cliente que siga mandando los campos se comporta igual que antes.

## Cómo probarlo

En el desktop, RRHH → Funcionarios → legajo: cambiar el salario por su diálogo y después guardar desde "Información general". El salario tiene que mantenerse.

Probado en local (central 8081 + filial 8082 + desktop) sobre datos reales, verificado por el usuario.

## Impacto en DB

**Ninguno.** Sin migraciones Flyway, sin cambios de schema GraphQL.

## Riesgo y rollback

**Bajo.** Rollback = revertir el commit; no hay estado de DB que deshacer. `./mvnw clean verify` en verde (451 tests, 0 fallos).

**Cambio de comportamiento a revisar:** preservar `credito` implica que vaciar el campo crédito en el diálogo "Adicionar funcionario" del desktop ya no lo borra (poner `0` sigue funcionando). Si se prefiere el comportamiento anterior, alcanza con sacar `credito` de la lista de campos preservados.

**Latente, fuera de alcance:** `FuncionarioInput.sueldo` es un `Float` de Java (32 bits), así que salarios por encima de ~16.700.000 Gs pierden precisión al guardarse por esta vía. Preexistente, no lo toca este PR.
