### PR TITLE
fix(compras): descartar el costo de compra con salto implausible

### DIFF
--- a/src/main/java/com/franco/dev/service/productos/CostosPorProductoService.java
+++ b/src/main/java/com/franco/dev/service/productos/CostosPorProductoService.java
@@ -10,6 +10,8 @@ import com.franco.dev.service.CrudService;
 import com.franco.dev.service.operaciones.MovimientoStockService;
 import com.franco.dev.service.productos.builder.CostoMedioCalculator;
 import lombok.AllArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -23,6 +25,8 @@ import java.util.List;
 @Service
 @AllArgsConstructor
 public class CostosPorProductoService extends CrudService<CostoPorProducto, CostosPorProductoRepository, Long> {
+
+    private static final Logger log = LoggerFactory.getLogger(CostosPorProductoService.class);
 
     @Autowired
     private final CostosPorProductoRepository repository;
@@ -121,6 +125,22 @@ public class CostosPorProductoService extends CrudService<CostoPorProducto, Cost
     public static final String SUCURSAL_COMPRAS = "COMPRAS";
 
     /**
+     * Cuántas veces puede crecer el costo de un producto en una sola compra antes de considerarlo
+     * un error de conversión de moneda. 100 queda holgadamente por encima de cualquier aumento real
+     * y por debajo de la cotización más baja en uso (real ~1.100), que es el factor con el que se
+     * inflaba el costo cuando se aplicaba la cotización dos veces.
+     */
+    private static final double FACTOR_SALTO_SOSPECHOSO = 100.0;
+
+    /**
+     * Costo mínimo en Gs para que el costo anterior sirva como ancla del guard. Por debajo de esto
+     * el valor previo no es un costo en guaraníes creíble (nada cuesta menos de 100 Gs): es un
+     * importe en moneda extranjera guardado sin cotización. Anclar el guard en un valor así haría
+     * que la primera compra correcta pareciera un salto y quedara descartada para siempre.
+     */
+    private static final double COSTO_ANCLA_MINIMO_GS = 100.0;
+
+    /**
      * Aplica el costo de una compra real (recepción de mercadería) al producto.
      *
      * - costoMedio: promedio ponderado GLOBAL en Gs (moneda base), usando el inventario REAL
@@ -133,9 +153,12 @@ public class CostosPorProductoService extends CrudService<CostoPorProducto, Cost
      *   como Gs, así que se persiste ya convertido para no depender de que cada lector aplique la cotización.
      * - Dedup: si el costo resultante es idéntico al último registro (mismo costoMedio, ultimoPrecioCompra
      *   y moneda), NO se inserta una fila nueva. Evita inflar la tabla con compras al mismo precio.
+     * - Guard: si el costo salta más de {@link #FACTOR_SALTO_SOSPECHOSO} veces respecto al anterior se
+     *   descarta y se conserva el costo previo, porque es una conversión de moneda aplicada de más.
      *
-     * @return el CostoPorProducto resultante (nuevo, o el último existente si no hubo cambio);
-     *         null si la compra no tenía un costo válido (no aplica a bonificaciones).
+     * @return el CostoPorProducto resultante (nuevo, o el último existente si no hubo cambio o si el
+     *         salto de costo se descartó); null si la compra no tenía un costo válido (no aplica a
+     *         bonificaciones).
      */
     @org.springframework.transaction.annotation.Transactional
     public CostoPorProducto aplicarCostoCompra(Producto producto, Double cantidadEntrada, Double costoUnitario,
@@ -157,12 +180,45 @@ public class CostosPorProductoService extends CrudService<CostoPorProducto, Cost
                 producto.getId(), Arrays.asList(SUCURSAL_COMPRAS));
         if (stockReal == null) stockReal = 0.0;
 
+        // Guard anti-inflación: un costo que salta decenas de veces respecto al anterior casi nunca es
+        // un cambio de precio real, es un importe que ya venía en Gs y se volvió a multiplicar por la
+        // cotización. Si se dejara pasar, el costo inflado vuelve como precio sugerido de la compra
+        // siguiente y el error se compone en cada compra (ver FACTOR_SALTO_SOSPECHOSO).
+        if (esSaltoSospechoso(costoAnterior, costoEnGs)) {
+            log.warn("Costo de compra descartado por salto sospechoso: producto={} ({}), costo anterior={} Gs, " +
+                            "costo nuevo={} Gs, moneda={}, cotizacion={}. Se conserva el costo anterior.",
+                    producto.getId(), producto.getDescripcion(), costoAnterior.getUltimoPrecioCompra(),
+                    costoEnGs, (moneda != null ? moneda.getDenominacion() : null), cotiz);
+            return costoAnterior;
+        }
+
         Double costoMedioAnterior = (costoAnterior != null) ? costoAnterior.getCostoMedio() : null;
         double nuevoCostoMedio = CostoMedioCalculator.calcular(stockReal, cantidadEntrada, costoMedioAnterior,
                 costoEnGs);
 
         return guardarSiCambia(producto, nuevoCostoMedio, costoEnGs, moneda, cotiz, sucursal, usuario, fecha,
                 costoAnterior);
+    }
+
+    /**
+     * Detecta un salto de costo implausible respecto al último costo conocido.
+     *
+     * Solo mira hacia arriba: una baja de precio grande es plausible (bonificación, cambio de proveedor),
+     * mientras que una subida de dos órdenes de magnitud en la práctica siempre fue una conversión de
+     * moneda aplicada de más. El umbral está muy por encima de cualquier suba real de precio y por
+     * debajo de la cotización más baja en uso (el real, ~1.100), así que no puede tapar un error de
+     * cotización real ni bloquear un aumento legítimo.
+     *
+     * Y solo actúa si el costo anterior es un ancla creíble: si el producto arrastra un costo por
+     * debajo de {@link #COSTO_ANCLA_MINIMO_GS} (típicamente un precio en US$/R$ guardado sin
+     * cotización, p.ej. 7,99), la primera compra correcta en Gs se vería como un salto de ~1.000x
+     * y el guard la descartaría, dejando el costo malo congelado para siempre.
+     */
+    private boolean esSaltoSospechoso(CostoPorProducto costoAnterior, double costoEnGs) {
+        if (costoAnterior == null) return false;
+        Double anterior = costoAnterior.getUltimoPrecioCompra();
+        if (anterior == null || anterior < COSTO_ANCLA_MINIMO_GS) return false;
+        return costoEnGs > anterior * FACTOR_SALTO_SOSPECHOSO;
     }
 
     /**

--- a/src/test/java/com/franco/dev/service/productos/CostosPorProductoServiceTest.java
+++ b/src/test/java/com/franco/dev/service/productos/CostosPorProductoServiceTest.java
@@ -177,6 +177,85 @@ class CostosPorProductoServiceTest {
                 sucursal(2L), null, LocalDateTime.now()));
     }
 
+    // --- aplicarCostoCompra: guard anti-inflación por cotización aplicada de más ---
+
+    /**
+     * Caso real del producto 6993: una compra de 0,57 US$ a 5980 quedó registrada como 3.408,6 Gs,
+     * el diálogo de pedido volvió a multiplicar por la cotización y la compra siguiente entró a
+     * 3.408,6 "US$" = 20.383.428 Gs. Ese salto se descarta y el costo anterior se conserva.
+     */
+    @Test
+    void aplicarCostoCompra_saltoPorCotizacionAplicadaDeMas_descartaYConservaElAnterior() {
+        Moneda usd = moneda(3L);
+        CostoPorProducto anterior = costoAnterior(3393.63, 3408.6, usd);
+        stubUltimoCosto(anterior);
+        stubStockReal(100.0);
+
+        // 3408,6 "US$" x 5980 = 20.383.428 Gs
+        CostoPorProducto r = service.aplicarCostoCompra(producto(6993L), 10.0, 3408.6, usd, 5980.0,
+                sucursal(2L), null, LocalDateTime.now());
+
+        assertSame(anterior, r);
+        verify(repository, never()).save(any(CostoPorProducto.class));
+    }
+
+    @Test
+    void aplicarCostoCompra_aumentoFuertePeroPlausible_seGuarda() {
+        Moneda gs = moneda(1L);
+        stubUltimoCosto(costoAnterior(10000.0, 10000.0, gs));
+        stubStockReal(5.0); // no pondera
+
+        // x50: brutal para un precio, pero por debajo del umbral. Tiene que pasar.
+        CostoPorProducto r = service.aplicarCostoCompra(producto(10L), 10.0, 500000.0, gs, 1.0,
+                sucursal(2L), null, LocalDateTime.now());
+
+        assertEquals(500000.0, r.getUltimoPrecioCompra(), DELTA);
+        verify(repository, times(1)).save(any(CostoPorProducto.class));
+    }
+
+    @Test
+    void aplicarCostoCompra_bajaFuerte_seGuarda() {
+        Moneda gs = moneda(1L);
+        stubUltimoCosto(costoAnterior(500000.0, 500000.0, gs));
+        stubStockReal(5.0);
+
+        CostoPorProducto r = service.aplicarCostoCompra(producto(10L), 10.0, 100.0, gs, 1.0,
+                sucursal(2L), null, LocalDateTime.now());
+
+        assertEquals(100.0, r.getUltimoPrecioCompra(), DELTA);
+        verify(repository, times(1)).save(any(CostoPorProducto.class));
+    }
+
+    /**
+     * Un costo anterior por debajo del mínimo creíble en Gs (p.ej. 7,99, que es un precio en R$
+     * guardado sin cotización) no puede servir de ancla: si lo fuera, la primera compra correcta
+     * en guaraníes parecería un salto de ~1.000x y quedaría descartada para siempre.
+     */
+    @Test
+    void aplicarCostoCompra_costoAnteriorNoCreiblePorBajo_noActivaElGuard() {
+        Moneda gs = moneda(1L);
+        stubUltimoCosto(costoAnterior(7.99, 7.99, moneda(2L)));
+        stubStockReal(5.0);
+
+        CostoPorProducto r = service.aplicarCostoCompra(producto(8761L), 10.0, 8800.0, gs, 1.0,
+                sucursal(2L), null, LocalDateTime.now());
+
+        assertEquals(8800.0, r.getUltimoPrecioCompra(), DELTA);
+        verify(repository, times(1)).save(any(CostoPorProducto.class));
+    }
+
+    @Test
+    void aplicarCostoCompra_sinCostoPrevio_noActivaElGuard() {
+        stubUltimoCosto(null);
+        stubStockReal(10.0);
+
+        CostoPorProducto r = service.aplicarCostoCompra(producto(10L), 10.0, 5000000.0, moneda(1L), 1.0,
+                sucursal(2L), null, LocalDateTime.now());
+
+        assertEquals(5000000.0, r.getUltimoPrecioCompra(), DELTA);
+        verify(repository, times(1)).save(any(CostoPorProducto.class));
+    }
+
     // --- registrarCostoCompraManual (transferencia desde COMPRAS) ---
 
     @Test


### PR DESCRIPTION
## Qué resuelve

Red de contención para un bug de costos que se **componía en cada compra**: el costo sugerido al cargar un producto en un pedido salía multiplicado por la cotización, se aceptaba, se recepcionaba, y volvía como costo de la compra siguiente.

Caso real en `bodega3`, producto 6993 (AMSTEL LAGER BOT 250 ML), tres compras consecutivas:

| Fecha | Moneda / cotiz. | Precio en la nota | `ultimo_precio_compra` resultante |
|---|---|---|---|
| 09/08 10:00 | US$ 5980 | **0,57 US$** ✅ | 3.408,6 |
| 09/08 10:06 | US$ 5980 | 3.408,6 "US$" ❌ | 20.383.428 |
| 07/09 08:10 | Gs | 121.892.899.440 ❌ | 121.892.899.440 |

Es exactamente `0,57 × 5980³`. Ninguna pantalla avisó nada.

**La causa raíz está del lado del lector, en el desktop** — ver `GabFrank/frc-sistemas-integrados-angular` rama `fix/compras-costo-inflado-cotizacion`. `costo_por_producto.ultimo_precio_compra` se persiste en guaraníes desde 3920ae74, igual que `costo_medio`, y `moneda`/`cotizacion` quedaron como referencia de la compra original; el diálogo de ítem de pedido seguía con la semántica vieja y lo multiplicaba por `costo.cotizacion` "para convertirlo a Gs".

Este PR es la contención en el central: aunque un cliente vuelva a mandar un precio inflado, el costo del producto no se envenena.

## Qué cambia

`CostosPorProductoService.aplicarCostoCompra`: si el costo en Gs de una compra supera **100×** el último costo conocido del producto, se descarta y se conserva el anterior, con un `log.warn` que identifica producto, montos, moneda y cotización.

Dos decisiones de diseño:

- **Solo mira hacia arriba.** Una baja fuerte es plausible (bonificación, cambio de proveedor); una subida de dos órdenes de magnitud en la práctica siempre fue una conversión aplicada de más. El umbral queda muy por encima de cualquier aumento real y por debajo de la cotización más baja en uso (el real, ~1.100).
- **Solo actúa con un ancla creíble.** Si el producto arrastra un costo por debajo de 100 Gs (típicamente un precio en US$/R$ guardado sin cotización, p.ej. 7,99), la primera compra correcta en Gs se vería como un salto de ~1.000× y el guard la descartaría, dejando el costo malo congelado para siempre. Ese caso existe hoy en la base (producto 8761).

## Cómo probarlo

`./mvnw test -Dtest=CostosPorProductoServiceTest` — 15 tests, 5 nuevos:

- `aplicarCostoCompra_saltoPorCotizacionAplicadaDeMas_descartaYConservaElAnterior` reproduce el segundo escalón del caso real (3.408,6 × 5980 = 20.383.428). Verificado que **falla sin el guard**, con el valor observado `2.0383428E7`.
- `aplicarCostoCompra_aumentoFuertePeroPlausible_seGuarda` (×50 pasa)
- `aplicarCostoCompra_bajaFuerte_seGuarda`
- `aplicarCostoCompra_costoAnteriorNoCreiblePorBajo_noActivaElGuard`
- `aplicarCostoCompra_sinCostoPrevio_noActivaElGuard`

Preflight completo: `./mvnw clean verify -B -DskipFlyway=true` → **512 tests, 0 fallos**.

## Impacto en DB

**Ninguno.** Sin migraciones, sin cambios de schema. Solo cambia qué fila se inserta (o no) en `productos.costo_por_producto` de acá en adelante.

No se incluye reparación de datos históricos a propósito: la corrupción está en la base de desarrollo, no en producción, y una migración de reparación sobre datos que no se pueden inspeccionar antes agrega más riesgo del que saca.

## Riesgo y rollback

**Bajo.** El cambio es aditivo y acotado a un método. En el peor caso (un aumento real de más de 100× sobre un costo mayor a 100 Gs) el costo no se actualiza y queda el anterior: se pierde una actualización, no se corrompe nada, y queda el `log.warn` con todos los datos para detectarlo. Rollback = revertir el commit, sin estado que deshacer.

## Impacto cross-proyecto

Ninguno en la API GraphQL: no se agregan, renombran ni eliminan campos ni valores de enum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEiWuZS8RLXE6U1dgRktzg