### PR TITLE
feat(rrhh): proteger el catalogo de conceptos de liquidacion al borrar y renombrar

### DIFF
--- a/src/main/java/com/franco/dev/graphql/rrhh/LiquidacionConceptoGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/rrhh/LiquidacionConceptoGraphQL.java
@@ -2,8 +2,10 @@ package com.franco.dev.graphql.rrhh;
 
 import com.franco.dev.domain.rrhh.LiquidacionConcepto;
 import com.franco.dev.graphql.rrhh.input.LiquidacionConceptoInput;
+import com.franco.dev.repository.rrhh.LiquidacionItemRepository;
 import com.franco.dev.service.personas.UsuarioService;
 import com.franco.dev.service.rrhh.LiquidacionConceptoService;
+import graphql.GraphQLException;
 import graphql.kickstart.tools.GraphQLMutationResolver;
 import graphql.kickstart.tools.GraphQLQueryResolver;
 import org.modelmapper.ModelMapper;
@@ -29,6 +31,9 @@ public class LiquidacionConceptoGraphQL implements GraphQLQueryResolver, GraphQL
     @Autowired
     private UsuarioService usuarioService;
 
+    @Autowired
+    private LiquidacionItemRepository liquidacionItemRepository;
+
     public Optional<LiquidacionConcepto> liquidacionConcepto(Long id) {
         return service.findById(id);
     }
@@ -52,8 +57,9 @@ public class LiquidacionConceptoGraphQL implements GraphQLQueryResolver, GraphQL
         return service.count();
     }
 
-    public LiquidacionConcepto saveLiquidacionConcepto(LiquidacionConceptoInput input) {
+    public LiquidacionConcepto saveLiquidacionConcepto(LiquidacionConceptoInput input) throws GraphQLException {
         seg.requireAnyRole(seg.CONFIG, seg.GESTIONAR);
+        validarCodigo(input);
         ModelMapper m = new ModelMapper();
         // Ver ConfiguracionRrhhGraphQL: en update, los campos null del input no deben
         // pisar valores existentes (ej. creadoEn) y disparar NOT NULL al guardar.
@@ -77,8 +83,55 @@ public class LiquidacionConceptoGraphQL implements GraphQLQueryResolver, GraphQL
         return service.save(e);
     }
 
-    public Boolean deleteLiquidacionConcepto(Long id) {
+    /**
+     * El codigo es la unica llave entre el catalogo y {@code liquidacion_item.codigo}, que
+     * es un String suelto: si se duplica, findByCodigo empieza a resolver cualquiera de
+     * los dos; si se renombra uno ya emitido, los items historicos quedan huerfanos igual
+     * que si lo hubieran borrado. La base no protege ninguno de los dos casos.
+     */
+    private void validarCodigo(LiquidacionConceptoInput input) throws GraphQLException {
+        if (input.getCodigo() == null) return;
+        String codigo = input.getCodigo().toUpperCase();
+        LiquidacionConcepto conMismoCodigo = service.findByCodigo(codigo).orElse(null);
+        if (conMismoCodigo != null && !conMismoCodigo.getId().equals(input.getId())) {
+            throw new GraphQLException("Ya existe un concepto con el codigo " + codigo);
+        }
+        if (input.getId() == null) return;
+        LiquidacionConcepto actual = service.findById(input.getId()).orElse(null);
+        if (actual == null || actual.getCodigo() == null || actual.getCodigo().equals(codigo)) return;
+        Long items = liquidacionItemRepository.countByCodigo(actual.getCodigo());
+        if (items != null && items > 0) {
+            throw new GraphQLException(
+                    "No se puede cambiar el codigo: " + actual.getCodigo() + " aparece en " + items
+                            + " item(s) de liquidaciones ya emitidas");
+        }
+    }
+
+    /**
+     * Borrar un concepto ya usado deja recibos historicos sin etiqueta y sin forma de
+     * saber si eran remunerativos: {@code liquidacion_item.codigo} es un String, no una
+     * FK, asi que la base no lo impide. Para sacarlo de circulacion esta {@code activo =
+     * false}, que lo saca del select de item manual sin tocar lo emitido.
+     *
+     * <p>Ademas CrudService.deleteById atrapa la excepcion y devuelve false, y el desktop
+     * toma como exito cualquier respuesta sin errors: sin este chequeo la UI diria
+     * "eliminado con exito" sin haber borrado nada. Mismo patron que
+     * CargoGraphQL.deleteCargo.</p>
+     */
+    public Boolean deleteLiquidacionConcepto(Long id) throws GraphQLException {
         seg.requireAnyRole(seg.CONFIG, seg.GESTIONAR);
+        LiquidacionConcepto concepto = service.findById(id).orElse(null);
+        if (concepto == null) {
+            throw new GraphQLException("No se puede eliminar: el concepto ya no existe");
+        }
+        if (concepto.getCodigo() != null) {
+            Long items = liquidacionItemRepository.countByCodigo(concepto.getCodigo());
+            if (items != null && items > 0) {
+                throw new GraphQLException(
+                        "No se puede eliminar: el concepto " + concepto.getCodigo() + " aparece en "
+                                + items + " item(s) de liquidaciones ya emitidas. Desactivelo en vez de borrarlo");
+            }
+        }
         return service.deleteById(id);
     }
 }

--- a/src/main/java/com/franco/dev/repository/rrhh/LiquidacionItemRepository.java
+++ b/src/main/java/com/franco/dev/repository/rrhh/LiquidacionItemRepository.java
@@ -19,6 +19,14 @@ public interface LiquidacionItemRepository extends HelperRepository<LiquidacionI
     List<LiquidacionItem> findByLiquidacionIdAndManualFalse(Long liquidacionId);
 
     /**
+     * Items ya emitidos que usan un codigo del catalogo. {@code liquidacion_item.codigo}
+     * es un String, no una FK, asi que la base no impide borrar un concepto en uso: los
+     * recibos historicos se quedarian sin etiqueta y el codigo dejaria de resolver a
+     * remunerativo/no remunerativo. Lo chequea LiquidacionConceptoGraphQL antes de borrar.
+     */
+    Long countByCodigo(String codigo);
+
+    /**
      * Suma ya cobrada de una cuota de venta a credito (CREDITO_CONVENIO_CUOTA) por las
      * liquidaciones mensuales no ANULADAS, excluyendo la liquidacion en curso.
      */

--- a/src/main/java/com/franco/dev/service/rrhh/LiquidacionConceptoService.java
+++ b/src/main/java/com/franco/dev/service/rrhh/LiquidacionConceptoService.java
@@ -38,12 +38,9 @@ public class LiquidacionConceptoService extends CrudService<LiquidacionConcepto,
         if (entity.getEsHaber() == null) entity.setEsHaber(true);
         if (entity.getEsCalculadoAuto() == null) entity.setEsCalculadoAuto(false);
         // Default true, igual que la columna: un cliente viejo que no manda el campo no
-        // puede reventar el insert.
-        //
-        // Ojo: hoy no hay ABM de conceptos en el desktop, asi que este default es el
-        // camino normal y no la red. Un concepto nuevo entra a la base remunerativa sin
-        // que nadie lo decida -- la misma falla silenciosa que este cambio corrige en
-        // otro lado. Cuando exista el ABM, tiene que pedir el valor en el alta.
+        // puede reventar el insert. Es la red, no el camino normal: el ABM del desktop
+        // (list-liquidacion-concepto) pide el valor explicitamente en el alta, para que
+        // nadie entre a la base remunerativa del aguinaldo y del IPS por omision.
         if (entity.getEsRemunerativo() == null) entity.setEsRemunerativo(true);
         if (entity.getCodigo() != null) entity.setCodigo(entity.getCodigo().toUpperCase());
         return super.save(entity);


### PR DESCRIPTION
## Qué resuelve

Acompaña al ABM de conceptos de liquidación del desktop (GabFrank/frc-sistemas-integrados-angular#246). Con la pantalla nueva, borrar y renombrar conceptos deja de ser algo que solo pasaba por SQL, así que el backend tiene que defender el catálogo.

`liquidacion_item.codigo` es un `String`, no una FK: la base deja borrar un concepto ya usado, deja duplicar su código y deja renombrarlo. En los tres casos los recibos históricos quedan sin etiqueta y sus ítems dejan de resolver si eran remunerativos, sin ningún error visible.

- `deleteLiquidacionConcepto` cuenta los ítems emitidos con ese código y rechaza con `GraphQLException`, indicando que se desactive en vez de borrar.
- `saveLiquidacionConcepto` rechaza un código repetido y el cambio de código de un concepto ya emitido.
- `LiquidacionItemRepository.countByCodigo` es lo único nuevo del lado de datos.

Sin el chequeo previo el desktop mostraba "eliminado con éxito" sin haber borrado nada, porque `CrudService.deleteById` atrapa la excepción y devuelve `false`. Mismo patrón que `CargoGraphQL.deleteCargo`.

## Cómo probarlo

Con el central en 8081 y el desktop apuntando ahí, en RRHH → Configuración → Conceptos de liquidación:

1. Eliminar `SALARIO_BASE` (482 ítems emitidos) → rechazado, con el conteo en el mensaje; la fila queda en la lista.
2. Crear un concepto con código `SALARIO_BASE` → *«Ya existe un concepto con el codigo SALARIO_BASE»*.
3. Crear `PRUEBA_ABM` y eliminarlo → se borra, porque no tiene ítems.

Verificado en la UI contra el central de desarrollo, y contrastado con la base después de cada paso.

## Impacto en DB

Ninguno: no trae migración. Solo lecturas nuevas (`count`) sobre `rrhh.liquidacion_item`.

## Riesgo

Bajo. Solo agrega rechazos donde antes había un borrado silencioso o un catálogo corrompible. Ningún cliente existente dependía de poder borrar un concepto en uso — hasta ahora no había forma de intentarlo desde la UI.

## Rollback

Volver el JAR a la versión anterior alcanza; no hay estado nuevo que revertir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCvkRsbeRLuPFX36aGTjQn