### PR TITLE
fix(rrhh): usar el subject del JWT cuando falta el claim nickname

### DIFF
--- a/src/main/java/com/franco/dev/security/JwtValidator.java
+++ b/src/main/java/com/franco/dev/security/JwtValidator.java
@@ -22,7 +22,7 @@ public class JwtValidator {
 
             jwtUser = new JwtUser();
 
-            jwtUser.setNickname((String) body.get("nickname"));
+            jwtUser.setNickname(resolveNickname(body));
             jwtUser.setPassword((String) body.get("password"));
         }
         catch (Exception e) {
@@ -30,5 +30,28 @@ public class JwtValidator {
         }
 
         return jwtUser;
+    }
+
+    /**
+     * El nickname del claim dedicado, con fallback al subject del JWT.
+     *
+     * El JwtGenerator del filial solo setea el subject y nunca escribe el claim
+     * "nickname". Leyendo unicamente el claim, un token emitido por el filial
+     * dejaba el principal en null, y todo lo que resuelve al usuario autenticado
+     * por SecurityContext (RrhhSecurityService, TesoreriaSecurityService) lo veia
+     * como no autenticado: reportaba falta de permisos aunque el usuario tuviera
+     * los roles, incluso ADMIN. El desktop cae al token del filial cuando
+     * token_central no esta seteado (ver login.service.ts / graphql-connection.service.ts).
+     *
+     * El fallback tambien cubre los tokens ya emitidos: estos JWT no llevan
+     * expiracion, asi que sin esto los usuarios seguirian bloqueados hasta
+     * volver a loguearse.
+     */
+    private String resolveNickname(Claims body) {
+        String nickname = (String) body.get("nickname");
+        if (nickname == null || nickname.trim().isEmpty()) {
+            nickname = body.getSubject();
+        }
+        return nickname;
     }
 }

--- a/src/test/java/com/franco/dev/security/JwtValidatorTest.java
+++ b/src/test/java/com/franco/dev/security/JwtValidatorTest.java
@@ -1,0 +1,63 @@
+package com.franco.dev.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class JwtValidatorTest {
+
+    private static final String SECRET = "Graphql";
+
+    private final JwtValidator validator = new JwtValidator();
+
+    /** Token como lo emite el JwtGenerator del central: subject + claim "nickname". */
+    private String tokenDelCentral(String nickname) {
+        Claims claims = Jwts.claims().setSubject(nickname);
+        claims.put("nickname", nickname);
+        claims.put("password", "x");
+        return Jwts.builder().setClaims(claims).signWith(SignatureAlgorithm.HS512, SECRET).compact();
+    }
+
+    /** Token como lo emite el JwtGenerator del filial: solo subject, sin claim "nickname". */
+    private String tokenDelFilial(String nickname) {
+        Claims claims = Jwts.claims().setSubject(nickname);
+        claims.put("password", "x");
+        return Jwts.builder().setClaims(claims).signWith(SignatureAlgorithm.HS512, SECRET).compact();
+    }
+
+    @Test
+    void leeElClaimNicknameCuandoEstaPresente() {
+        assertEquals("MR", validator.validate(tokenDelCentral("MR")).getNickname());
+    }
+
+    @Test
+    void caeAlSubjectCuandoNoHayClaimNickname() {
+        // El JwtGenerator del filial nunca escribe el claim "nickname". Sin este
+        // fallback el principal quedaba null y los servicios que resuelven al
+        // usuario por SecurityContext (RrhhSecurityService, TesoreriaSecurityService)
+        // reportaban falta de permisos aunque el usuario tuviera los roles.
+        assertEquals("mr", validator.validate(tokenDelFilial("mr")).getNickname());
+    }
+
+    @Test
+    void caeAlSubjectCuandoElClaimNicknameEstaVacio() {
+        Claims claims = Jwts.claims().setSubject("MR");
+        claims.put("nickname", "   ");
+        String token = Jwts.builder().setClaims(claims).signWith(SignatureAlgorithm.HS512, SECRET).compact();
+
+        assertEquals("MR", validator.validate(token).getNickname());
+    }
+
+    @Test
+    void nicknameNuloSiElTokenNoTraeNiClaimNiSubject() {
+        Claims claims = Jwts.claims();
+        claims.put("password", "x");
+        String token = Jwts.builder().setClaims(claims).signWith(SignatureAlgorithm.HS512, SECRET).compact();
+
+        assertNull(validator.validate(token).getNickname());
+    }
+}


### PR DESCRIPTION
## Que resuelve

La lista de liquidaciones (y cualquier resolver de RRHH o Tesoreria) devolvia `No autorizado: se requiere un rol de RRHH para ver estos datos` a usuarios que tenian todos los roles asignados, incluso `ADMIN`.

No era un problema de roles. El `JwtGenerator` del **filial** solo setea el subject y nunca escribe el claim `nickname`, pero el `JwtValidator` del **central** leia unicamente ese claim. Con un token emitido por el filial el principal quedaba en `null`, y todo lo que resuelve al usuario autenticado desde el `SecurityContext` (`RrhhSecurityService`, `TesoreriaSecurityService`) lo trataba como no autenticado: sin usuario no hay roles, y ni el bypass de `ADMIN` aplica.

Al central le llega un token del filial porque el desktop cae a `localStorage.getItem("token")` cuando `token_central` no esta seteado (`graphql-connection.service.ts`), cosa que pasa si `autenticarEnCentral()` no llego a resolver — es fire-and-forget con `timeout(3000)` y `catchError` silencioso.

## Como probarlo

1. Loguearse en el desktop contra el filial con un usuario que tenga rol `ADMIN` o cualquier rol `RRHH *`.
2. En la consola: `localStorage.removeItem('token_central')` y recargar, para forzar el fallback al token del filial.
3. Abrir RRHH -> Liquidaciones. Antes de este cambio daba el error de autorizacion; ahora lista normalmente.

Verificado tambien por request directo con un token que solo lleva `sub` (la forma exacta que emite el filial): el central con el fix responde la pagina de liquidaciones, sin el fix devuelve el error.

Tests nuevos en `JwtValidatorTest`: claim presente, claim ausente (fallback al subject), claim vacio, y token sin ninguno de los dos.

## Impacto en DB

Ninguno. No hay migraciones.

## Impacto en rollback

Ninguno. El cambio es de lectura de un claim del JWT y no altera el formato de los tokens que se emiten; volver a la version anterior solo reintroduce el bug.

## Riesgo

**Bajo.** Amplia el conjunto de tokens que resuelven a un usuario (los que traen subject pero no el claim), sin relajar ninguna verificacion: la firma se sigue validando igual y el usuario se sigue buscando en `personas.usuario`. Un token sin subject ni claim deja el nickname en `null`, exactamente como antes.

Vale notar que el fallback tambien recupera los tokens ya emitidos: estos JWT no llevan expiracion, asi que sin esto los usuarios afectados seguirian bloqueados hasta volver a loguearse.

## Pendiente aparte (no incluido)

- El `JwtGenerator` del filial deberia escribir el claim `nickname`, y su propio `JwtValidator` tiene el mismo bug de lectura.
- Que `autenticarEnCentral()` no falle en silencio y no se caiga al token del filial para queries al central.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ATks8c7ooBvDBoW7g64bk