### PR TITLE
fix(financiero): mandar cliente y usuario al filial al facturar desde el central

### DIFF
--- a/src/main/java/com/franco/dev/service/financiero/FacturaLegalFilialService.java
+++ b/src/main/java/com/franco/dev/service/financiero/FacturaLegalFilialService.java
@@ -5,6 +5,9 @@ import com.franco.dev.domain.empresarial.Sucursal;
 import com.franco.dev.graphql.financiero.input.FacturaLegalInput;
 import com.franco.dev.graphql.financiero.input.FacturaLegalItemInput;
 import com.franco.dev.service.empresarial.SucursalService;
+import com.franco.dev.domain.personas.Cliente;
+import com.franco.dev.domain.personas.Persona;
+import com.franco.dev.service.financiero.dto.ClienteFilialRequest;
 import com.franco.dev.service.financiero.dto.ErrorResponseDTO;
 import com.franco.dev.service.financiero.dto.FacturaLegalFilialRequest;
 import com.franco.dev.service.financiero.dto.FacturaLegalFilialResponse;
@@ -42,6 +45,9 @@ public class FacturaLegalFilialService {
 
     @Autowired
     private ObjectMapper objectMapper;
+
+    @Autowired
+    private com.franco.dev.service.personas.ClienteService clienteService;
 
     public FacturaLegalFilialResponse crearFacturaLegalEnFilial(
             FacturaLegalInput facturaInput,
@@ -122,6 +128,48 @@ public class FacturaLegalFilialService {
         }
     }
 
+    /**
+     * Copia los datos del cliente para que viajen con la factura. El filial puede no
+     * tenerlo: en esta arquitectura personas y clientes no llegan por replicacion a todas
+     * las filiales, y sin estos datos la factura se guardaba alla con cliente_id null.
+     *
+     * @return null si no hay cliente o si el central tampoco lo encuentra
+     */
+    private ClienteFilialRequest mapearCliente(Long clienteId) {
+        if (clienteId == null) {
+            return null;
+        }
+
+        Cliente cliente = clienteService.findById(clienteId).orElse(null);
+        if (cliente == null) {
+            log.warn("El cliente {} no existe en el central; la factura viaja al filial sin datos de cliente", clienteId);
+            return null;
+        }
+
+        ClienteFilialRequest request = new ClienteFilialRequest();
+        request.setId(cliente.getId());
+        request.setTipo(cliente.getTipo() != null ? cliente.getTipo().name() : null);
+        request.setCredito(cliente.getCredito());
+        request.setCodigo(cliente.getCodigo());
+        request.setTributa(cliente.getTributa());
+        request.setVerificadoSet(cliente.getVerificadoSet());
+        request.setActivo(cliente.getActivo());
+
+        Persona persona = cliente.getPersona();
+        if (persona != null) {
+            request.setPersonaId(persona.getId());
+            request.setPersonaNombre(persona.getNombre());
+            request.setPersonaApodo(persona.getApodo());
+            request.setPersonaDocumento(persona.getDocumento());
+            request.setPersonaSexo(persona.getSexo());
+            request.setPersonaDireccion(persona.getDireccion());
+            request.setPersonaTelefono(persona.getTelefono());
+            request.setPersonaEmail(persona.getEmail());
+        }
+
+        return request;
+    }
+
     private FacturaLegalFilialRequest mapearRequest(
             FacturaLegalInput facturaInput,
             List<FacturaLegalItemInput> items,
@@ -131,6 +179,8 @@ public class FacturaLegalFilialService {
         request.setTimbradoDetalleId(timbradoDetalleId);
         request.setCajaId(facturaInput.getCajaId() != null ? facturaInput.getCajaId().longValue() : null);
         request.setClienteId(facturaInput.getClienteId() != null ? facturaInput.getClienteId().longValue() : null);
+        request.setUsuarioId(facturaInput.getUsuarioId() != null ? facturaInput.getUsuarioId().longValue() : null);
+        request.setCliente(mapearCliente(request.getClienteId()));
         request.setNombre(facturaInput.getNombre());
         request.setRuc(facturaInput.getRuc());
         request.setDireccion(facturaInput.getDireccion());

--- a/src/main/java/com/franco/dev/service/financiero/dto/ClienteFilialRequest.java
+++ b/src/main/java/com/franco/dev/service/financiero/dto/ClienteFilialRequest.java
@@ -1,0 +1,35 @@
+package com.franco.dev.service.financiero.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Copia de los datos del cliente que el central manda junto con la factura para que el
+ * filial pueda materializarlo si todavia no lo tiene.
+ * <p>
+ * El central es el dueño del cliente: los ids que viajan aca son los suyos, y el filial
+ * los respeta tal cual. Sin esto, una factura emitida desde el central contra un cliente
+ * que el filial no conoce se guardaba con cliente_id null y sin ningun aviso.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClienteFilialRequest {
+    private Long id;
+    private String tipo;
+    private Float credito;
+    private String codigo;
+    private Boolean tributa;
+    private Boolean verificadoSet;
+    private Boolean activo;
+
+    private Long personaId;
+    private String personaNombre;
+    private String personaApodo;
+    private String personaDocumento;
+    private String personaSexo;
+    private String personaDireccion;
+    private String personaTelefono;
+    private String personaEmail;
+}

--- a/src/main/java/com/franco/dev/service/financiero/dto/FacturaLegalFilialRequest.java
+++ b/src/main/java/com/franco/dev/service/financiero/dto/FacturaLegalFilialRequest.java
@@ -13,6 +13,13 @@ public class FacturaLegalFilialRequest {
     private Long timbradoDetalleId;
     private Long cajaId;
     private Long clienteId;
+    /**
+     * Datos del cliente para que el filial pueda materializarlo si no lo tiene todavia.
+     * Va lleno siempre que clienteId no sea null.
+     */
+    private ClienteFilialRequest cliente;
+    /** Usuario que emite la factura. Sin esto la factura queda sin trazabilidad en el filial. */
+    private Long usuarioId;
     private String nombre;
     private String ruc;
     private String direccion;


### PR DESCRIPTION
## Qué resuelve

Las facturas emitidas desde el central se guardaban en el filial con `cliente_id` y `usuario_id` en **null**, sin error ni log.

Confirmado con datos en alpha: las 5 facturas del 2026-09-01 en filial2 tienen los dos campos vacíos. Para contraste, 20.636 de 22.315 facturas históricas sí tienen `cliente_id` — el camino del PDV lo guarda bien, es **este** camino el que no.

Son dos causas distintas:

- **`usuarioId` nunca se mapeaba.** Ya viaja lleno desde el desktop hasta `FacturaLegalInput` (campo existente, línea 32), pero `FacturaLegalFilialRequest` no tenía el campo y `mapearRequest` no lo pasaba. Plomería faltante.
- **El filial no conoce al cliente.** Personas y clientes no llegan por replicación lógica a todas las filiales, así que `clienteService.findById` fallaba allá y el `setCliente` se salteaba en silencio.

Este PR agrega ambos al contrato REST: `usuarioId`, y una copia de los datos del cliente para que el filial pueda materializarlo. El central es el dueño del cliente, así que los ids que viajan son los suyos.

Va en par con GabFrank/franco-system-backend-filial#112, que es el lado que los consume.

## Cómo probarlo

Requiere el PR del filial desplegado. Emitir una factura desde la ventana administrativa del central hacia una sucursal, eligiendo un cliente que esa filial no tenga, y verificar en la base del filial:

```sql
select cliente_id, usuario_id from financiero.factura_legal order by id desc limit 1;
```

Antes: ambos null. Después: ambos cargados.

Ya se verificó de punta a punta contra un filial local: HTTP 201, `cliente_id` y `usuario_id` poblados, el cliente y la persona materializados con los ids del central. Detalle en el PR del filial.

## Impacto en DB

Ninguno en este repo: no hay migraciones. Solo se leen `personas.cliente` y `personas.persona` para armar la copia.

## Impacto en rollback

Ninguno. El cambio es aditivo sobre el contrato REST: volver a la versión anterior deja de mandar los dos campos y el filial vuelve al comportamiento actual. No hay estado persistido en este lado que quede inconsistente.

## Riesgo

**Bajo.** Solo se toca `FacturaLegalFilialService.mapearRequest`, que es exclusivo del camino "facturar desde el central". No toca la emisión propia del central, ni SIFEN, ni la validación de timbrado, ni el consumo del correlativo.

Un detalle de orden: si este PR sale **antes** que el del filial, el filial ignora los campos nuevos que no conoce y el comportamiento queda igual al actual. No rompe. El orden inverso también es seguro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DNH1tFMSRTe8cowpR3mxoP