### PR TITLE
fix(impresoras): resolver la ambiguedad de ModelMapper al guardar una impresora

### DIFF
--- a/src/main/java/com/franco/dev/graphql/empresarial/ImpresoraGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/empresarial/ImpresoraGraphQL.java
@@ -9,6 +9,7 @@ import com.franco.dev.service.personas.UsuarioService;
 import graphql.kickstart.tools.GraphQLMutationResolver;
 import graphql.kickstart.tools.GraphQLQueryResolver;
 import org.modelmapper.ModelMapper;
+import org.modelmapper.convention.MatchingStrategies;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -71,9 +72,23 @@ public class ImpresoraGraphQL implements GraphQLQueryResolver, GraphQLMutationRe
         return cupsAdminService.listarColasInstaladas();
     }
 
-    public Impresora saveImpresora(ImpresoraInput input) {
+    /**
+     * ModelMapper con matching STRICT (solo nombres exactos). Con la estrategia por defecto,
+     * {@code smbUsuario} y {@code usuarioId} caian los dos sobre el destino
+     * {@code Impresora.usuario.usuario} (Usuario se auto-referencia) y el mapeo abortaba con
+     * "matches multiple source property hierarchies". Los ids (sucursalId/usuarioId) se resuelven
+     * a mano mas abajo, asi que no perdemos nada al exigir nombres exactos.
+     */
+    private static final ModelMapper MAPPER = strictMapper();
+
+    static ModelMapper strictMapper() {
         ModelMapper m = new ModelMapper();
-        Impresora e = m.map(input, Impresora.class);
+        m.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
+        return m;
+    }
+
+    public Impresora saveImpresora(ImpresoraInput input) {
+        Impresora e = MAPPER.map(input, Impresora.class);
         if (input.getSucursalId() != null) {
             e.setSucursal(sucursalService.findById(input.getSucursalId()).orElse(null));
         }

--- a/src/test/java/com/franco/dev/graphql/empresarial/ImpresoraInputMappingTest.java
+++ b/src/test/java/com/franco/dev/graphql/empresarial/ImpresoraInputMappingTest.java
@@ -1,0 +1,92 @@
+package com.franco.dev.graphql.empresarial;
+
+import com.franco.dev.domain.empresarial.Impresora;
+import com.franco.dev.domain.empresarial.enums.PerfilPapel;
+import com.franco.dev.domain.empresarial.enums.TipoConexion;
+import com.franco.dev.domain.empresarial.enums.TipoImpresora;
+import com.franco.dev.domain.empresarial.enums.UsoImpresora;
+import com.franco.dev.graphql.empresarial.input.ImpresoraInput;
+import org.junit.jupiter.api.Test;
+import org.modelmapper.ModelMapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * ImpresoraInput trae {@code smbUsuario} (usuario del share de Windows) y {@code usuarioId}
+ * (quien la da de alta). Con la estrategia de matching por defecto de ModelMapper ambos caen
+ * sobre el destino {@code Impresora.usuario.usuario} (Usuario se auto-referencia) y guardar
+ * explotaba con "matches multiple source property hierarchies".
+ */
+class ImpresoraInputMappingTest {
+
+    @Test
+    void mapeaImpresoraSmbSinAmbiguedadDeUsuario() {
+        ImpresoraInput input = new ImpresoraInput();
+        input.setNombre("test");
+        input.setConexion(TipoConexion.SMB);
+        input.setSmbHost("100.64.0.10");
+        input.setSmbRecurso("adm_ticket");
+        input.setSmbUsuario("user");
+        input.setSmbDominio("WORKGROUP");
+        input.setUsuarioId(7L);
+        input.setSucursalId(0L);
+
+        Impresora e = ImpresoraGraphQL.strictMapper().map(input, Impresora.class);
+
+        assertEquals("test", e.getNombre());
+        assertEquals(TipoConexion.SMB, e.getConexion());
+        assertEquals("100.64.0.10", e.getSmbHost());
+        assertEquals("adm_ticket", e.getSmbRecurso());
+        assertEquals("user", e.getSmbUsuario());
+        assertEquals("WORKGROUP", e.getSmbDominio());
+        // sucursalId/usuarioId los resuelve el resolver contra el service, no el mapper.
+        assertNull(e.getUsuario());
+        assertNull(e.getSucursal());
+    }
+
+    /** El matching STRICT no puede dejar de copiar ningun campo de nombre identico. */
+    @Test
+    void copiaTodosLosCamposDeNombreIdentico() {
+        ImpresoraInput input = new ImpresoraInput();
+        input.setId(9L);
+        input.setNombre("caja1");
+        input.setActivo(true);
+        input.setEsPredeterminada(true);
+        input.setTipo(TipoImpresora.TERMICA);
+        input.setUso(UsoImpresora.TICKET);
+        input.setConexion(TipoConexion.USB);
+        input.setColaCups("caja1");
+        input.setIp("192.168.0.50");
+        input.setPuerto(9100);
+        input.setPerfilPapel(PerfilPapel.MM_58);
+        input.setColumnas(32);
+        input.setAnchoMm(58);
+        input.setAltoMm(210);
+        input.setMarca("EPSON");
+        input.setCodepage("CP437");
+        input.setCompartidaEnCentral(true);
+
+        ModelMapper m = ImpresoraGraphQL.strictMapper();
+        Impresora e = m.map(input, Impresora.class);
+
+        assertEquals(9L, e.getId());
+        assertEquals("caja1", e.getNombre());
+        assertTrue(e.getActivo());
+        assertTrue(e.getEsPredeterminada());
+        assertEquals(TipoImpresora.TERMICA, e.getTipo());
+        assertEquals(UsoImpresora.TICKET, e.getUso());
+        assertEquals(TipoConexion.USB, e.getConexion());
+        assertEquals("caja1", e.getColaCups());
+        assertEquals("192.168.0.50", e.getIp());
+        assertEquals(9100, e.getPuerto());
+        assertEquals(PerfilPapel.MM_58, e.getPerfilPapel());
+        assertEquals(32, e.getColumnas());
+        assertEquals(58, e.getAnchoMm());
+        assertEquals(210, e.getAltoMm());
+        assertEquals("EPSON", e.getMarca());
+        assertEquals("CP437", e.getCodepage());
+        assertTrue(e.getCompartidaEnCentral());
+    }
+}


### PR DESCRIPTION
## Qué resuelve

Guardar cualquier impresora fallaba con:

```
ModelMapper configuration errors: The destination property
Impresora.setUsuario()/Usuario.setUsuario() matches multiple source
property hierarchies: getUsuarioId(), getSmbUsuario()
```

`saveImpresora` construía `new ModelMapper()`, que usa la estrategia de matching **STANDARD** (por tokens). Como `Usuario` se auto-referencia (`Usuario.usuario`), el destino `Impresora.usuario.usuario` quedaba con dos candidatos en el input: `getSmbUsuario()` y `getUsuarioId()`.

Lo disparó **V201.5** al agregar los campos SMB del share de Windows: desde esa migración **no se podía guardar ninguna impresora**, no sólo las SMB. El error es determinístico por la forma de las clases, independiente de los valores.

## Cómo se arregla

Matching **STRICT** (sólo nombres exactos), en un `static final` para no reconstruir el TypeMap en cada request. Los ids (`sucursalId`, `usuarioId`) ya se resuelven a mano contra el service más abajo, así que STRICT no pierde ningún campo.

### Por qué no se inyecta el bean `modelMapper()`

`FrancoSystemsApplication.modelMapper()` está documentado como STRICT, pero además tiene `setFieldMatchingEnabled(true)` con acceso a campos `PRIVATE`. Con eso ModelMapper entra por reflexión a los campos privados de `java.time.LocalDateTime` y rompe el mapeo de `Impresora.creadoEn`:

```
InaccessibleObjectException: Unable to make field private final java.time.LocalDate
java.time.LocalDateTime.date accessible: module java.base does not "opens java.time"
```

Verificado en JDK 17 (el proyecto declara Java 11 y CI usa JDK 11, donde probablemente sólo advierta). El mapper local evita el problema en ambos.

## Cómo probarlo

1. Alta de impresora → **Guardar**. Antes fallaba con el error de arriba en cualquier conexión; ahora guarda.
2. Con conexión **Windows compartida (Samba)** cargando `smbHost`/`smbRecurso`/`smbUsuario`/`smbDominio`: los cuatro campos tienen que persistir, y `usuario_id` quedar con el usuario que la dio de alta.
3. `./mvnw test -Dtest=ImpresoraInputMappingTest`

Tests nuevos: el caso SMB (reproduce el bug) y uno que verifica que STRICT no deje de copiar ningún campo de nombre idéntico.

## Impacto en DB

Ninguno. No hay migraciones nuevas.

## Impacto en rollback

Ninguno. Cambio acotado a un resolver, sin cambios de schema GraphQL ni de datos.

## Riesgo

**Bajo.** Cambio de una sola clase, cubierto por tests. `./mvnw clean verify -B -DskipFlyway=true` → **489 tests, 0 fallos**.

## Nota

`ImpresoraGraphQL` es el único resolver que se cambia. Los otros ~137 `new ModelMapper()` del repo quedan como están: no tienen inputs con nombres que colisionen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Jh7J3qPUsdrr5hUt3PrF7