### PR TITLE
feat(personas): mutation para asignar varios roles a un usuario [FRC]

### DIFF
--- a/src/main/java/com/franco/dev/graphql/personas/UsuarioRoleGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/personas/UsuarioRoleGraphQL.java
@@ -12,8 +12,12 @@ import graphql.kickstart.tools.GraphQLMutationResolver;
 import graphql.kickstart.tools.GraphQLQueryResolver;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Component
 public class UsuarioRoleGraphQL implements GraphQLQueryResolver, GraphQLMutationResolver {
@@ -36,16 +40,44 @@ public class UsuarioRoleGraphQL implements GraphQLQueryResolver, GraphQLMutation
     }
 
     public UsuarioRole saveUsuarioRole(UsuarioRoleInput input) {
+        Usuario usuario = usuarioService.findById(input.getUserId()).orElse(null);
+        return guardarUsuarioRole(input, usuario);
+    }
+
+    @Transactional
+    public List<UsuarioRole> saveUsuarioRoleList(List<UsuarioRoleInput> inputList) {
+        List<UsuarioRole> guardados = new ArrayList<>();
+        if (inputList == null || inputList.isEmpty()) {
+            return guardados;
+        }
+        Long userId = inputList.get(0).getUserId();
+        Usuario usuario = userId != null ? usuarioService.findById(userId).orElse(null) : null;
+        Set<Long> rolesActuales = new HashSet<>();
+        if (userId != null) {
+            for (UsuarioRole ur : service.findByUserId(userId)) {
+                if (ur.getRole() != null) {
+                    rolesActuales.add(ur.getRole().getId());
+                }
+            }
+        }
+        for (UsuarioRoleInput input : inputList) {
+            if (input.getRoleId() == null || !rolesActuales.add(input.getRoleId())) {
+                continue;
+            }
+            guardados.add(guardarUsuarioRole(input, usuario));
+        }
+        return guardados;
+    }
+
+    private UsuarioRole guardarUsuarioRole(UsuarioRoleInput input, Usuario usuario) {
         UsuarioRole e = new UsuarioRole();
         if (input.getId() != null) {
             e.setId(input.getId());
         }
-        Usuario usuario = usuarioService.findById(input.getUserId()).orElse(null);
         e.setUser(usuario);
         e.setUsuario(usuario);
         e.setRole(roleService.findById(input.getRoleId()).orElse(null));
-        e = service.save(e);
-        return e;
+        return service.save(e);
     }
 
     public Boolean deleteUsuarioRole(Long id) {

--- a/src/main/resources/graphql/personas/usuario-role.graphqls
+++ b/src/main/resources/graphql/personas/usuario-role.graphqls
@@ -19,6 +19,7 @@ extend type Query {
 
 extend type Mutation {
     saveUsuarioRole(usuarioRole:UsuarioRoleInput!):UsuarioRole!
+    saveUsuarioRoleList(usuarioRoleList:[UsuarioRoleInput!]!):[UsuarioRole!]!
     deleteUsuarioRole(id:ID!):Boolean!
 }
 


### PR DESCRIPTION
## Qué resuelve

El desktop asigna roles a un usuario de a uno: un `saveUsuarioRole` por rol. Esta mutation permite mandarlos todos juntos, para el multi-select del PR [GabFrank/frc-sistemas-integrados-angular#260](https://github.com/GabFrank/frc-sistemas-integrados-angular/pull/260).

## Qué cambia

`usuario-role.graphqls`:

```graphql
saveUsuarioRoleList(usuarioRoleList: [UsuarioRoleInput!]!): [UsuarioRole!]!
```

`UsuarioRoleGraphQL.saveUsuarioRoleList()`, `@Transactional`:

- Resuelve el `Usuario` una sola vez en vez de una por rol.
- Carga los roles que el usuario ya tiene y descarta los repetidos — tanto contra lo ya persistido como contra duplicados dentro del mismo lote.
- Devuelve solo los `UsuarioRole` efectivamente creados.

El armado de la entidad se extrajo a `guardarUsuarioRole()`, que ahora comparten la mutation simple y la nueva. **`saveUsuarioRole` no cambia de firma ni de comportamiento.**

## Cómo probarlo

Desde GraphiQL, con un usuario que ya tenga el rol 5:

```graphql
mutation {
  saveUsuarioRoleList(usuarioRoleList: [
    {userId: 101, roleId: 5},
    {userId: 101, roleId: 8},
    {userId: 101, roleId: 8},
    {userId: 101, roleId: 9}
  ]) { id role { id nombre } }
}
```

Devuelve solo los roles 8 y 9 (uno solo el 8, y el 5 se saltea por repetido). Verificar con `usuarioRolePorUsuarioId` que no quedaron duplicados.

## Impacto

- **DB:** ninguno, sin migraciones.
- **API:** cambio **aditivo**. `saveUsuarioRole` sigue igual, así que el desktop actual y la PWA no se ven afectados. No es breaking.
- **Rollback:** limpio. Si se revierte, el front nuevo pierde el botón "Agregar (N)" pero nada más se rompe.
- **Riesgo:** bajo.

## Verificación

`./mvnw clean verify -B -DskipFlyway=true` → BUILD SUCCESS, 500 tests, 0 fallas. `SchemaEnumsSincronizadosTest` y `SchemaSinCamposDuplicadosTest` incluidos.

## Orden de despliegue

Este PR va **antes** que el del desktop: hasta que el central esté desplegado, el botón del front devuelve error de campo desconocido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyppKiNNxzE37GnTtrZEW6