### PR TITLE
fix(activos): no informar un pendiente de cero cuando no hay datos del activo

### DIFF
--- a/src/main/java/com/franco/dev/service/activos/util/ActivoPagoNormalizer.java
+++ b/src/main/java/com/franco/dev/service/activos/util/ActivoPagoNormalizer.java
@@ -17,6 +17,25 @@ public final class ActivoPagoNormalizer {
     }
 
     /**
+     * El saldo pendiente que se le informa al cliente, o {@code null} cuando el central no
+     * tiene con que calcularlo.
+     *
+     * Sin monto total no hay deuda conocida. Devolver cero ahi afirma que el activo no debe
+     * nada, que es una afirmacion distinta de "no hay datos cargados" — y la lee alguien que
+     * esta por decidir cuanta plata pedir. Un activo recien dado de alta, sin financiacion,
+     * caia justo en ese caso: la PWA mostraba "Pendiente: 0,00".
+     *
+     * {@link #calcularMontoPendiente} sigue devolviendo un numero siempre porque
+     * {@link #debeMarcarComoPagado} lo compara; esta variante es la que va al DTO.
+     */
+    public static BigDecimal montoPendienteInformable(BigDecimal montoTotal, BigDecimal montoYaPagado) {
+        if (montoTotal == null) {
+            return null;
+        }
+        return calcularMontoPendiente(montoTotal, montoYaPagado);
+    }
+
+    /**
      * Un bien en estado PAGANDO sin saldo pendiente debe tratarse como pagado por completo,
      * incluyendo el ajuste de cuotas al 100% cuando existe un plan de cuotas.
      */

--- a/src/main/java/com/franco/dev/service/financiero/PreGastoService.java
+++ b/src/main/java/com/franco/dev/service/financiero/PreGastoService.java
@@ -955,8 +955,9 @@ public class PreGastoService extends CrudService<PreGasto, PreGastoRepository, E
         }
         BigDecimal total = dto.getMontoTotal() != null ? dto.getMontoTotal() : BigDecimal.ZERO;
         BigDecimal pagado = dto.getMontoYaPagado() != null ? dto.getMontoYaPagado() : BigDecimal.ZERO;
-        BigDecimal pendiente = total.subtract(pagado);
-        dto.setMontoPendiente(pendiente.compareTo(BigDecimal.ZERO) < 0 ? BigDecimal.ZERO : pendiente);
+        // Sin monto total el pendiente queda nulo: un cero afirmaria que no se debe nada.
+        dto.setMontoPendiente(
+                ActivoPagoNormalizer.montoPendienteInformable(dto.getMontoTotal(), dto.getMontoYaPagado()));
         ActivoPagoNormalizer.normalizarResumenSiPagadoCompleto(dto);
 
         if (total.compareTo(BigDecimal.ZERO) > 0) {

--- a/src/test/java/com/franco/dev/service/activos/util/ActivoPagoNormalizerPendienteTest.java
+++ b/src/test/java/com/franco/dev/service/activos/util/ActivoPagoNormalizerPendienteTest.java
@@ -1,0 +1,57 @@
+package com.franco.dev.service.activos.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * El resumen financiero de un activo lo lee alguien que esta por decidir cuanta plata pedir.
+ * "No debe nada" y "no hay datos cargados" son respuestas distintas, y devolver cero para la
+ * segunda afirma algo que nadie dijo: un vehiculo recien dado de alta, sin financiacion, hacia
+ * que la PWA mostrara "Pendiente: 0,00".
+ */
+class ActivoPagoNormalizerPendienteTest {
+
+    @Test
+    void sinMontoTotalNoHayPendienteQueInformar() {
+        assertNull(ActivoPagoNormalizer.montoPendienteInformable(null, null));
+    }
+
+    @Test
+    void sinMontoTotalTampocoSeInventaUnCeroAunqueHayaAlgoPagado() {
+        assertNull(ActivoPagoNormalizer.montoPendienteInformable(null, new BigDecimal("500")));
+    }
+
+    @Test
+    void conMontoTotalInformaLoQueFalta() {
+        assertEquals(0, new BigDecimal("45000000").compareTo(
+                ActivoPagoNormalizer.montoPendienteInformable(
+                        new BigDecimal("60000000"), new BigDecimal("15000000"))));
+    }
+
+    @Test
+    void unActivoSaldadoInformaCero() {
+        // Acá el cero sí es una afirmacion respaldada: hay total y esta todo pagado.
+        assertEquals(0, BigDecimal.ZERO.compareTo(
+                ActivoPagoNormalizer.montoPendienteInformable(
+                        new BigDecimal("100"), new BigDecimal("100"))));
+    }
+
+    @Test
+    void pagadoDeMasNoDevuelveNegativo() {
+        assertEquals(0, BigDecimal.ZERO.compareTo(
+                ActivoPagoNormalizer.montoPendienteInformable(
+                        new BigDecimal("100"), new BigDecimal("150"))));
+    }
+
+    @Test
+    void elCalculoInternoSigueDevolviendoNumeroParaDebeMarcarComoPagado() {
+        // `calcularMontoPendiente` no cambia: `debeMarcarComoPagado` lo compara sin
+        // chequear null.
+        assertEquals(0, BigDecimal.ZERO.compareTo(
+                ActivoPagoNormalizer.calcularMontoPendiente(null, null)));
+    }
+}


### PR DESCRIPTION
`getEnteFinancialSummary` informaba `montoPendiente: 0` para un activo que no tiene ninguna financiación cargada. Verificado contra el central local con un vehículo recién dado de alta: devolvía `montoTotal: null, montoYaPagado: null, montoPendiente: 0`.

## Por qué importa

El cálculo sustituía por cero los montos nulos:

```java
BigDecimal total  = dto.getMontoTotal()    != null ? dto.getMontoTotal()    : BigDecimal.ZERO;
BigDecimal pagado = dto.getMontoYaPagado() != null ? dto.getMontoYaPagado() : BigDecimal.ZERO;
dto.setMontoPendiente(total.subtract(pagado));   // 0 - 0 = 0
```

Ese resumen lo lee alguien que está por decidir **cuánta plata pedir**. Ahí «no debe nada» y «no hay datos cargados» son respuestas distintas, y el cero afirma la primera sin que nadie la haya dicho.

En la PWA se veía como «Pendiente: 0,00» — con decimales, además, porque sin moneda el formato cae a dos y el guaraní no lleva ninguno.

## El cambio

`ActivoPagoNormalizer.montoPendienteInformable` devuelve `null` cuando no hay monto total, y es lo que va al DTO.

**`calcularMontoPendiente` queda igual a propósito**: `debeMarcarComoPagado` compara su resultado sin chequear null, así que devolver null ahí rompería esa rama. Son dos preguntas distintas —«cuánto falta pagar para decidir si está saldado» y «qué le informo al cliente»— y ahora tienen dos métodos.

## Del lado del cliente, nada

La PWA ya distingue los dos casos y muestra «Sin datos del central» cuando recibe `null`; hoy no se activaba solo porque llegaba un cero calculado. Verificado en pantalla después del cambio: la tarjeta pasa de «Pendiente: 0,00» a «Sin datos del central», sin tocar una línea del frontend.

Las pantallas de activos del escritorio leen el mismo resumen, así que también dejan de mostrar el cero.

## Verificación

- 495 tests en verde, incluidos 6 nuevos sobre la regla: sin monto total no se informa pendiente, con monto total se informa lo que falta, un activo saldado sí informa cero —ahí el cero está respaldado—, y el cálculo interno sigue devolviendo número para `debeMarcarComoPagado`.
- Contra el central local: el resumen del vehículo sin financiación devuelve `montoPendiente: null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163TzsnGbnUuxmoaSnxHPDi
