### PR TITLE
feat(marcacion): registrar metodo, similitud y margen del segundo candidato

### DIFF
--- a/src/main/java/com/franco/dev/domain/administrativo/Marcacion.java
+++ b/src/main/java/com/franco/dev/domain/administrativo/Marcacion.java
@@ -1,5 +1,6 @@
 package com.franco.dev.domain.administrativo;
 
+import com.franco.dev.domain.administrativo.enums.MetodoMarcacion;
 import com.franco.dev.domain.administrativo.enums.TipoMarcacion;
 import com.franco.dev.domain.empresarial.Sucursal;
 import com.franco.dev.domain.personas.Usuario;
@@ -59,6 +60,30 @@ public class Marcacion implements Serializable {
 
     @Column(name = "device_info")
     private String deviceInfo;
+
+    /**
+     * Como se identifico a la persona. Ver {@link MetodoMarcacion}.
+     *
+     * Es VARCHAR y no un enum de Postgres --a diferencia de `tipo_marcacion`-- porque la
+     * tabla se replica a las filiales y un tipo nuevo habria que crearlo en cada una
+     * antes de que llegue la primera fila.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "metodo_registro", length = 30)
+    private MetodoMarcacion metodoRegistro;
+
+    /** Similitud del match aceptado, 0..1. Null si no hubo rostro. */
+    @Column(name = "similitud_facial")
+    private Float similitudFacial;
+
+    /**
+     * Cuanto le saco el reconocido al segundo candidato.
+     *
+     * Null cuando no hubo segundo --un solo enrolado-- o cuando no fue 1:N. No se rellena
+     * con 0 ni con 1: inventar la medicion es peor que no tenerla.
+     */
+    @Column(name = "margen_segundo_candidato")
+    private Float margenSegundoCandidato;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sucursal_entrada_id")

--- a/src/main/java/com/franco/dev/domain/administrativo/enums/MetodoMarcacion.java
+++ b/src/main/java/com/franco/dev/domain/administrativo/enums/MetodoMarcacion.java
@@ -1,0 +1,20 @@
+package com.franco.dev.domain.administrativo.enums;
+
+/**
+ * Como se identifico a la persona al registrar la marcacion.
+ *
+ * Existe para poder evaluar el 1:N con datos y no con impresiones: cuando aparezca un caso
+ * raro, sin esto no hay forma de distinguir un falso positivo de un olvido.
+ *
+ * Se guarda como texto y no como enum de Postgres a proposito: `administrativo.marcacion`
+ * esta replicada en las dos direcciones, y un tipo nuevo obliga a crearlo tambien en cada
+ * filial antes de que llegue la primera fila. Un VARCHAR no.
+ */
+public enum MetodoMarcacion {
+    /** Sin verificacion facial: la persona marco y confirmo que iba igual. */
+    MANUAL,
+    /** Verificacion 1:1 contra la galeria del usuario en sesion, en su telefono. */
+    FACIAL_1A1,
+    /** Identificacion 1:N en el kiosco compartido. Es la que puede marcar por otro. */
+    FACIAL_1AN_KIOSCO
+}

--- a/src/main/java/com/franco/dev/graphql/administrativo/MarcacionGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/administrativo/MarcacionGraphQL.java
@@ -127,6 +127,15 @@ public class MarcacionGraphQL implements GraphQLQueryResolver, GraphQLMutationRe
         if (marcacion.getDistanciaSucursalMetros() != null)
             e.setDistanciaSucursalMetros(marcacion.getDistanciaSucursalMetros());
 
+        // Como se identifico a la persona. Se copian solo si vinieron, igual que el resto:
+        // el desktop llama a este mismo metodo y no los manda.
+        if (marcacion.getMetodoRegistro() != null)
+            e.setMetodoRegistro(marcacion.getMetodoRegistro());
+        if (marcacion.getSimilitudFacial() != null)
+            e.setSimilitudFacial(marcacion.getSimilitudFacial());
+        if (marcacion.getMargenSegundoCandidato() != null)
+            e.setMargenSegundoCandidato(marcacion.getMargenSegundoCandidato());
+
         return service.save(e);
     }
 

--- a/src/main/java/com/franco/dev/graphql/administrativo/input/MarcacionInput.java
+++ b/src/main/java/com/franco/dev/graphql/administrativo/input/MarcacionInput.java
@@ -1,5 +1,6 @@
 package com.franco.dev.graphql.administrativo.input;
 
+import com.franco.dev.domain.administrativo.enums.MetodoMarcacion;
 import com.franco.dev.domain.administrativo.enums.TipoMarcacion;
 import lombok.Data;
 
@@ -28,4 +29,9 @@ public class MarcacionInput {
     private String codigo;
     private java.util.List<Double> embedding;
     private Boolean esSalidaAlmuerzo;
+
+    // Como se identifico a la persona. Opcionales: el desktop no los manda.
+    private MetodoMarcacion metodoRegistro;
+    private Float similitudFacial;
+    private Float margenSegundoCandidato;
 }

--- a/src/main/java/com/franco/dev/graphql/personas/UsuarioSimilitudResult.java
+++ b/src/main/java/com/franco/dev/graphql/personas/UsuarioSimilitudResult.java
@@ -5,10 +5,28 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * A quien reconocio el 1:N, y con cuanta ventaja sobre el siguiente.
+ *
+ * El margen es el dato que decide si una identificacion es solida. Una similitud de 0,71
+ * contra un segundo candidato de 0,45 identifica; la misma 0,71 contra un 0,69 es una
+ * moneda al aire. Sin el margen las dos llegan al cliente iguales, y despues no hay forma
+ * de distinguir un falso positivo de un acierto en los datos.
+ *
+ * `similitudSegundo` y `margen` son null cuando hay un solo enrolado: no hay contra quien
+ * comparar, y decir "margen 1" afirmaria una certeza que nadie midio.
+ */
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class UsuarioSimilitudResult {
     private Usuario usuario;
     private Double similitud;
+    private Double similitudSegundo;
+    private Double margen;
+
+    /** Compatibilidad con el uso anterior, que no conocia el segundo candidato. */
+    public UsuarioSimilitudResult(Usuario usuario, Double similitud) {
+        this(usuario, similitud, null, null);
+    }
 }

--- a/src/main/java/com/franco/dev/service/personas/UsuarioEmbeddingCacheService.java
+++ b/src/main/java/com/franco/dev/service/personas/UsuarioEmbeddingCacheService.java
@@ -89,6 +89,10 @@ public class UsuarioEmbeddingCacheService {
 
         CachedEntry best = null;
         double maxSimilarity = -1.0;
+        // El segundo mejor no es un extra: es lo unico que dice si el primero gano por
+        // mucho o por nada. Sin esto, 0,71 contra 0,45 y 0,71 contra 0,69 son la misma
+        // respuesta, y la segunda es una moneda al aire.
+        Double segundaSimilarity = null;
 
         for (CachedEntry entry : entries) {
             if (excluded.contains(entry.usuarioId.intValue())) {
@@ -96,13 +100,23 @@ public class UsuarioEmbeddingCacheService {
             }
             double similarity = embeddingGaleriaService.calcularMaximaSimilitud(queryEmbedding, entry.vectores);
             if (similarity > maxSimilarity) {
+                // El que venia primero pasa a segundo. Sin el `best != null` esto
+                // registraria como segundo el -1 del arranque, que no es nadie.
+                if (best != null) {
+                    segundaSimilarity = maxSimilarity;
+                }
                 maxSimilarity = similarity;
                 best = entry;
+            } else if (segundaSimilarity == null || similarity > segundaSimilarity) {
+                segundaSimilarity = similarity;
             }
         }
 
         if (best != null) {
-            return new UsuarioSimilitudResult(best.usuario, maxSimilarity);
+            // Con un solo candidato no hay margen. Devolver 0 o 1 seria inventar una
+            // medicion: null dice "no habia contra quien comparar", que es distinto.
+            Double margen = segundaSimilarity != null ? maxSimilarity - segundaSimilarity : null;
+            return new UsuarioSimilitudResult(best.usuario, maxSimilarity, segundaSimilarity, margen);
         }
         return null;
     }

--- a/src/main/resources/db/migration/V216.5__marcacion_metodo_y_similitud.sql
+++ b/src/main/resources/db/migration/V216.5__marcacion_metodo_y_similitud.sql
@@ -1,0 +1,45 @@
+-- Con que metodo se registro cada marcacion, y con cuanta confianza.
+--
+-- La marcacion guardaba buena evidencia de DONDE (latitud, longitud, precision_gps,
+-- distancia_sucursal) y ninguna de COMO se identifico a la persona. Con el kiosco de
+-- marcacion facial 1:N eso deja de ser un detalle: un falso positivo registra asistencia
+-- a nombre de quien no estuvo, y sin estas columnas es indistinguible de un olvido.
+--
+-- El margen contra el segundo candidato es el mas importante de los tres. Una similitud
+-- de 0,71 contra un segundo de 0,45 identifica; la misma 0,71 contra un 0,69 es una
+-- moneda al aire. El numero absoluto no distingue los dos casos; el margen si, y permite
+-- fijar el umbral con evidencia de esta poblacion --estas caras, estas camaras, esta
+-- luz-- en vez de copiarlo de un paper.
+--
+-- Aditiva: ningun DROP ni RENAME. Las tres columnas son opcionales, asi que el desktop
+-- --que usa saveMarcacion y no las manda-- sigue funcionando sin cambios.
+--
+-- ATENCION -- ESTA MIGRACION TIENE QUE CORRER TAMBIEN EN LAS FILIALES.
+-- `administrativo.marcacion` se replica en las dos direcciones: sube por BRANCH_TO_MAIN
+-- (ver V112) y baja por las publicaciones `central_filialN_pub`, que no llevan lista de
+-- columnas. Un publisher manda todas las columnas de la tabla: si el central gana una que
+-- la filial no tiene, la replicacion hacia esa filial se corta con "logical replication
+-- target relation is missing replicated column". Las columnas extra del lado del
+-- suscriptor no molestan; las que faltan, si.
+--
+-- Y ojo con el orden: sin `out-of-order` en Flyway, una filial que ya paso el
+-- installed_rank de este numero saltea la migracion en silencio y el corte aparece
+-- despues, en runtime.
+
+ALTER TABLE administrativo.marcacion
+    ADD COLUMN IF NOT EXISTS metodo_registro VARCHAR(30);
+
+-- La similitud del match aceptado, 0..1. Null cuando no hubo rostro (metodo MANUAL).
+ALTER TABLE administrativo.marcacion
+    ADD COLUMN IF NOT EXISTS similitud_facial REAL;
+
+-- Cuanto le saco al segundo candidato. Null cuando no hubo segundo contra quien comparar
+-- --un solo enrolado-- o cuando el metodo no fue 1:N. No se rellena con 0 ni con 1:
+-- inventar la medicion es peor que no tenerla.
+ALTER TABLE administrativo.marcacion
+    ADD COLUMN IF NOT EXISTS margen_segundo_candidato REAL;
+
+COMMENT ON COLUMN administrativo.marcacion.metodo_registro IS
+    'MANUAL | FACIAL_1A1 | FACIAL_1AN_KIOSCO. Texto y no enum de Postgres: la tabla se replica a las filiales y un tipo nuevo habria que crearlo en cada una.';
+COMMENT ON COLUMN administrativo.marcacion.margen_segundo_candidato IS
+    'similitud del mejor menos la del segundo. Es el dato que dice si el 1:N fue solido o una moneda al aire.';

--- a/src/main/resources/graphql/administrativo/marcacion.graphqls
+++ b/src/main/resources/graphql/administrativo/marcacion.graphqls
@@ -13,7 +13,11 @@ type Marcacion {
     
     deviceId: String
     deviceInfo: String
-    
+
+    metodoRegistro: MetodoMarcacion
+    similitudFacial: Float
+    margenSegundoCandidato: Float
+
     sucursalEntrada: Sucursal
     fechaEntrada: String
     
@@ -48,7 +52,11 @@ input MarcacionInput {
     
     deviceId: String
     deviceInfo: String
-    
+
+    metodoRegistro: MetodoMarcacion
+    similitudFacial: Float
+    margenSegundoCandidato: Float
+
     sucursalEntradaId: ID
     fechaEntrada: String
     
@@ -63,6 +71,13 @@ input MarcacionInput {
 enum TipoMarcacion {
     ENTRADA
     SALIDA
+}
+
+"""Como se identifico a la persona al registrar la marcacion."""
+enum MetodoMarcacion {
+    MANUAL
+    FACIAL_1A1
+    FACIAL_1AN_KIOSCO
 }
 
 extend type Query {

--- a/src/main/resources/graphql/personas/usuario.graphqls
+++ b/src/main/resources/graphql/personas/usuario.graphqls
@@ -13,6 +13,10 @@ type Usuario {
 type UsuarioSimilitud {
     usuario: Usuario
     similitud: Float
+    """La del siguiente candidato. Null si hay un solo enrolado."""
+    similitudSegundo: Float
+    """similitud - similitudSegundo. Dice si el 1:N fue solido o una moneda al aire."""
+    margen: Float
 }
 
 enum ResultadoIncorporacionEmbedding {

--- a/src/test/java/com/franco/dev/service/personas/UsuarioEmbeddingCacheMargenTest.java
+++ b/src/test/java/com/franco/dev/service/personas/UsuarioEmbeddingCacheMargenTest.java
@@ -1,0 +1,144 @@
+package com.franco.dev.service.personas;
+
+import com.franco.dev.domain.personas.Persona;
+import com.franco.dev.domain.personas.Usuario;
+import com.franco.dev.graphql.personas.UsuarioSimilitudResult;
+import com.franco.dev.repository.personas.UsuarioRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * El 1:N devuelve el mejor match; sin el segundo candidato ese numero no dice nada.
+ *
+ * Una similitud de 0,71 contra un segundo de 0,45 es una identificacion solida. La misma
+ * 0,71 contra un segundo de 0,69 es una moneda al aire, y hasta ahora las dos llegaban
+ * al cliente exactamente iguales: findBestMatch calculaba el maximo y descartaba el resto.
+ *
+ * Sin el margen, un falso positivo es indistinguible de un acierto en los datos. Con el
+ * margen se puede fijar un umbral con evidencia de esta poblacion en vez de copiarlo.
+ */
+class UsuarioEmbeddingCacheMargenTest {
+
+    private UsuarioRepository usuarioRepository;
+    private UsuarioEmbeddingCacheService cache;
+
+    /** Base ortonormal: el coseno contra cada eje es directamente su componente. */
+    private static final List<Double> CONSULTA = Arrays.asList(1.0, 0.0, 0.0);
+
+    @BeforeEach
+    void setUp() {
+        usuarioRepository = mock(UsuarioRepository.class);
+        cache = new UsuarioEmbeddingCacheService(usuarioRepository, new EmbeddingGaleriaService());
+    }
+
+    /**
+     * Un usuario cuya galeria es un solo vector, escrito como lo guarda la app.
+     *
+     * `parecido` es el coseno que va a dar contra {@link #CONSULTA}: se arma el vector
+     * (p, sqrt(1-p^2), 0), que tiene norma 1 y proyeccion p sobre el primer eje.
+     */
+    private Usuario usuarioConParecido(long id, double parecido) {
+        double resto = Math.sqrt(Math.max(0d, 1d - parecido * parecido));
+        String json = "{\"master\":[" + parecido + "," + resto + ",0.0],"
+                + "\"gallery\":[{\"pose\":\"front\",\"embedding\":["
+                + parecido + "," + resto + ",0.0],\"score\":0.9}]}";
+
+        Persona persona = new Persona();
+        persona.setId(id * 10);
+        persona.setNombre("Persona " + id);
+        persona.setEmbedding(json);
+
+        Usuario usuario = new Usuario();
+        usuario.setId(id);
+        usuario.setNickname("USUARIO" + id);
+        usuario.setActivo(true);
+        usuario.setPersona(persona);
+        return usuario;
+    }
+
+    private void enCache(Usuario... usuarios) {
+        when(usuarioRepository.findActivosConEmbedding()).thenReturn(new ArrayList<>(Arrays.asList(usuarios)));
+        cache.refreshAll();
+    }
+
+    @Test
+    void sinNadieEnLaCacheNoHayMatch() {
+        enCache();
+
+        assertNull(cache.findBestMatch(CONSULTA, Collections.emptyList()));
+    }
+
+    @Test
+    void devuelveElMejorDeTodos() {
+        enCache(usuarioConParecido(1, 0.45), usuarioConParecido(2, 0.71), usuarioConParecido(3, 0.30));
+
+        UsuarioSimilitudResult r = cache.findBestMatch(CONSULTA, Collections.emptyList());
+
+        assertNotNull(r);
+        assertEquals(2L, r.getUsuario().getId());
+        assertEquals(0.71, r.getSimilitud(), 0.001);
+    }
+
+    @Test
+    void informaLaSimilitudDelSegundoCandidato() {
+        enCache(usuarioConParecido(1, 0.45), usuarioConParecido(2, 0.71));
+
+        UsuarioSimilitudResult r = cache.findBestMatch(CONSULTA, Collections.emptyList());
+
+        assertEquals(0.45, r.getSimilitudSegundo(), 0.001);
+    }
+
+    @Test
+    void elMargenEsLaDistanciaAlSegundo() {
+        enCache(usuarioConParecido(1, 0.45), usuarioConParecido(2, 0.71));
+
+        UsuarioSimilitudResult r = cache.findBestMatch(CONSULTA, Collections.emptyList());
+
+        assertEquals(0.26, r.getMargen(), 0.001);
+    }
+
+    @Test
+    void unMargenChicoDelataLaMonedaAlAire() {
+        // Mismo 0,71 que el caso solido, y el numero absoluto no lo distingue.
+        enCache(usuarioConParecido(1, 0.69), usuarioConParecido(2, 0.71));
+
+        UsuarioSimilitudResult r = cache.findBestMatch(CONSULTA, Collections.emptyList());
+
+        assertEquals(0.71, r.getSimilitud(), 0.001);
+        assertTrue(r.getMargen() < 0.05, "el margen tiene que delatar que estuvo ajustado");
+    }
+
+    @Test
+    void conUnSoloEnroladoNoHaySegundoYElMargenNoSeInventa() {
+        enCache(usuarioConParecido(2, 0.71));
+
+        UsuarioSimilitudResult r = cache.findBestMatch(CONSULTA, Collections.emptyList());
+
+        // Ni 0 ni 1: no hay contra quien comparar, y decir "margen 1" afirmaria una
+        // certeza que nadie midio.
+        assertNull(r.getSimilitudSegundo());
+        assertNull(r.getMargen());
+    }
+
+    @Test
+    void elExcluidoNoCuentaComoSegundo() {
+        enCache(usuarioConParecido(1, 0.69), usuarioConParecido(2, 0.71), usuarioConParecido(3, 0.30));
+
+        UsuarioSimilitudResult r = cache.findBestMatch(CONSULTA, Collections.singletonList(1));
+
+        assertEquals(2L, r.getUsuario().getId());
+        assertEquals(0.30, r.getSimilitudSegundo(), 0.001);
+    }
+}


### PR DESCRIPTION
## Qué resuelve

`Closes #217`

La marcación guardaba buena evidencia de **dónde** —`latitud`, `longitud`, `precision_gps`, `distancia_sucursal`— y **ninguna de cómo se identificó a la persona**. Con el kiosco de marcación facial 1:N de la PWA (`GabFrank/frc-mobile-pwa#17`) eso deja de ser un detalle: un falso positivo registra asistencia a nombre de quien no estuvo, y sin estas columnas es indistinguible de un olvido.

## El margen es el punto

`findBestMatch()` calculaba el máximo y **descartaba el resto**, así que un `0.71` contra un segundo candidato de `0.45` —identificación sólida— llegaba al cliente **exactamente igual** que un `0.71` contra un `0.69`, que es una moneda al aire.

Ahora el segundo se conserva y `usuarioPorEmbedding` devuelve `similitudSegundo` y `margen`. Es lo que permite fijar un umbral con evidencia de esta población —estas caras, estas cámaras, esta luz— en vez de copiarlo.

## Cómo probarlo

```bash
./mvnw clean verify -B -DskipFlyway=true
```

**496 tests en verde**, incluidos 7 nuevos en `UsuarioEmbeddingCacheMargenTest`: el margen, el caso de un solo enrolado y el excluido que no cuenta como segundo. `SchemaEnumsSincronizadosTest` pasa — el enum de Java y el del `.graphqls` están sincronizados.

Contra una instancia real, con al menos dos personas enroladas:

```sql
SELECT metodo_registro, similitud_facial, margen_segundo_candidato
FROM administrativo.marcacion ORDER BY id DESC LIMIT 5;
```

Con un solo enrolado, `margen_segundo_candidato` tiene que quedar en `NULL` — ni 0 ni 1.

## Impacto en DB

`V216.5`, aditiva, sin `DROP` ni `RENAME`. Tres columnas nullable en `administrativo.marcacion`: `metodo_registro VARCHAR(30)`, `similitud_facial REAL`, `margen_segundo_candidato REAL`.

`metodo_registro` es **VARCHAR y no un enum de Postgres** —a diferencia de `tipo_marcacion`— porque la tabla se replica a las filiales y un tipo nuevo habría que crearlo en cada una antes de que llegue la primera fila.

## ⚠️ Requiere la migración espejo en la filial, ANTES

**`GabFrank/franco-system-backend-filial#116` (`V91.5`) tiene que estar aplicada en todas las filiales.**

`administrativo.marcacion` se replica en **las dos direcciones** —sube por `BRANCH_TO_MAIN` (V112) y baja por `central_filial<N>_pub`— y ninguna de esas publicaciones lleva lista de columnas: el publicador manda todas. El suscriptor necesita todas las que el publicador manda.

- Central primero → se corta la **bajada** a las filiales que no la tengan.
- Filial primero → se corta la **subida** hacia un central que no la tenga.

Es simétrico, así que **las dos migraciones van en la misma ventana**, en horario de poca marcación. Y hay que confirmar `flyway_schema_history` **filial por filial**: sin `out-of-order`, una que ya pasó ese `installed_rank` la saltea en silencio.

El modo de falla es `logical replication target relation is missing replicated column` → crash-loop, slot inactivo, WAL creciendo. Mismo patrón que el incidente del 2026-08-20 con el enum `tipo_dispositivo`. **Es recuperable**: se aplica la migración que falta y el worker se pone al día.

## Impacto en rollback

**El JAR se puede revertir sin problema.** `ddl-auto=none` y las columnas son nullable, así que un JAR anterior convive con ellas.

⚠️ **Pero la exigencia sobre las filiales no se revierte.** La publicación es de la base, no del JAR: una vez aplicada `V216.5`, las filiales necesitan `V91.5` para siempre. En la práctica esta migración es de ida.

## Impacto cross-proyecto

**Ninguno.** Todo es aditivo: 3 campos opcionales en `MarcacionInput`, 3 en el tipo `Marcacion`, 2 en `UsuarioSimilitud`, un enum nuevo. Nada borrado ni renombrado.

- **Desktop** (`frc-sistemas-integrados-angular`): verificado. Su `marcacionFragment` selecciona solo campos preexistentes, su `usuarioPorEmbedding` pide `usuario` + `similitud` y nada más, y su clase `MarcacionInput` no tiene los campos nuevos. No necesita redeploy.
- **PWA vieja** (build cacheado por el service worker): sigue funcionando. Este PR se puede mergear y desplegar **antes** que el de la PWA.
- **APK legacy**: igual.

Lo que **no** se puede es al revés: la PWA nueva contra un central sin esto rompe la marcación entera, porque manda `metodoRegistro` en toda marcación.

## Riesgo

**Medio.** El código es aditivo y de bajo riesgo; el riesgo está en la coordinación de las dos migraciones y en verificar filial por filial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ao455deF3nmPa22hafSTti