### PR TITLE
fix(movimiento-stock): declarar stock como Float en StockPorTipoMovimientoDto

### DIFF
--- a/src/main/resources/graphql/operaciones/movimiento-stock.graphqls
+++ b/src/main/resources/graphql/operaciones/movimiento-stock.graphqls
@@ -42,7 +42,7 @@ type ResumenMovimientoStock {
 
 type StockPorTipoMovimientoDto {
     tipoMovimiento: TipoMovimiento
-    stock: Int
+    stock: Float
 }
 
 type ProductoSaldoDto {


### PR DESCRIPTION
## Problema

Al filtrar list-movimiento-stock por varias sucursales, la UI mostraba:

> Ups! Algo salió mal: Can't serialize value (/data[0]/stock) : Expected type 'Int' but was 'Double'

## Causa

`StockPorTipoMovimientoDto.stock` es `Double` (la query hace `SUM(ms.cantidad)`), pero el schema GraphQL lo declaraba `stock: Int`. graphql-java convierte un `Double` sin parte decimal, pero falla apenas el total tiene decimales, y eso rompe la respuesta entera.

Aparecía "solo con varias sucursales" porque el frontend hace una llamada por sucursal: basta que **una** devuelva un total fraccionario (productos fraccionados) para que la consulta falle. Verificado en la DB: hay sumas con decimales en todas las sucursales.

El filial ya declaraba este campo como `Float`; solo el central estaba desalineado.

## Cambio

Una línea en `movimiento-stock.graphqls`: `stock: Int` → `stock: Float`.

El frontend no requiere cambios de tipo: el modelo TS ya usa `number` y el HTML ya formatea con `number: "1.0-2"`.

## Verificación

- `./mvnw compile` OK.
- Probado por el usuario en la UI con producto LIMON TAITI (id 1422) y sucursales 1, 3 y 4: el error desapareció y los totales fraccionarios se muestran.

PR relacionado: mismo nombre de rama en `frc-sistemas-integrados-angular`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SeVu8bzARUfXiyC9U7f8k1