### PR TITLE
fix(financiero): exponer facturaSimilarReciente en el central

### DIFF
--- a/src/main/java/com/franco/dev/domain/financiero/dto/FacturaSimilarDto.java
+++ b/src/main/java/com/franco/dev/domain/financiero/dto/FacturaSimilarDto.java
@@ -1,0 +1,26 @@
+package com.franco.dev.domain.financiero.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * Datos de una factura ya emitida en el turno de caja que se parece a la que el
+ * cajero está por generar. Se usa solo para mostrarle el aviso de posible duplicado
+ * antes de emitirla; no se persiste.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class FacturaSimilarDto {
+    private Long facturaLegalId;
+    /**
+     * Número de factura en formato EEE-PPP-NNNNNNN.
+     */
+    private String numeroFactura;
+    private LocalDateTime fecha;
+    private Double totalFinal;
+    private String clienteNombre;
+}

--- a/src/main/java/com/franco/dev/graphql/financiero/FacturaLegalGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/FacturaLegalGraphQL.java
@@ -92,6 +92,9 @@ public class FacturaLegalGraphQL implements GraphQLQueryResolver, GraphQLMutatio
     private FacturaLegalService service;
 
     @Autowired
+    private com.franco.dev.service.financiero.FacturaSimilarService facturaSimilarService;
+
+    @Autowired
     private UsuarioService usuarioService;
 
     @Autowired
@@ -158,6 +161,18 @@ public class FacturaLegalGraphQL implements GraphQLQueryResolver, GraphQLMutatio
 
     public FacturaLegal facturaLegal(Long id, Long sucId) {
         return service.findByIdAndSucursalId(id, sucId);
+    }
+
+    /**
+     * Busca una factura del día que se parezca a la que el cajero está por emitir (mismo
+     * cliente, mismo total y mismos items), para poder avisarle antes de emitir un
+     * duplicado. Devuelve null si no hay ninguna.
+     */
+    public com.franco.dev.domain.financiero.dto.FacturaSimilarDto facturaSimilarReciente(
+            Long usuarioId, Long clienteId, Double totalFinal,
+            List<FacturaLegalItemInput> items, Long sucursalId) {
+        return facturaSimilarService.buscarFacturaSimilarReciente(
+                usuarioId, clienteId, totalFinal, items, sucursalId);
     }
 
     public List<FacturaLegal> facturaLegales(int page, int size, Long sucId) {

--- a/src/main/java/com/franco/dev/repository/financiero/FacturaLegalRepository.java
+++ b/src/main/java/com/franco/dev/repository/financiero/FacturaLegalRepository.java
@@ -35,6 +35,13 @@ public interface FacturaLegalRepository
 
         FacturaLegal findByIdAndSucursalId(Long id, Long sucId);
 
+        /**
+         * Facturas que el usuario emitió en la sucursal desde una fecha, de la más nueva a la
+         * más vieja. Se usa para detectar que está por repetir una factura ya emitida hoy.
+         */
+        List<FacturaLegal> findByUsuarioIdAndClienteIdAndSucursalIdAndCreadoEnGreaterThanEqualOrderByIdDesc(
+                        Long usuarioId, Long clienteId, Long sucursalId, LocalDateTime desde);
+
         Boolean deleteByIdAndSucursalId(Long id, Long sucId);
 
         FacturaLegal findByVentaIdAndSucursalId(Long id, Long sucId);

--- a/src/main/java/com/franco/dev/service/financiero/FacturaSimilarService.java
+++ b/src/main/java/com/franco/dev/service/financiero/FacturaSimilarService.java
@@ -1,0 +1,236 @@
+package com.franco.dev.service.financiero;
+
+import com.franco.dev.domain.empresarial.Sucursal;
+import com.franco.dev.domain.financiero.FacturaLegal;
+import com.franco.dev.domain.financiero.FacturaLegalItem;
+import com.franco.dev.domain.financiero.TimbradoDetalle;
+import com.franco.dev.domain.financiero.dto.FacturaSimilarDto;
+import com.franco.dev.domain.personas.Cliente;
+import com.franco.dev.graphql.financiero.input.FacturaLegalItemInput;
+import com.franco.dev.repository.financiero.FacturaLegalRepository;
+import com.franco.dev.utilitarios.FacturaNumeroUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Detecta si el cajero está por emitir una factura prácticamente idéntica a otra que
+ * ya emitió hoy, para poder avisarle ANTES de emitirla (la emisión imprime y consume
+ * un número de timbrado, así que no hay vuelta atrás).
+ * <p>
+ * Criterio de coincidencia: mismo cliente + mismo total + mismas líneas
+ * (descripción, cantidad y precio unitario), del mismo usuario y la misma sucursal,
+ * dentro del día en curso.
+ * <p>
+ * Es solo un aviso: no bloquea nada. La decisión final la toma el cajero desde el
+ * diálogo de confirmación del desktop.
+ */
+@Service
+public class FacturaSimilarService {
+
+    private static final Logger log = LoggerFactory.getLogger(FacturaSimilarService.class);
+
+    /**
+     * Tolerancia al comparar montos: los totales viajan como Double desde el frontend,
+     * así que no se pueden comparar con equals.
+     */
+    private static final double TOLERANCIA_MONTO = 0.5;
+
+    /**
+     * Tolerancia al comparar cantidades. En la entidad son Float y en el input Double,
+     * y hay presentaciones que se venden fraccionadas.
+     */
+    private static final double TOLERANCIA_CANTIDAD = 0.0001;
+
+    /**
+     * Cliente 0 = consumidor final. Dos consumidores finales que compran lo mismo no son
+     * un duplicado, así que para ellos no se verifica nada.
+     */
+    private static final long CLIENTE_CONSUMIDOR_FINAL = 0L;
+
+    @Autowired
+    private FacturaLegalRepository facturaLegalRepository;
+
+    @Autowired
+    private FacturaLegalItemService facturaLegalItemService;
+
+    /**
+     * A diferencia del servidor filial, el central atiende a todas las sucursales, así que
+     * la sucursal no sale de la configuración: la manda el cliente junto con la factura que
+     * está por emitir. Sin ella no hay contra qué comparar y no se verifica nada.
+     *
+     * @return la factura similar más reciente del turno, o null si no hay ninguna
+     */
+    @Transactional(readOnly = true)
+    public FacturaSimilarDto buscarFacturaSimilarReciente(Long usuarioId, Long clienteId,
+                                                          Double totalFinal, List<FacturaLegalItemInput> items,
+                                                          Long sucursalId) {
+        if (usuarioId == null || totalFinal == null || items == null || items.isEmpty()) {
+            return null;
+        }
+
+        // Solo aplica a facturas con cliente identificado
+        if (clienteId == null || clienteId <= CLIENTE_CONSUMIDOR_FINAL) {
+            return null;
+        }
+
+        if (sucursalId == null) {
+            return null;
+        }
+
+        LocalDateTime desde = LocalDate.now().atStartOfDay();
+
+        List<FacturaLegal> candidatas = facturaLegalRepository
+                .findByUsuarioIdAndClienteIdAndSucursalIdAndCreadoEnGreaterThanEqualOrderByIdDesc(
+                        usuarioId, clienteId, sucursalId, desde);
+
+        if (candidatas == null || candidatas.isEmpty()) {
+            return null;
+        }
+
+        List<ItemInfo> itemsNuevaFactura = fromInputs(items);
+
+        for (FacturaLegal candidata : candidatas) {
+            if (Boolean.FALSE.equals(candidata.getActivo())) {
+                continue;
+            }
+            // Filtro barato primero: el monto. Solo si coincide vale la pena cargar los items.
+            if (candidata.getTotalFinal() == null
+                    || Math.abs(candidata.getTotalFinal() - totalFinal) > TOLERANCIA_MONTO) {
+                continue;
+            }
+
+            List<FacturaLegalItem> itemsCandidata =
+                    facturaLegalItemService.findByFacturaLegalId(candidata.getId());
+            if (!sonIguales(fromEntities(itemsCandidata), itemsNuevaFactura)) {
+                continue;
+            }
+
+            log.info("Posible factura duplicada: usuario {} está por repetir la factura {} (cliente {})",
+                    usuarioId, candidata.getId(), clienteId);
+            return toDto(candidata);
+        }
+
+        return null;
+    }
+
+    private FacturaSimilarDto toDto(FacturaLegal facturaLegal) {
+        FacturaSimilarDto dto = new FacturaSimilarDto();
+        dto.setFacturaLegalId(facturaLegal.getId());
+        dto.setFecha(facturaLegal.getFecha() != null ? facturaLegal.getFecha() : facturaLegal.getCreadoEn());
+        dto.setTotalFinal(facturaLegal.getTotalFinal());
+        dto.setClienteNombre(nombreCliente(facturaLegal));
+        dto.setNumeroFactura(numeroFactura(facturaLegal));
+        return dto;
+    }
+
+    /**
+     * El nombre impreso en la factura es la fuente más fiel de a quién se le facturó;
+     * si no está, se cae al nombre de la persona del cliente.
+     */
+    private String nombreCliente(FacturaLegal facturaLegal) {
+        if (facturaLegal.getNombre() != null && !facturaLegal.getNombre().trim().isEmpty()) {
+            return facturaLegal.getNombre();
+        }
+        Cliente cliente = facturaLegal.getCliente();
+        if (cliente == null || cliente.getPersona() == null) return null;
+        return cliente.getPersona().getNombre();
+    }
+
+    private String numeroFactura(FacturaLegal facturaLegal) {
+        TimbradoDetalle timbradoDetalle = facturaLegal.getTimbradoDetalle();
+        if (timbradoDetalle == null) return null;
+
+        Sucursal sucursal = timbradoDetalle.getSucursal();
+        return FacturaNumeroUtils.format(
+                sucursal != null ? sucursal.getCodigoEstablecimientoFactura() : null,
+                timbradoDetalle.getPuntoExpedicion(),
+                facturaLegal.getNumeroFactura());
+    }
+
+    // --- Comparación de items -------------------------------------------------
+
+    /**
+     * Representación mínima de una línea de factura a los efectos de la comparación.
+     * <p>
+     * Se compara por descripción, cantidad y precio unitario, y NO por producto o
+     * presentación: en {@code factura_legal_item} esas dos columnas están casi siempre
+     * vacías (el item de factura se arma con la descripción impresa), así que usarlas
+     * daría falsos negativos en la mayoría de las facturas.
+     */
+    private static class ItemInfo {
+        private final String descripcion;
+        private final Double cantidad;
+        private final Double precioUnitario;
+
+        ItemInfo(String descripcion, Double cantidad, Double precioUnitario) {
+            this.descripcion = normalizar(descripcion);
+            this.cantidad = cantidad;
+            this.precioUnitario = precioUnitario;
+        }
+
+        private static String normalizar(String texto) {
+            return texto == null ? "" : texto.trim().toUpperCase();
+        }
+    }
+
+    private static final Comparator<ItemInfo> ORDEN = Comparator
+            .comparing((ItemInfo i) -> i.descripcion, Comparator.nullsFirst(Comparator.naturalOrder()))
+            .thenComparing(i -> i.cantidad, Comparator.nullsFirst(Comparator.naturalOrder()))
+            .thenComparing(i -> i.precioUnitario, Comparator.nullsFirst(Comparator.naturalOrder()));
+
+    private List<ItemInfo> fromInputs(List<FacturaLegalItemInput> items) {
+        return items.stream()
+                .map(i -> new ItemInfo(i.getDescripcion(), i.getCantidad(), i.getPrecioUnitario()))
+                .collect(Collectors.toList());
+    }
+
+    private List<ItemInfo> fromEntities(List<FacturaLegalItem> items) {
+        if (items == null) return new ArrayList<>();
+        return items.stream()
+                .map(i -> new ItemInfo(
+                        i.getDescripcion(),
+                        i.getCantidad() != null ? i.getCantidad().doubleValue() : null,
+                        i.getPrecioUnitario()))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * @return true si ambas listas contienen exactamente las mismas líneas, ignorando el orden
+     */
+    private boolean sonIguales(List<ItemInfo> items1, List<ItemInfo> items2) {
+        if (items1.size() != items2.size()) return false;
+
+        List<ItemInfo> ordenados1 = new ArrayList<>(items1);
+        List<ItemInfo> ordenados2 = new ArrayList<>(items2);
+        ordenados1.sort(ORDEN);
+        ordenados2.sort(ORDEN);
+
+        for (int i = 0; i < ordenados1.size(); i++) {
+            if (!esMismoItem(ordenados1.get(i), ordenados2.get(i))) return false;
+        }
+        return true;
+    }
+
+    private boolean esMismoItem(ItemInfo a, ItemInfo b) {
+        if (!Objects.equals(a.descripcion, b.descripcion)) return false;
+        if (!sonCasiIguales(a.cantidad, b.cantidad, TOLERANCIA_CANTIDAD)) return false;
+        return sonCasiIguales(a.precioUnitario, b.precioUnitario, TOLERANCIA_MONTO);
+    }
+
+    private boolean sonCasiIguales(Double a, Double b, double tolerancia) {
+        if (a == null || b == null) return Objects.equals(a, b);
+        return Math.abs(a - b) <= tolerancia;
+    }
+}

--- a/src/main/java/com/franco/dev/utilitarios/FacturaNumeroUtils.java
+++ b/src/main/java/com/franco/dev/utilitarios/FacturaNumeroUtils.java
@@ -1,0 +1,30 @@
+package com.franco.dev.utilitarios;
+
+/**
+ * Formato del número de factura legal: {@code EEE-PPP-NNNNNNN}
+ * (establecimiento - punto de expedición - correlativo con padding a 7 dígitos).
+ */
+public final class FacturaNumeroUtils {
+
+    private static final int LARGO_CORRELATIVO = 7;
+
+    private FacturaNumeroUtils() {
+    }
+
+    /**
+     * @param codigoEstablecimiento código de establecimiento de la sucursal
+     * @param puntoExpedicion       punto de expedición del timbrado detalle
+     * @param numeroFactura         correlativo de la factura
+     * @return el número formateado, o null si no hay correlativo
+     */
+    public static String format(String codigoEstablecimiento, String puntoExpedicion, Integer numeroFactura) {
+        if (numeroFactura == null) return null;
+        StringBuilder correlativo = new StringBuilder();
+        String numero = numeroFactura.toString();
+        for (int i = LARGO_CORRELATIVO; i > numero.length(); i--) {
+            correlativo.append("0");
+        }
+        correlativo.append(numero);
+        return codigoEstablecimiento + "-" + puntoExpedicion + "-" + correlativo;
+    }
+}

--- a/src/main/resources/graphql/financiero/factura-legal.graphqls
+++ b/src/main/resources/graphql/financiero/factura-legal.graphqls
@@ -94,7 +94,16 @@ type SaveFacturaLegalToFilialResponse {
     documentoElectronicoGenerado: Boolean
 }
 
+type FacturaSimilar {
+    facturaLegalId: ID!
+    numeroFactura: String
+    fecha: Date
+    totalFinal: Float
+    clienteNombre: String
+}
+
 extend type Query {
+    facturaSimilarReciente(usuarioId: ID!, clienteId: ID, totalFinal: Float!, items: [FacturaLegalItemInput], sucursalId: ID): FacturaSimilar
     facturaLegal(id:ID!, sucId: ID):FacturaLegal
     facturaLegales(page: Int, size: Int, fechaInicio: String, fechaFin: String, sucId: [ID], ruc: String, nombre: String, iva5: Boolean, iva10: Boolean, isElectronico: Boolean, activo: Boolean, sinNombre: Boolean, ventaId: ID):FacturaLegalPage!
     countFacturaLegal: Int


### PR DESCRIPTION
## Problema

La verificación de factura duplicada se agregó el **2026-08-01** solo en el servidor filial (`4301013`), junto con el lado del desktop (`62b9ded3` en el Angular). Pero el desktop consulta esa query **también cuando factura desde el central**, y ahí nunca existió.

Resultado, en producción desde el 1 de agosto: cada emisión desde el central devuelve

```
Validation error of type FieldUndefined: Field 'facturaSimilarReciente' in type 'Query' is undefined
```

que el cajero ve como "Ups! Algo salió mal" antes de poder emitir.

## Qué hace este PR

Porta la verificación al central: `FacturaSimilarDto`, `FacturaNumeroUtils` y `FacturaSimilarService`, más el campo en el schema, su resolver y el método derivado en `FacturaLegalRepository`.

Una diferencia de diseño respecto del filial: el filial saca la sucursal de `env.getProperty("sucursalId")`, pero el central atiende a todas, así que **la sucursal viaja como argumento de la query**. Si llega null no se verifica nada, en vez de adivinar contra qué sucursal comparar.

## Impacto en la facturación

Ninguno. Es **puramente aditivo**: tres archivos nuevos que nadie más referencia, un campo nuevo de consulta y su resolver. La emisión —papel y electrónica— va por mutations, que no se tocan, igual que el paquete `sifen`, la validación de timbrado y el consumo del correlativo.

El método derivado y el binding del resolver se validan **al arrancar**: si estuvieran mal, el central no levanta, falla a la vista y no en silencio. El riesgo es bajo porque ese mismo método derivado ya corre en el filial contra un mapeo de entidad idéntico.

## Verificación

- `mvn compile` ✅
- No se arrancó la aplicación: las validaciones de arranque se confirman al reiniciar.

## Depende de

- filial: `fix/factura-similar-sucursal-explicita`
- angular: `fix/factura-legal-duplicado-y-lista`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DNH1tFMSRTe8cowpR3mxoP