### PR TITLE
feat(transferencia): registrar el solicitante del pedido

### DIFF
--- a/src/main/java/com/franco/dev/domain/operaciones/Transferencia.java
+++ b/src/main/java/com/franco/dev/domain/operaciones/Transferencia.java
@@ -69,6 +69,15 @@ public class Transferencia implements Identifiable<Long> {
         @Column(name = "creado_en")
         private LocalDateTime creadoEn;
 
+        /**
+         * Funcionario de la sucursal destino que pidio los productos. No participa del flujo:
+         * no crea, no prepara, no transporta y no necesariamente recibe. Es el dato de a quien
+         * le responde la transferencia.
+         */
+        @ManyToOne(fetch = FetchType.LAZY)
+        @JoinColumn(name = "solicitante_id", nullable = true)
+        private Usuario solicitante;
+
         @ManyToOne(fetch = FetchType.LAZY)
         @JoinColumn(name = "usuario_pre_transferencia_id", nullable = true)
         private Usuario usuarioPreTransferencia;

--- a/src/main/java/com/franco/dev/graphql/financiero/PdvCajaGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/PdvCajaGraphQL.java
@@ -199,6 +199,17 @@ public class PdvCajaGraphQL implements GraphQLQueryResolver, GraphQLMutationReso
         return service.findActiveBySucursalId(sucursalId);
     }
 
+    /**
+     * Los cajeros que hoy estan en caja en la sucursal.
+     *
+     * Existe aparte de cajaAbiertoPorSucursal porque ese devuelve todo lo que tiene activo = true,
+     * que incluye cajas abandonadas de anios anteriores. Ese comportamiento se deja intacto porque
+     * la grilla de cajas y los balances dependen de el; aca hace falta el criterio estricto.
+     */
+    public List<Usuario> cajerosConCajaAbiertaPorSucursal(Long sucursalId) {
+        return service.findCajerosConCajaAbiertaBySucursalId(sucursalId);
+    }
+
     public PdvCaja imprimirBalance(Long id, String printerName, String local, Long sucId) {
         // Ruteo a la filial SOLO cuando el caller no especifica impresora (frc-mobile envia
         // printerName=null y la filial resuelve su propia config). El desktop siempre envia

--- a/src/main/java/com/franco/dev/graphql/operaciones/TransferenciaGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/TransferenciaGraphQL.java
@@ -106,6 +106,31 @@ public class TransferenciaGraphQL implements GraphQLQueryResolver, GraphQLMutati
         }
     }
 
+    /**
+     * El solicitante se carga a mano en la etapa de creacion y es obligatorio para salir de ella.
+     *
+     * Se valida al salir de PRE_TRANSFERENCIA_CREACION y no en cada avance, por dos razones: las
+     * transferencias anteriores a esta columna estan todas mas adelante en el flujo y seguirian
+     * avanzando sin quedar trabadas, y una transferencia nueva no tiene forma de esquivar el
+     * control porque siempre nace en esa etapa. El chequeo no vive dentro del {@code case} de
+     * PRE_TRANSFERENCIA_ORIGEN porque {@link EtapaTransferencia#puedeAvanzarA} permite saltear
+     * etapas hacia adelante, y ese salto lo saltearia tambien.
+     *
+     * Se llama desde {@code avanzarEtapaTransferencia} y tambien desde {@code saveTransferencia},
+     * porque el cliente reenvia la etapa en cada save y por ahi tambien se puede avanzar. Lo que
+     * nunca se exige es tener solicitante para crear: la transferencia nace al confirmar origen y
+     * destino, y recien despues se elige quien pidio los productos.
+     */
+    private void validarSolicitanteCargado(Long id, EtapaTransferencia actual, EtapaTransferencia destino,
+            Usuario solicitante) {
+        if (actual != EtapaTransferencia.PRE_TRANSFERENCIA_CREACION) return;
+        if (destino == null || destino == EtapaTransferencia.PRE_TRANSFERENCIA_CREACION) return;
+        if (solicitante == null) {
+            throw new GraphQLException("La transferencia " + id
+                    + " no puede avanzar sin solicitante: hay que indicar que funcionario pidio los productos.");
+        }
+    }
+
     public Transferencia saveTransferencia(TransferenciaInput input) {
         ModelMapper m = new ModelMapper();
         Transferencia e = m.map(input, Transferencia.class);
@@ -121,6 +146,18 @@ public class TransferenciaGraphQL implements GraphQLQueryResolver, GraphQLMutati
         // El cliente reenvia la etapa en cada save (ver Transferencia.toInput en el desktop), asi
         // que un input viejo alcanza para retroceder el header si no se valida aca.
         validarAvanceDeEtapa(transferencia, input.getEtapa());
+
+        if (input.getSolicitanteId() != null)
+            e.setSolicitante(usuarioService.findById(input.getSolicitanteId()).orElse(null));
+        else if (transferencia != null)
+            e.setSolicitante(transferencia.getSolicitante());
+
+        // El save tambien puede mover la etapa (el cliente la reenvia), asi que la obligatoriedad
+        // del solicitante se controla por los dos caminos y no solo por avanzarEtapaTransferencia.
+        if (transferencia != null) {
+            validarSolicitanteCargado(transferencia.getId(), transferencia.getEtapa(), input.getEtapa(),
+                    e.getSolicitante());
+        }
 
         if (input.getUsuarioPreTransferenciaId() != null)
             e.setUsuarioPreTransferencia(usuarioService.findById(input.getUsuarioPreTransferenciaId()).orElse(null));
@@ -277,6 +314,8 @@ public class TransferenciaGraphQL implements GraphQLQueryResolver, GraphQLMutati
         Transferencia transferencia = transferencia(id).orElse(null);
         if (transferencia != null) {
             validarAvanceDeEtapa(transferencia, etapa);
+            validarSolicitanteCargado(transferencia.getId(), transferencia.getEtapa(), etapa,
+                    transferencia.getSolicitante());
             Usuario usuario = usuarioService.findById(usuarioId).orElse(null);
             List<TransferenciaItem> transferenciaItemList = transferenciaItemService
                     .findByTransferenciaId(transferencia.getId());

--- a/src/main/java/com/franco/dev/graphql/operaciones/TransferenciaGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/TransferenciaGraphQL.java
@@ -293,10 +293,24 @@ public class TransferenciaGraphQL implements GraphQLQueryResolver, GraphQLMutati
         return service.count();
     }
 
+    /**
+     * Cierra la creacion y manda la transferencia a origen.
+     *
+     * Usado en:
+     * - Desktop: No (inyecta el GQL pero la unica llamada esta comentada; su boton "Finalizar"
+     *   usa avanzarEtapaTransferencia)
+     * - Mobile: Si (la PWA cierra el borrador por aca)
+     *
+     * ⚠️ **Mueve la etapa sin pasar por avanzarEtapaTransferencia**, asi que las validaciones de
+     * ese camino hay que repetirlas aca o no se aplican a nadie que entre por este. El solicitante
+     * se colaba justamente por este agujero.
+     */
     public Boolean finalizarTransferencia(Long id, Long usuarioId) {
         Transferencia transferencia = service.findById(id).orElse(null);
         Usuario usuario = usuarioService.findById(usuarioId).orElse(null);
         if (transferencia.getEstado() == TransferenciaEstado.ABIERTA) {
+            validarSolicitanteCargado(transferencia.getId(), transferencia.getEtapa(),
+                    EtapaTransferencia.PRE_TRANSFERENCIA_ORIGEN, transferencia.getSolicitante());
             transferencia.setEstado(TransferenciaEstado.EN_ORIGEN);
             transferencia.setEtapa(EtapaTransferencia.PRE_TRANSFERENCIA_ORIGEN);
             transferencia.setUsuarioPreTransferencia(usuario);

--- a/src/main/java/com/franco/dev/graphql/operaciones/input/TransferenciaInput.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/input/TransferenciaInput.java
@@ -19,6 +19,7 @@ public class TransferenciaInput {
     private Boolean isOrigen;
     private Boolean isDestino;
     private String observacion;
+    private Long solicitanteId;
     private Long usuarioPreTransferenciaId;
     private Long usuarioPreparacionId;
     private Long usuarioTransporteId;

--- a/src/main/java/com/franco/dev/repository/financiero/PdvCajaRepository.java
+++ b/src/main/java/com/franco/dev/repository/financiero/PdvCajaRepository.java
@@ -4,6 +4,7 @@ import com.franco.dev.domain.EmbebedPrimaryKey;
 import com.franco.dev.domain.financiero.PdvCaja;
 import com.franco.dev.domain.financiero.enums.PdvCajaEstado;
 import com.franco.dev.domain.operaciones.Venta;
+import com.franco.dev.domain.personas.Usuario;
 import com.franco.dev.domain.operaciones.enums.VentaEstado;
 import com.franco.dev.repository.HelperRepository;
 import com.franco.dev.repository.HelperRepositoryEmbeddedId;
@@ -60,6 +61,27 @@ public interface PdvCajaRepository extends HelperRepository<PdvCaja, Long>, JpaS
     public Page<PdvCaja> findAllWithFilters(Long cajaId, PdvCajaEstado estado, Long maletinId, Long cajeroId, LocalDateTime fechaInicio, LocalDateTime fechaFin, Long sucId, Boolean verificado, Pageable pageable);
 
     List<PdvCaja> findBySucursalIdAndActivo(Long sucursalId, Boolean activo);
+
+    /**
+     * Los cajeros que hoy estan en caja en una sucursal.
+     *
+     * No alcanza con activo = true: esa bandera solo dice que la caja nunca se cerro, y en la base
+     * hay cajas de 2022-2024 que quedaron asi. Una caja realmente abierta es la ultima de su
+     * maletin -- si aparecio otra caja despues en el mismo maletin, la anterior se abandono.
+     * Tampoco sirve el campo estado, que esta nulo en toda la tabla.
+     *
+     * Se excluyen las cajas sin fecha de apertura, que son filas que nunca llegaron a abrirse.
+     */
+    @Query("select distinct c.usuario from PdvCaja c " +
+            "where c.sucursalId = ?1 " +
+            "and c.activo = true " +
+            "and c.fechaApertura is not null " +
+            "and c.usuario is not null " +
+            "and not exists (select 1 from PdvCaja c2 " +
+            "                where c2.sucursalId = c.sucursalId " +
+            "                and c2.maletin = c.maletin " +
+            "                and c2.fechaApertura > c.fechaApertura)")
+    List<Usuario> findCajerosConCajaAbiertaBySucursalId(Long sucursalId);
 
     @Query("SELECT DISTINCT v.caja FROM VentaObservacion vo JOIN vo.venta v WHERE v.caja IS NOT NULL")
     List<PdvCaja> findCajasWithVentaObservaciones();

--- a/src/main/java/com/franco/dev/service/financiero/PdvCajaService.java
+++ b/src/main/java/com/franco/dev/service/financiero/PdvCajaService.java
@@ -28,6 +28,8 @@ import javax.persistence.criteria.Predicate;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import com.franco.dev.domain.personas.Usuario;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -643,6 +645,14 @@ public class PdvCajaService extends CrudService<PdvCaja, PdvCajaRepository, Long
      */
     public List<PdvCaja> findActiveBySucursalId(Long sucursalId) {
         return repository.findBySucursalIdAndActivo(sucursalId, true);
+    }
+
+    /**
+     * Los cajeros que hoy estan en caja en la sucursal, ya deduplicados: un mismo cajero puede
+     * tener mas de una caja abierta. Ver el detalle del criterio en el repositorio.
+     */
+    public List<Usuario> findCajerosConCajaAbiertaBySucursalId(Long sucursalId) {
+        return repository.findCajerosConCajaAbiertaBySucursalId(sucursalId);
     }
 
     public List<PdvCaja> findCajasWithVentaObservaciones() {

--- a/src/main/resources/db/migration/V162.3__add_solicitante_transferencia.sql
+++ b/src/main/resources/db/migration/V162.3__add_solicitante_transferencia.sql
@@ -1,0 +1,22 @@
+-- Solicitante: el funcionario de la sucursal destino que pidio los productos.
+-- No es ninguno de los usuarios del flujo (creacion, preparacion, transporte, recepcion):
+-- esos son quienes operan la transferencia, este es quien la origino como pedido.
+-- Nullable porque las transferencias ya existentes no lo tienen; la obligatoriedad se
+-- aplica al avanzar de PRE_TRANSFERENCIA_CREACION, no a nivel de esquema.
+
+ALTER TABLE operaciones.transferencia
+    ADD COLUMN IF NOT EXISTS solicitante_id BIGINT;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'fk_transferencia_solicitante'
+    ) THEN
+        ALTER TABLE operaciones.transferencia
+            ADD CONSTRAINT fk_transferencia_solicitante
+            FOREIGN KEY (solicitante_id) REFERENCES personas.usuario(id);
+    END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_transferencia_solicitante
+    ON operaciones.transferencia (solicitante_id);

--- a/src/main/resources/graphql/financiero/pdv-caja.graphqls
+++ b/src/main/resources/graphql/financiero/pdv-caja.graphqls
@@ -68,6 +68,7 @@ extend type Query {
     cajaAbiertoPorUsuarioIdPorSucursal(id:ID!, sucId: ID):PdvCaja
     pdvCajaDesdeFilial(id:ID!, sucursalId: ID!):PdvCaja
     cajaAbiertoPorSucursal(sucursalId: ID!):[PdvCaja]
+    cajerosConCajaAbiertaPorSucursal(sucursalId: ID!):[Usuario]
     imprimirBalance(id:ID!, printerName: String, local: String, sucId: ID):PdvCaja
     balancePorFecha(inicio: String, fin: String, sucId: ID): CajaBalance
     balancePorCajaIdAndSucursalId(id: ID!, sucId: ID): CajaBalance

--- a/src/main/resources/graphql/operaciones/transferencia.graphqls
+++ b/src/main/resources/graphql/operaciones/transferencia.graphqls
@@ -5,6 +5,7 @@ type Transferencia {
     estado: TransferenciaEstado
     tipo: TipoTransferencia
     observacion: String
+    solicitante: Usuario
     usuarioPreTransferencia: Usuario
     usuarioPreparacion: Usuario
     usuarioTransporte: Usuario
@@ -27,6 +28,7 @@ input TransferenciaInput {
     isOrigen: Boolean
     isDestino: Boolean
     etapa: EtapaTransferencia
+    solicitanteId: Int
     usuarioPreTransferenciaId: Int
     usuarioPreparacionId: Int
     usuarioTransporteId: Int

--- a/src/test/java/com/franco/dev/graphql/operaciones/TransferenciaGraphQLSolicitanteTest.java
+++ b/src/test/java/com/franco/dev/graphql/operaciones/TransferenciaGraphQLSolicitanteTest.java
@@ -148,6 +148,26 @@ class TransferenciaGraphQLSolicitanteTest {
     }
 
     @Test
+    @DisplayName("finalizarTransferencia tampoco cierra la creacion sin solicitante")
+    void finalizarSinSolicitanteFalla() {
+        persistida(7009L, EtapaTransferencia.PRE_TRANSFERENCIA_CREACION, null);
+
+        assertThrows(GraphQLException.class, () -> resolver.finalizarTransferencia(7009L, 1L));
+
+        verify(service, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("finalizarTransferencia con solicitante cierra la creacion normalmente")
+    void finalizarConSolicitanteFunciona() {
+        persistida(7010L, EtapaTransferencia.PRE_TRANSFERENCIA_CREACION, usuario(SOLICITANTE_ID));
+
+        assertTrue(resolver.finalizarTransferencia(7010L, 1L));
+
+        verify(service).save(any());
+    }
+
+    @Test
     @DisplayName("un save que no manda solicitanteId no borra el solicitante ya guardado")
     void savePreservaElSolicitante() {
         persistida(7007L, EtapaTransferencia.PRE_TRANSFERENCIA_CREACION, usuario(SOLICITANTE_ID));

--- a/src/test/java/com/franco/dev/graphql/operaciones/TransferenciaGraphQLSolicitanteTest.java
+++ b/src/test/java/com/franco/dev/graphql/operaciones/TransferenciaGraphQLSolicitanteTest.java
@@ -1,0 +1,183 @@
+package com.franco.dev.graphql.operaciones;
+
+import com.franco.dev.domain.operaciones.Transferencia;
+import com.franco.dev.domain.operaciones.enums.EtapaTransferencia;
+import com.franco.dev.domain.operaciones.enums.TransferenciaEstado;
+import com.franco.dev.domain.personas.Usuario;
+import com.franco.dev.graphql.operaciones.input.TransferenciaInput;
+import com.franco.dev.service.operaciones.MovimientoStockService;
+import com.franco.dev.service.operaciones.TransferenciaItemService;
+import com.franco.dev.service.operaciones.TransferenciaService;
+import com.franco.dev.service.personas.UsuarioService;
+import graphql.GraphQLException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * El solicitante es el funcionario de la sucursal destino que pidio los productos. Se carga a mano
+ * en la etapa de creacion y es obligatorio para salir de ella; no reemplaza a ninguno de los cuatro
+ * usuarios del flujo, que siguen siendo quienes operan la transferencia.
+ */
+class TransferenciaGraphQLSolicitanteTest {
+
+    private static final Long SOLICITANTE_ID = 77L;
+
+    private TransferenciaService service;
+    private UsuarioService usuarioService;
+    private TransferenciaGraphQL resolver;
+
+    @BeforeEach
+    void setUp() {
+        service = mock(TransferenciaService.class);
+        usuarioService = mock(UsuarioService.class);
+        TransferenciaItemService transferenciaItemService = mock(TransferenciaItemService.class);
+        MovimientoStockService movimientoStockService = mock(MovimientoStockService.class);
+
+        resolver = new TransferenciaGraphQL();
+        ReflectionTestUtils.setField(resolver, "service", service);
+        ReflectionTestUtils.setField(resolver, "usuarioService", usuarioService);
+        ReflectionTestUtils.setField(resolver, "transferenciaItemService", transferenciaItemService);
+        ReflectionTestUtils.setField(resolver, "movimientoStockService", movimientoStockService);
+
+        when(usuarioService.findById(any())).thenReturn(Optional.of(new Usuario()));
+        when(transferenciaItemService.findByTransferenciaId(any())).thenReturn(Collections.emptyList());
+        when(service.save(any())).thenAnswer(i -> i.getArgument(0));
+    }
+
+    private Usuario usuario(Long id) {
+        Usuario u = new Usuario();
+        u.setId(id);
+        return u;
+    }
+
+    private Transferencia persistida(Long id, EtapaTransferencia etapa, Usuario solicitante) {
+        Transferencia t = new Transferencia();
+        t.setId(id);
+        t.setEtapa(etapa);
+        t.setEstado(TransferenciaEstado.ABIERTA);
+        t.setSolicitante(solicitante);
+        when(service.findById(id)).thenReturn(Optional.of(t));
+        return t;
+    }
+
+    @Test
+    @DisplayName("no se puede salir de la etapa de creacion sin solicitante")
+    void avanzarSinSolicitanteFalla() {
+        persistida(7001L, EtapaTransferencia.PRE_TRANSFERENCIA_CREACION, null);
+
+        assertThrows(GraphQLException.class, () -> resolver.avanzarEtapaTransferencia(
+                7001L, EtapaTransferencia.PRE_TRANSFERENCIA_ORIGEN, 1L));
+
+        verify(service, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("saltear etapas hacia adelante tampoco esquiva el solicitante obligatorio")
+    void saltarEtapasSinSolicitanteFalla() {
+        persistida(7002L, EtapaTransferencia.PRE_TRANSFERENCIA_CREACION, null);
+
+        assertThrows(GraphQLException.class, () -> resolver.avanzarEtapaTransferencia(
+                7002L, EtapaTransferencia.PREPARACION_MERCADERIA, 1L));
+
+        verify(service, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("con solicitante cargado la transferencia avanza normalmente")
+    void avanzarConSolicitanteFunciona() {
+        persistida(7003L, EtapaTransferencia.PRE_TRANSFERENCIA_CREACION, usuario(SOLICITANTE_ID));
+
+        assertTrue(resolver.avanzarEtapaTransferencia(
+                7003L, EtapaTransferencia.PRE_TRANSFERENCIA_ORIGEN, 1L));
+
+        verify(service).save(any());
+    }
+
+    @Test
+    @DisplayName("una transferencia anterior a la columna, ya pasada la creacion, no queda trabada")
+    void transferenciaViejaSinSolicitanteSigueAvanzando() {
+        persistida(7004L, EtapaTransferencia.TRANSPORTE_EN_CAMINO, null);
+
+        assertTrue(resolver.avanzarEtapaTransferencia(
+                7004L, EtapaTransferencia.RECEPCION_EN_VERIFICACION, 1L));
+
+        verify(service).save(any());
+    }
+
+    @Test
+    @DisplayName("el save tampoco deja avanzar la etapa sin solicitante")
+    void saveNoAvanzaEtapaSinSolicitante() {
+        persistida(7005L, EtapaTransferencia.PRE_TRANSFERENCIA_CREACION, null);
+
+        TransferenciaInput input = new TransferenciaInput();
+        input.setId(7005L);
+        input.setEtapa(EtapaTransferencia.PRE_TRANSFERENCIA_ORIGEN);
+
+        assertThrows(GraphQLException.class, () -> resolver.saveTransferencia(input));
+
+        verify(service, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("el save que no mueve la etapa sigue andando sin solicitante")
+    void saveEnLaMismaEtapaSinSolicitanteFunciona() {
+        persistida(7006L, EtapaTransferencia.PRE_TRANSFERENCIA_CREACION, null);
+
+        TransferenciaInput input = new TransferenciaInput();
+        input.setId(7006L);
+        input.setEtapa(EtapaTransferencia.PRE_TRANSFERENCIA_CREACION);
+
+        resolver.saveTransferencia(input);
+
+        verify(service).save(any());
+    }
+
+    @Test
+    @DisplayName("un save que no manda solicitanteId no borra el solicitante ya guardado")
+    void savePreservaElSolicitante() {
+        persistida(7007L, EtapaTransferencia.PRE_TRANSFERENCIA_CREACION, usuario(SOLICITANTE_ID));
+
+        TransferenciaInput input = new TransferenciaInput();
+        input.setId(7007L);
+        input.setEtapa(EtapaTransferencia.PRE_TRANSFERENCIA_CREACION);
+
+        resolver.saveTransferencia(input);
+
+        ArgumentCaptor<Transferencia> captor = ArgumentCaptor.forClass(Transferencia.class);
+        verify(service).save(captor.capture());
+        assertEquals(SOLICITANTE_ID, captor.getValue().getSolicitante().getId());
+    }
+
+    @Test
+    @DisplayName("el solicitante que llega en el input se resuelve y se guarda")
+    void saveAsignaElSolicitanteDelInput() {
+        persistida(7008L, EtapaTransferencia.PRE_TRANSFERENCIA_CREACION, null);
+        when(usuarioService.findById(SOLICITANTE_ID)).thenReturn(Optional.of(usuario(SOLICITANTE_ID)));
+
+        TransferenciaInput input = new TransferenciaInput();
+        input.setId(7008L);
+        input.setEtapa(EtapaTransferencia.PRE_TRANSFERENCIA_CREACION);
+        input.setSolicitanteId(SOLICITANTE_ID);
+
+        resolver.saveTransferencia(input);
+
+        ArgumentCaptor<Transferencia> captor = ArgumentCaptor.forClass(Transferencia.class);
+        verify(service).save(captor.capture());
+        assertEquals(SOLICITANTE_ID, captor.getValue().getSolicitante().getId());
+    }
+}

--- a/src/test/java/com/franco/dev/service/financiero/CajerosConCajaAbiertaIT.java
+++ b/src/test/java/com/franco/dev/service/financiero/CajerosConCajaAbiertaIT.java
@@ -1,0 +1,87 @@
+package com.franco.dev.service.financiero;
+
+import com.franco.dev.domain.financiero.PdvCaja;
+import com.franco.dev.domain.personas.Usuario;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Verifica el criterio de "caja realmente abierta" contra la DB dev real.
+ *
+ * El bug: el buscador de solicitante traia 4 cajeros de la sucursal 8 cuando habia una sola caja
+ * abierta. La causa era usar activo = true, que solo dice que la caja nunca se cerro -- en la base
+ * hay cajas de 2023 y 2024 que quedaron asi. El criterio nuevo se queda con la ultima caja de cada
+ * maletin.
+ *
+ * NO corre en CI (no hay DB): se activa con -Dit.caja=true.
+ * Es de solo lectura y @Transactional, no ensucia nada.
+ *
+ * Correr:  ./mvnw -Dit.caja=true -Dtest=CajerosConCajaAbiertaIT test
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@ActiveProfiles({"dev", "user-dev"})
+@Transactional
+@org.junit.jupiter.api.condition.EnabledIfSystemProperty(named = "it.caja", matches = "true")
+class CajerosConCajaAbiertaIT {
+
+    private static final Long SUCURSAL_CON_UNA_CAJA_ABIERTA = 8L;
+
+    @Autowired
+    private PdvCajaService service;
+
+    @Test
+    @DisplayName("el JPQL es valido y corre contra la DB")
+    void laQueryEjecuta() {
+        List<Usuario> cajeros = service.findCajerosConCajaAbiertaBySucursalId(SUCURSAL_CON_UNA_CAJA_ABIERTA);
+        assertTrue(cajeros != null, "la query no devolvio nada, ni siquiera una lista vacia");
+    }
+
+    @Test
+    @DisplayName("el criterio estricto nunca agrega cajeros que activo = true no tenga")
+    void esSubconjuntoDelCriterioViejo() {
+        Set<Long> estrictos = service.findCajerosConCajaAbiertaBySucursalId(SUCURSAL_CON_UNA_CAJA_ABIERTA)
+                .stream().map(Usuario::getId).collect(Collectors.toSet());
+        Set<Long> porActivo = service.findActiveBySucursalId(SUCURSAL_CON_UNA_CAJA_ABIERTA)
+                .stream().map(PdvCaja::getUsuario).filter(u -> u != null).map(Usuario::getId)
+                .collect(Collectors.toSet());
+
+        assumeTrue(!porActivo.isEmpty(), "la sucursal no tiene ninguna caja con activo = true");
+        assertTrue(porActivo.containsAll(estrictos),
+                "el criterio estricto devolvio cajeros que activo = true no tiene: " + estrictos + " vs " + porActivo);
+    }
+
+    @Test
+    @DisplayName("descarta las cajas abandonadas que no son la ultima de su maletin")
+    void descartaLasAbandonadas() {
+        List<PdvCaja> porActivo = service.findActiveBySucursalId(SUCURSAL_CON_UNA_CAJA_ABIERTA);
+        assumeTrue(porActivo.size() > 1, "la sucursal no tiene cajas abandonadas para descartar");
+
+        Set<Long> estrictos = service.findCajerosConCajaAbiertaBySucursalId(SUCURSAL_CON_UNA_CAJA_ABIERTA)
+                .stream().map(Usuario::getId).collect(Collectors.toSet());
+
+        // La ultima caja abierta de la sucursal es, por definicion, la ultima de su maletin.
+        PdvCaja masReciente = porActivo.stream()
+                .filter(c -> c.getFechaApertura() != null)
+                .max((a, b) -> a.getFechaApertura().compareTo(b.getFechaApertura()))
+                .orElse(null);
+        assumeTrue(masReciente != null && masReciente.getUsuario() != null,
+                "no hay ninguna caja con fecha de apertura y usuario");
+
+        assertTrue(estrictos.contains(masReciente.getUsuario().getId()),
+                "se perdio el cajero de la caja abierta mas reciente (caja " + masReciente.getId() + ")");
+        assertFalse(estrictos.size() >= porActivo.size(),
+                "no se descarto ninguna caja abandonada: " + estrictos.size() + " cajeros de " + porActivo.size() + " cajas");
+    }
+}


### PR DESCRIPTION
## Qué resuelve

La transferencia guardaba cuatro usuarios —quién la creó, quién preparó, quién transportó y quién recibió— pero ninguno decía **quién pidió los productos**. El que crea la transferencia se toma de la sesión (`mainService.usuarioActual`), que suele ser alguien de bodega, no el funcionario de la sucursal destino que hizo el pedido.

Se agrega `solicitante` (FK a `personas.usuario`) a nivel transferencia. Es obligatorio para salir de `PRE_TRANSFERENCIA_CREACION`, no para crear: la transferencia nace al confirmar origen y destino y recién después se elige el solicitante.

Incluye además una query de **cajeros realmente en caja por sucursal**, que es lo que alimenta el buscador de solicitante en los dos clientes.

## Los tres commits

| Commit | Qué hace |
|---|---|
| `40840c10` | El campo `solicitante` y su obligatoriedad |
| `e820a9f4` | `cajerosConCajaAbiertaPorSucursal` |
| `2ee76599` | Cierra el agujero de `finalizarTransferencia` |

### Por qué la validación no está en un solo lugar

Se dispara **al salir de `PRE_TRANSFERENCIA_CREACION`**, no dentro de un `case` puntual, porque `puedeAvanzarA` permite saltear etapas hacia adelante y ese salto la saltearía. Y corre por los **tres** caminos que mueven la etapa:

- `avanzarEtapaTransferencia` — el del escritorio
- `saveTransferencia` — el cliente reenvía la etapa en cada save
- `finalizarTransferencia` — el de la PWA, que escribía `etapa = PRE_TRANSFERENCIA_ORIGEN` **sin pasar por ninguna validación**

### `activo = true` no significa "caja abierta"

Esa bandera solo dice que la caja nunca se cerró. Para la sucursal 8 devolvía 6 cajas —5 abandonadas de 2023 y 2024— que deduplicadas daban 4 cajeros donde hay uno. En toda la base hay **144 cajas con `activo = true` y 117 son de 2022 a 2024**. El campo `estado` tampoco discrimina: está NULL en las 53.944 filas.

El criterio que sí funciona es que una caja activa sea **la última de su maletín**. Las abandonadas tienen entre 412 y 1001 cajas posteriores en el mismo maletín; la real tiene cero. Global 144 → 32, sucursal 8 → 1.

`cajaAbiertoPorSucursal` **queda intacto a propósito**: la grilla de cajas y los balances dependen de su semántica actual y cambiarla tiene un radio de impacto mucho mayor.

## Cómo probarlo

```bash
./mvnw clean verify -B -DskipFlyway=true     # 517 tests
./mvnw -Dit.caja=true -Dtest=CajerosConCajaAbiertaIT test   # contra la DB dev
```

A mano: crear una transferencia, intentar avanzar de etapa sin solicitante (rechaza), asignarlo y volver a avanzar (pasa). Una transferencia anterior a este cambio, ya pasada la creación, **tiene que seguir avanzando**.

## Impacto en DB

Migración **`V162.3`**: `ALTER TABLE operaciones.transferencia ADD COLUMN solicitante_id BIGINT` + FK a `personas.usuario` + índice. Idempotente (`IF NOT EXISTS`).

**La columna es nullable a propósito**: las transferencias existentes no la tienen y el control no aplica a las que ya pasaron la etapa de creación, así que ninguna queda trabada.

⚠️ **La filial va a saltear esta migración.** `V162.3` queda por debajo del máximo ya aplicado y la filial no tiene `out-of-order`: la ignora en silencio. Como `operaciones.transferencia` replica, **hay que aplicarla a mano en la filial antes de desplegar**.

## Impacto en rollback

Bajo. La columna es aditiva y nullable: un JAR anterior la ignora y sigue funcionando. Flyway no revierte, pero no hay nada que revertir — no se borra ni se renombra nada.

## Riesgo

**Medio**, y está concentrado en un solo punto: `finalizarTransferencia` ahora puede rechazar donde antes siempre aceptaba. Solo afecta a transferencias que estén **en etapa de creación y sin solicitante**; cualquier otra pasa igual que antes. El desktop no usa esa mutation (su única llamada está comentada).

## Limitaciones conocidas

- Con la regla del último maletín **siguen pasando 6 cajas abandonadas** a nivel global, de maletines que se dejaron de usar y no tienen caja posterior. Ninguna en la sucursal 8.
- Se excluyen las 8 filas con `fecha_apertura` NULL: son cajas que nunca llegaron a abrirse.
- El IT **no corre en CI** (no hay DB): gateado con `-Dit.caja=true`.

## Se despliega junto con

- `frc-sistemas-integrados-angular` — rama `feature/transferencia-solicitante`
- `frc-mobile-pwa` — rama `feat/transferencia-solicitante`

**El central va primero.** Contra un central sin estos cambios, la PWA no crea la transferencia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QJ8gWHYRYSWiT6PHkRnxE