### PR TITLE
fix(activos): saveEnte y saveTipoCombustible fallaban con cualquier input

### DIFF
--- a/src/main/java/com/franco/dev/graphql/activos/EnteGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/activos/EnteGraphQL.java
@@ -17,6 +17,7 @@ import graphql.GraphQLException;
 import graphql.kickstart.tools.GraphQLMutationResolver;
 import graphql.kickstart.tools.GraphQLQueryResolver;
 import org.modelmapper.ModelMapper;
+import org.modelmapper.convention.MatchingStrategies;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -128,8 +129,33 @@ public class EnteGraphQL implements GraphQLQueryResolver, GraphQLMutationResolve
     }
 
 
+    /**
+     * ModelMapper propio, con matching STRICT y SIN field matching.
+     *
+     * No se usa el bean {@code modelMapper()} de {@code FrancoSystemsApplication}: ese tiene
+     * {@code setFieldMatchingEnabled(true)} con acceso a campos privados, y para llenar
+     * {@code Ente.creadoEn} entra por reflexion a los campos internos de
+     * {@code java.time.LocalDateTime}. En JDK 17 eso lanza
+     * {@code InaccessibleObjectException: module java.base does not "opens java.time"},
+     * asi que {@code saveEnte} fallaba con CUALQUIER input — incluso uno vacio — y ni el
+     * escritorio ni la PWA podian dar de alta un ente.
+     *
+     * Es el mismo problema que ya se resolvio en {@code ImpresoraGraphQL}; aca ademas del
+     * matching hay que apagar el field matching, que es lo que dispara la reflexion.
+     *
+     * Los ids ({@code tipoEnte}, {@code usuarioId}) se resuelven a mano mas abajo, asi que
+     * exigir nombres exactos no pierde nada.
+     */
+    private static final ModelMapper MAPPER = strictMapper();
+
+    static ModelMapper strictMapper() {
+        ModelMapper m = new ModelMapper();
+        m.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
+        return m;
+    }
+
     public Ente saveEnte(EnteInput input) {
-        Ente e = modelMapper.map(input, Ente.class);
+        Ente e = MAPPER.map(input, Ente.class);
         if (input.getTipoEnte() != null) {
             e.setTipoEnte(TipoEnte.valueOf(input.getTipoEnte()));
         }

--- a/src/main/java/com/franco/dev/graphql/activos/TipoCombustibleGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/activos/TipoCombustibleGraphQL.java
@@ -8,6 +8,7 @@ import graphql.GraphQLException;
 import graphql.kickstart.tools.GraphQLMutationResolver;
 import graphql.kickstart.tools.GraphQLQueryResolver;
 import org.modelmapper.ModelMapper;
+import org.modelmapper.convention.MatchingStrategies;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -25,8 +26,26 @@ public class TipoCombustibleGraphQL implements GraphQLQueryResolver, GraphQLMuta
     @Autowired
     private UsuarioService usuarioService;
 
-    @Autowired
-    private ModelMapper modelMapper;
+    /**
+     * ModelMapper propio, con matching STRICT y SIN field matching.
+     *
+     * Mismo motivo que en {@link EnteGraphQL}: el bean {@code modelMapper()} de la aplicacion
+     * tiene {@code setFieldMatchingEnabled(true)} con acceso a campos privados, y para llenar
+     * {@code TipoCombustible.creadoEn} entra por reflexion a los campos internos de
+     * {@code java.time.LocalDateTime}. En JDK 17 eso lanza
+     * {@code InaccessibleObjectException: module java.base does not "opens java.time"}, asi
+     * que guardar fallaba con cualquier input.
+     *
+     * {@code usuarioId} se resuelve a mano contra el service, asi que exigir nombres exactos
+     * no pierde nada.
+     */
+    private static final ModelMapper MAPPER = strictMapper();
+
+    static ModelMapper strictMapper() {
+        ModelMapper m = new ModelMapper();
+        m.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
+        return m;
+    }
 
     public Optional<TipoCombustible> tipoCombustible(Long id) {
         return service.findById(id);
@@ -46,7 +65,7 @@ public class TipoCombustibleGraphQL implements GraphQLQueryResolver, GraphQLMuta
     }
 
     public TipoCombustible saveTipoCombustible(TipoCombustibleInput input) {
-        TipoCombustible e = modelMapper.map(input, TipoCombustible.class);
+        TipoCombustible e = MAPPER.map(input, TipoCombustible.class);
         if (input.getUsuarioId() != null) {
             e.setUsuario(usuarioService.findById(input.getUsuarioId()).orElse(null));
         }

--- a/src/test/java/com/franco/dev/graphql/activos/EnteInputMappingTest.java
+++ b/src/test/java/com/franco/dev/graphql/activos/EnteInputMappingTest.java
@@ -1,0 +1,61 @@
+package com.franco.dev.graphql.activos;
+
+import com.franco.dev.domain.activos.Ente;
+import com.franco.dev.domain.activos.enums.TipoEnte;
+import com.franco.dev.graphql.activos.input.EnteInput;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@code saveEnte} usaba el bean {@code modelMapper()} de la aplicacion, que tiene
+ * {@code setFieldMatchingEnabled(true)} con acceso a campos privados. Para llenar
+ * {@code Ente.creadoEn} entraba por reflexion a los campos internos de
+ * {@code java.time.LocalDateTime}, y en JDK 17 eso lanza
+ * {@code InaccessibleObjectException: module java.base does not "opens java.time"}.
+ *
+ * El efecto era que dar de alta un ente fallaba con CUALQUIER input, incluso uno vacio,
+ * tanto desde el escritorio como desde la PWA.
+ */
+class EnteInputMappingTest {
+
+    @Test
+    void mapeaUnEnteNuevoSinTocarLaReflexionDeLocalDateTime() {
+        EnteInput input = new EnteInput();
+        input.setTipoEnte("VEHICULO");
+        input.setReferenciaId(88L);
+        input.setActivo(true);
+        input.setUsuarioId(410L);
+
+        Ente e = EnteGraphQL.strictMapper().map(input, Ente.class);
+
+        assertEquals(88L, e.getReferenciaId());
+        assertTrue(e.getActivo());
+        // El resolver resuelve tipoEnte y usuario a mano contra el enum y el service.
+        assertNull(e.getUsuario());
+    }
+
+    @Test
+    void unInputVacioTampocoRompe() {
+        // Es el caso que delataba el bug: fallaba incluso sin ningun campo cargado,
+        // porque la reflexion sobre `creadoEn` no depende de lo que traiga el input.
+        Ente e = EnteGraphQL.strictMapper().map(new EnteInput(), Ente.class);
+
+        assertNull(e.getId());
+        assertNull(e.getReferenciaId());
+    }
+
+    @Test
+    void elTipoDeEnteLlegaDesdeElStringDelInput() {
+        // TipoEnte es un enum en el dominio y un String en el input: la conversion
+        // tiene que seguir funcionando con matching STRICT.
+        EnteInput input = new EnteInput();
+        input.setTipoEnte("INMUEBLE");
+
+        Ente e = EnteGraphQL.strictMapper().map(input, Ente.class);
+
+        assertEquals(TipoEnte.INMUEBLE, e.getTipoEnte());
+    }
+}

--- a/src/test/java/com/franco/dev/graphql/activos/TipoCombustibleInputMappingTest.java
+++ b/src/test/java/com/franco/dev/graphql/activos/TipoCombustibleInputMappingTest.java
@@ -1,0 +1,42 @@
+package com.franco.dev.graphql.activos;
+
+import com.franco.dev.domain.activos.TipoCombustible;
+import com.franco.dev.graphql.activos.input.TipoCombustibleInput;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Mismo bug que {@link EnteInputMappingTest}: {@code saveTipoCombustible} usaba el bean
+ * {@code modelMapper()} de la aplicacion, que con {@code setFieldMatchingEnabled(true)}
+ * entraba por reflexion a los campos internos de {@code java.time.LocalDateTime} para
+ * llenar {@code TipoCombustible.creadoEn}. En JDK 17 eso lanza
+ * {@code InaccessibleObjectException} y guardar fallaba con cualquier input.
+ */
+class TipoCombustibleInputMappingTest {
+
+    @Test
+    void mapeaUnTipoDeCombustibleNuevo() {
+        TipoCombustibleInput input = new TipoCombustibleInput();
+        input.setDescripcion("DIESEL");
+        input.setUsuarioId(410L);
+
+        TipoCombustible e = TipoCombustibleGraphQL.strictMapper().map(input, TipoCombustible.class);
+
+        assertEquals("DIESEL", e.getDescripcion());
+        // usuarioId lo resuelve el resolver contra el service, no el mapper.
+        assertNull(e.getUsuario());
+    }
+
+    @Test
+    void unInputVacioTampocoRompe() {
+        // El caso que delataba el bug: la reflexion sobre `creadoEn` no depende
+        // de lo que traiga el input.
+        TipoCombustible e = TipoCombustibleGraphQL.strictMapper()
+                .map(new TipoCombustibleInput(), TipoCombustible.class);
+
+        assertNull(e.getId());
+        assertNull(e.getDescripcion());
+    }
+}


### PR DESCRIPTION
`saveEnte` y `saveTipoCombustible` fallaban con **cualquier** input, incluido uno vacío. Nadie podía dar de alta un ente ni un tipo de combustible: ni el escritorio, que usa `saveEnte` desde el módulo de activos, ni la PWA, donde bloqueaba imputar un gasto a un activo sin ficha previa.

## La causa

Los dos resolvers usaban el bean `modelMapper()` de `FrancoSystemsApplication`, que tiene `setFieldMatchingEnabled(true)` con acceso a campos privados. Para llenar `creadoEn` el mapper entra por reflexión a los campos internos de `java.time.LocalDateTime`, y en JDK 17 eso lanza:

```
InaccessibleObjectException: Unable to make field private final
java.time.LocalDate java.time.LocalDateTime.date accessible:
module java.base does not "opens java.time" to unnamed module
```

**La falla es al construir el mapeo, no al convertir un valor.** Por eso ocurría con cualquier input — verificado con uno vacío, uno parcial y uno completo, los tres fallaban igual. Y por eso el síntoma no daba ninguna pista sobre qué campo lo causaba.

## El remedio

El mismo que 40b6d3a8 aplicó a `ImpresoraGraphQL` la semana pasada: un `ModelMapper` propio con matching `STRICT`, en un `static final` para no reconstruir el `TypeMap` en cada request.

La diferencia con aquel caso: allá el problema era una ambigüedad de matching, acá lo que hay que apagar es el **field matching**, que es lo que dispara la reflexión. Aquel commit ya dejaba anotado por qué no conviene inyectar ese bean; esto es la misma advertencia cobrándose en otros dos resolvers.

`tipoEnte` y `usuarioId` ya se resuelven a mano contra el enum y el service, así que exigir nombres exactos no pierde nada.

## Alcance

Revisé todas las llamadas a `.map(input, X.class)` del central. Quedan dos, y son las dos de este PR. `InventarioProductoItemGraphQL` parecía sospechosa —su destino también tiene `LocalDateTime`— pero está a salvo: construye su propio `ModelMapper` local en vez de usar el bean.

## Verificación

- 494 tests en verde, incluidos 5 nuevos que cubren el mapeo de los dos inputs, con el caso de input vacío que delataba el bug.
- Contra el central local corriendo: las dos mutations responden OK con input vacío, parcial y completo.
- Desde la PWA: elegir un activo sin ficha previa ahora crea el ente y muestra la tarjeta, en vez de «No se pudo consultar el activo».

No toca ni el escritorio ni la PWA, pero los beneficia a los dos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163TzsnGbnUuxmoaSnxHPDi
