### PR TITLE
fix(stock): devolver los insumos de la cantidad sugerida agrupados por sucursal

### DIFF
--- a/src/main/java/com/franco/dev/domain/operaciones/dto/CantidadSugeridaPorSucursalDto.java
+++ b/src/main/java/com/franco/dev/domain/operaciones/dto/CantidadSugeridaPorSucursalDto.java
@@ -1,0 +1,28 @@
+package com.franco.dev.domain.operaciones.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * Los insumos de la cantidad sugerida de un producto en una sucursal, en un rango de fechas.
+ *
+ * Junta lo que devuelven {@link VentasPorSucursalDto} y {@link ComprasPorSucursalDto}. Son los
+ * cuatro numeros que consume el diálogo de ítem de compra y nada mas: la cuenta final se hace en
+ * el cliente, que es el unico que conoce el stock actual contra el que se resta.
+ *
+ * Una sucursal sin movimientos en el rango no aparece —no hay filas que agrupar—, igual que en
+ * {@link StockPorSucursalDto}. El llamador la muestra en cero.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CantidadSugeridaPorSucursalDto {
+    private Long sucursalId;
+    private Double totalVentas;
+    private Long cantidadCompras;
+    private LocalDateTime primeraCompra;
+    private LocalDateTime ultimaCompra;
+}

--- a/src/main/java/com/franco/dev/domain/operaciones/dto/ComprasPorSucursalDto.java
+++ b/src/main/java/com/franco/dev/domain/operaciones/dto/ComprasPorSucursalDto.java
@@ -1,0 +1,24 @@
+package com.franco.dev.domain.operaciones.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * Cuantas veces entro un producto a una sucursal en un rango, y entre que fechas.
+ *
+ * Con estos tres numeros alcanza para la frecuencia de compra que calcula el diálogo de ítem:
+ * el promedio de las diferencias entre compras consecutivas ordenadas telescopa a
+ * {@code (ultima - primera) / (cantidad - 1)}, asi que las fechas del medio no hacen falta.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ComprasPorSucursalDto {
+    private Long sucursalId;
+    private Long cantidadCompras;
+    private LocalDateTime primeraCompra;
+    private LocalDateTime ultimaCompra;
+}

--- a/src/main/java/com/franco/dev/domain/operaciones/dto/VentasPorSucursalDto.java
+++ b/src/main/java/com/franco/dev/domain/operaciones/dto/VentasPorSucursalDto.java
@@ -1,0 +1,19 @@
+package com.franco.dev.domain.operaciones.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Cuanto se vendio de un producto en una sucursal, en un rango de fechas.
+ *
+ * Proyeccion de una sola consulta agrupada. Existe para que el cliente no tenga que bajarse los
+ * movimientos de venta —hasta 1000 por sucursal— solo para sumarles la cantidad.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class VentasPorSucursalDto {
+    private Long sucursalId;
+    private Double totalVentas;
+}

--- a/src/main/java/com/franco/dev/graphql/operaciones/MovimientoGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/MovimientoGraphQL.java
@@ -3,6 +3,7 @@ package com.franco.dev.graphql.operaciones;
 import com.franco.dev.domain.EmbebedPrimaryKey;
 import com.franco.dev.domain.dto.StockPorTipoMovimientoDto;
 import com.franco.dev.domain.empresarial.Sucursal;
+import com.franco.dev.domain.operaciones.dto.CantidadSugeridaPorSucursalDto;
 import com.franco.dev.domain.operaciones.MovimientoStock;
 import com.franco.dev.domain.operaciones.enums.TipoMovimiento;
 import com.franco.dev.domain.personas.Usuario;
@@ -27,6 +28,7 @@ import org.springframework.stereotype.Component;
 
 import java.text.DecimalFormat;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -78,6 +80,26 @@ public class MovimientoGraphQL implements GraphQLQueryResolver, GraphQLMutationR
             return null;
         return service.findMovimientoStockWithFilters(stringToDate(inicio), stringToDate(fin), sucursalList, productoId,
                 tipoMovimientoList, usuarioId, pageable);
+    }
+
+    /**
+     * Insumos de la cantidad sugerida para todas las sucursales pedidas, en UN request.
+     *
+     * El diálogo de ítem de compra pedia esto con dos consultas encadenadas por sucursal
+     * —{@code findMovimientoStockByFilters} con {@code size: 1000}, primero compras y en su
+     * respuesta ventas—, escalonadas con {@code setTimeout}. Con 10 distribuciones eran 20 idas y
+     * vueltas y decenas de miles de filas para terminar en cuatro numeros por sucursal.
+     *
+     * Devuelve solo las sucursales con movimientos en el rango; el cliente muestra el resto en
+     * cero, igual que hace con {@code stockPorSucursales}.
+     */
+    public List<CantidadSugeridaPorSucursalDto> cantidadSugeridaPorSucursales(Long productoId,
+            String inicio, String fin, List<Long> sucursalList) {
+        if (productoId == null || inicio == null || fin == null) {
+            return new ArrayList<>();
+        }
+        return service.cantidadSugeridaPorSucursales(productoId, stringToDate(inicio), stringToDate(fin),
+                sucursalList);
     }
 
     public Optional<MovimientoStock> movimientoStock(Long id, Long sucId) {

--- a/src/main/java/com/franco/dev/repository/operaciones/MovimientoStockRepository.java
+++ b/src/main/java/com/franco/dev/repository/operaciones/MovimientoStockRepository.java
@@ -4,7 +4,9 @@ import com.franco.dev.domain.dto.StockPorTipoMovimientoDto;
 import com.franco.dev.domain.operaciones.MovimientoStock;
 import com.franco.dev.domain.operaciones.dto.MovimientoStockCantidadAndIdDto;
 import com.franco.dev.domain.operaciones.dto.ProductoSaldoDto;
+import com.franco.dev.domain.operaciones.dto.ComprasPorSucursalDto;
 import com.franco.dev.domain.operaciones.dto.StockPorSucursalDto;
+import com.franco.dev.domain.operaciones.dto.VentasPorSucursalDto;
 import com.franco.dev.domain.operaciones.enums.TipoMovimiento;
 import com.franco.dev.repository.HelperRepository;
 import org.springframework.data.domain.Page;
@@ -53,6 +55,63 @@ public interface MovimientoStockRepository
                         "where p.estado = true and pro.id = ?1 " +
                         "group by p.sucursalId")
         public List<StockPorSucursalDto> stockPorSucursales(Long proId);
+
+        /**
+         * Cuanto se vendio del producto en cada sucursal del rango, en UNA consulta.
+         *
+         * Reemplaza a bajarse los movimientos de VENTA —hasta 1000 por sucursal— para que el
+         * cliente los sume. Se filtra {@code estado = true} a proposito: una venta cancelada no
+         * es consumo, y contarla infla la cantidad sugerida.
+         *
+         * Se compara el tipo con {@code cast(... as text)} porque {@code tipo_movimiento} es un
+         * enum de Postgres, igual que en el resto de las consultas de esta interfaz.
+         */
+        @Query("select new com.franco.dev.domain.operaciones.dto.VentasPorSucursalDto(ms.sucursalId, SUM(ABS(ms.cantidad))) "
+                        +
+                        "from MovimientoStock ms " +
+                        "join ms.producto p " +
+                        "where p.id = (:productoId) " +
+                        "and ((:sucursalList) is null or ms.sucursalId in (:sucursalList)) " +
+                        "and ms.estado = true " +
+                        "and cast(ms.tipoMovimiento as text) = 'VENTA' " +
+                        "and ms.creadoEn between cast((:inicio) as timestamp) and cast((:fin) as timestamp) "
+                        +
+                        "group by ms.sucursalId")
+        public List<VentasPorSucursalDto> ventasPorSucursal(
+                        @Param("productoId") Long productoId,
+                        @Param("inicio") LocalDateTime inicio,
+                        @Param("fin") LocalDateTime fin,
+                        @Param("sucursalList") List<Long> sucursalList);
+
+        /**
+         * Cuantas veces entro el producto a cada sucursal del rango y entre que fechas, en UNA
+         * consulta.
+         *
+         * Entrada es COMPRA, o TRANSFERENCIA con cantidad positiva: una transferencia negativa es
+         * la salida del otro lado y el cliente ya la descartaba.
+         *
+         * Se cuenta {@code creadoEn} y no la entidad porque {@code MovimientoStock} tiene clave
+         * compuesta ({@code @IdClass}) y {@code count(ms)} genera un {@code count} de dos columnas
+         * que Postgres rechaza.
+         */
+        @Query("select new com.franco.dev.domain.operaciones.dto.ComprasPorSucursalDto(ms.sucursalId, COUNT(ms.creadoEn), MIN(ms.creadoEn), MAX(ms.creadoEn)) "
+                        +
+                        "from MovimientoStock ms " +
+                        "join ms.producto p " +
+                        "where p.id = (:productoId) " +
+                        "and ((:sucursalList) is null or ms.sucursalId in (:sucursalList)) " +
+                        "and ms.estado = true " +
+                        "and (cast(ms.tipoMovimiento as text) = 'COMPRA' " +
+                        "     or (cast(ms.tipoMovimiento as text) = 'TRANSFERENCIA' and ms.cantidad > 0)) "
+                        +
+                        "and ms.creadoEn between cast((:inicio) as timestamp) and cast((:fin) as timestamp) "
+                        +
+                        "group by ms.sucursalId")
+        public List<ComprasPorSucursalDto> comprasPorSucursal(
+                        @Param("productoId") Long productoId,
+                        @Param("inicio") LocalDateTime inicio,
+                        @Param("fin") LocalDateTime fin,
+                        @Param("sucursalList") List<Long> sucursalList);
 
         @Query("select new com.franco.dev.domain.operaciones.dto.MovimientoStockCantidadAndIdDto(COALESCE(SUM(p.cantidad), 0), MAX(p.id), count(p.id)) "
                         +

--- a/src/main/java/com/franco/dev/service/operaciones/MovimientoStockService.java
+++ b/src/main/java/com/franco/dev/service/operaciones/MovimientoStockService.java
@@ -4,6 +4,9 @@ import com.franco.dev.domain.EmbebedPrimaryKey;
 import com.franco.dev.domain.dto.StockPorTipoMovimientoDto;
 import com.franco.dev.domain.empresarial.Sucursal;
 import com.franco.dev.domain.operaciones.MovimientoStock;
+import com.franco.dev.domain.operaciones.dto.CantidadSugeridaPorSucursalDto;
+import com.franco.dev.domain.operaciones.dto.ComprasPorSucursalDto;
+import com.franco.dev.domain.operaciones.dto.VentasPorSucursalDto;
 import com.franco.dev.domain.operaciones.dto.StockPorSucursalDto;
 import com.franco.dev.domain.operaciones.TransferenciaItem;
 import com.franco.dev.domain.operaciones.TransferenciaItemLote;
@@ -26,7 +29,9 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 @Service
@@ -69,6 +74,56 @@ public class MovimientoStockService extends CrudService<MovimientoStock, Movimie
      */
     public List<StockPorSucursalDto> stockPorSucursales(Long proId) {
         return repository.stockPorSucursales(proId);
+    }
+
+    /**
+     * Los insumos de la cantidad sugerida del producto en cada sucursal, en DOS consultas.
+     *
+     * El diálogo de ítem de compra necesita, por sucursal, cuanto se vendio y cuantas compras hubo
+     * entre que fechas. Hasta ahora los sacaba bajandose los movimientos: dos requests encadenados
+     * por sucursal —el de ventas recien salia cuando volvia el de compras—, cada uno con
+     * {@code size: 1000}. Con 10 distribuciones eran 20 idas y vueltas y decenas de miles de filas
+     * al navegador para terminar en cuatro numeros por fila.
+     *
+     * Son dos consultas y no una con {@code CASE} adentro de los agregados a proposito:
+     * {@code tipo_movimiento} es un enum de Postgres, y un {@code SUM(case ...)} proyectado a un
+     * DTO deja el tipo de retorno —{@code Double} o {@code BigDecimal}— a merced de como lo infiera
+     * Hibernate. Lo que habia que bajar son los requests HTTP, no las consultas: las dos salen en
+     * el mismo request y usan el mismo indice.
+     *
+     * A diferencia de {@code findByFilters}, que es lo que usaba el cliente, acá se filtra
+     * {@code estado = true}: una venta cancelada o una transferencia rechazada no son consumo.
+     *
+     * Una sucursal sin movimientos en el rango no vuelve en la lista —no hay filas que agrupar—;
+     * el llamador la muestra en cero.
+     */
+    public List<CantidadSugeridaPorSucursalDto> cantidadSugeridaPorSucursales(Long productoId,
+            LocalDateTime inicio, LocalDateTime fin, List<Long> sucursalList) {
+        Map<Long, CantidadSugeridaPorSucursalDto> porSucursal = new TreeMap<>();
+
+        for (VentasPorSucursalDto fila : repository.ventasPorSucursal(productoId, inicio, fin, sucursalList)) {
+            filaDe(porSucursal, fila.getSucursalId())
+                    .setTotalVentas(fila.getTotalVentas() != null ? fila.getTotalVentas() : 0.0);
+        }
+
+        for (ComprasPorSucursalDto fila : repository.comprasPorSucursal(productoId, inicio, fin, sucursalList)) {
+            CantidadSugeridaPorSucursalDto destino = filaDe(porSucursal, fila.getSucursalId());
+            destino.setCantidadCompras(fila.getCantidadCompras() != null ? fila.getCantidadCompras() : 0L);
+            destino.setPrimeraCompra(fila.getPrimeraCompra());
+            destino.setUltimaCompra(fila.getUltimaCompra());
+        }
+
+        return new ArrayList<>(porSucursal.values());
+    }
+
+    /**
+     * La fila de esa sucursal, creandola en cero si todavia no esta. Una sucursal puede venir en
+     * una sola de las dos consultas —vendio pero no compro, o al reves— y en ese caso el otro lado
+     * vale cero, no null: es lo que el cliente espera para hacer la cuenta.
+     */
+    private CantidadSugeridaPorSucursalDto filaDe(Map<Long, CantidadSugeridaPorSucursalDto> acc, Long sucursalId) {
+        return acc.computeIfAbsent(sucursalId,
+                id -> new CantidadSugeridaPorSucursalDto(id, 0.0, 0L, null, null));
     }
 
     public Double stockByProductoId(Long proId) {

--- a/src/main/resources/graphql/operaciones/movimiento-stock.graphqls
+++ b/src/main/resources/graphql/operaciones/movimiento-stock.graphqls
@@ -40,6 +40,21 @@ type ResumenMovimientoStock {
     stock: Float
 }
 
+# Insumos de la cantidad sugerida de un producto en una sucursal, para un rango de fechas.
+#
+# Son los cuatro numeros que necesita el diálogo de ítem de compra, no los movimientos: hasta
+# ahora se bajaba hasta 1000 filas por sucursal y por tipo para terminar sumando esto.
+# La cuenta final la hace el cliente, que es el unico que conoce el stock actual.
+#
+# Las fechas usan el mismo escalar Date que MovimientoStock.creadoEn.
+type CantidadSugeridaPorSucursal {
+    sucursalId: ID
+    totalVentas: Float
+    cantidadCompras: Int
+    primeraCompra: Date
+    ultimaCompra: Date
+}
+
 type StockPorTipoMovimientoDto {
     tipoMovimiento: TipoMovimiento
     stock: Float
@@ -76,6 +91,7 @@ extend type Query {
     findMovimientoStockByFilters(inicio: String, fin: String, sucursalList: [ID], productoId: ID,tipoMovimientoList: [TipoMovimiento],usuarioId: ID, page: Int, size: Int): MovimientoStockPage
     findStockWithFilters(inicio: String, fin: String, sucursalList: [ID], productoId: ID,tipoMovimientoList: [TipoMovimiento],usuarioId: ID): Float
     findStockPorTipoMovimiento(inicio: String, fin: String, sucursalList: [ID], productoId: ID,tipoMovimientoList: [TipoMovimiento],usuarioId: ID): [StockPorTipoMovimientoDto]
+    cantidadSugeridaPorSucursales(productoId: ID!, inicio: String!, fin: String!, sucursalList: [ID]): [CantidadSugeridaPorSucursal]!
     productosConCantidadPositiva(sucursalId: ID, productoId: ID, page: Int = 0, size: Int = 10): ProductoSaldoPage
     productosConCantidadNegativa(sucursalId: ID, productoId: ID, page: Int = 0, size: Int = 10): ProductoSaldoPage
     productosFaltantes(sucursalId: ID!, productoId: ID, fechaInicio: String!, fechaFin: String!, page: Int = 0, size: Int = 10): ProductoSaldoPage

--- a/src/test/java/com/franco/dev/repository/operaciones/CantidadSugeridaQueriesIT.java
+++ b/src/test/java/com/franco/dev/repository/operaciones/CantidadSugeridaQueriesIT.java
@@ -1,0 +1,137 @@
+package com.franco.dev.repository.operaciones;
+
+import com.franco.dev.domain.operaciones.dto.ComprasPorSucursalDto;
+import com.franco.dev.domain.operaciones.dto.VentasPorSucursalDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Que las dos consultas agregadas de la cantidad sugerida realmente corran.
+ *
+ * Los tests unitarios del service mockean el repositorio, asi que no tocan el JPQL. Acá está lo
+ * unico que esos no pueden cubrir, y que ademas no falla en el build sino recien cuando el JAR
+ * arranca contra una base:
+ *
+ * - el {@code cast(ms.tipoMovimiento as text)} sobre el enum de Postgres,
+ * - el {@code COUNT(ms.creadoEn)} en una entidad con clave compuesta ({@code @IdClass}), que con
+ *   {@code count(ms)} generaria un count de dos columnas que Postgres rechaza,
+ * - la proyeccion a DTO con {@code new ...(...)}, donde el tipo que Hibernate infiere para cada
+ *   agregado tiene que coincidir con el constructor.
+ *
+ * Corre contra una base real con el esquema aplicado, y se pide a mano:
+ *
+ *   ./mvnw test -Dit.cantidadSugerida=true -Dtest=CantidadSugeridaQueriesIT \
+ *       -Dspring.datasource.url=jdbc:postgresql://localhost:5551/una_base
+ *
+ * Flyway queda apagado a proposito: el test necesita el esquema, no aplicarlo. Es transaccional,
+ * asi que las filas que inserta se revierten al terminar. Y arranca sin web ({@code NONE}): con el
+ * contexto web, {@code GraphQLWebsocketAutoConfiguration} pide un {@code ServerContainer} que en un
+ * test no existe, y el contexto ni levanta.
+ */
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.NONE,
+        properties = {
+                "spring.flyway.enabled=false",
+                "spring.jpa.hibernate.ddl-auto=none"
+        })
+@ActiveProfiles({"dev", "user-dev"})
+@Transactional
+@EnabledIfSystemProperty(named = "it.cantidadSugerida", matches = "true")
+class CantidadSugeridaQueriesIT {
+
+    private static final long PRODUCTO_ID = 999111222L;
+    private static final LocalDateTime INICIO = LocalDateTime.of(2025, 9, 1, 0, 0);
+    private static final LocalDateTime FIN = LocalDateTime.of(2025, 9, 30, 23, 59, 59);
+    private static final List<Long> SUCURSALES = Arrays.asList(1L, 2L);
+
+    @Autowired
+    private MovimientoStockRepository repository;
+
+    @Autowired
+    private EntityManager em;
+
+    private long proximoId = 900000000L;
+
+    @BeforeEach
+    void sembrarMovimientos() {
+        em.createNativeQuery("insert into productos.producto (id) values (:id)")
+                .setParameter("id", PRODUCTO_ID).executeUpdate();
+
+        // Sucursal 1: dos ventas vivas y una anulada, mas dos compras.
+        mov(1L, "VENTA", -30, "2025-09-03 10:00", true);
+        mov(1L, "VENTA", -20, "2025-09-10 10:00", true);
+        mov(1L, "VENTA", -99, "2025-09-11 10:00", false);
+        mov(1L, "COMPRA", 100, "2025-09-02 08:00", true);
+        mov(1L, "COMPRA", 100, "2025-09-22 08:00", true);
+
+        // Sucursal 2: una transferencia de entrada, una de salida (no cuenta) y una fuera del rango.
+        mov(2L, "TRANSFERENCIA", 40, "2025-09-05 09:00", true);
+        mov(2L, "TRANSFERENCIA", -40, "2025-09-06 09:00", true);
+        mov(2L, "COMPRA", 10, "2025-08-01 09:00", true);
+
+        em.flush();
+    }
+
+    private void mov(Long sucursalId, String tipo, double cantidad, String creadoEn, boolean estado) {
+        em.createNativeQuery("insert into operaciones.movimiento_stock " +
+                        "(id, producto_id, tipo_movimiento, referencia, cantidad, creado_en, estado, sucursal_id) " +
+                        "values (:id, :pro, cast(:tipo as operaciones.tipo_movimiento), 0, :cant, cast(:fecha as timestamptz), :estado, :suc)")
+                .setParameter("id", proximoId++)
+                .setParameter("pro", PRODUCTO_ID)
+                .setParameter("tipo", tipo)
+                .setParameter("cant", cantidad)
+                .setParameter("fecha", creadoEn)
+                .setParameter("estado", estado)
+                .setParameter("suc", sucursalId)
+                .executeUpdate();
+    }
+
+    @Test
+    void sumaLasVentasVivasEnValorAbsolutoYDescartaLasAnuladas() {
+        List<VentasPorSucursalDto> filas = repository.ventasPorSucursal(PRODUCTO_ID, INICIO, FIN, SUCURSALES);
+
+        assertEquals(1, filas.size(), "solo la sucursal 1 tuvo ventas");
+        assertEquals(1L, filas.get(0).getSucursalId());
+        // 30 + 20 en positivo. La venta anulada de 99 no entra.
+        assertEquals(50.0, filas.get(0).getTotalVentas(), 0.0001);
+    }
+
+    @Test
+    void cuentaLasComprasYLasTransferenciasDeEntradaConSusFechas() {
+        List<ComprasPorSucursalDto> filas = repository.comprasPorSucursal(PRODUCTO_ID, INICIO, FIN, SUCURSALES);
+
+        ComprasPorSucursalDto suc1 = filas.stream().filter(f -> f.getSucursalId() == 1L)
+                .findFirst().orElseThrow(AssertionError::new);
+        assertEquals(2L, suc1.getCantidadCompras());
+        assertEquals(LocalDateTime.of(2025, 9, 2, 8, 0), suc1.getPrimeraCompra());
+        assertEquals(LocalDateTime.of(2025, 9, 22, 8, 0), suc1.getUltimaCompra());
+
+        // La transferencia de salida (-40) no es una entrada; la compra de agosto queda fuera del rango.
+        ComprasPorSucursalDto suc2 = filas.stream().filter(f -> f.getSucursalId() == 2L)
+                .findFirst().orElseThrow(AssertionError::new);
+        assertEquals(1L, suc2.getCantidadCompras());
+        assertEquals(LocalDateTime.of(2025, 9, 5, 9, 0), suc2.getUltimaCompra());
+    }
+
+    @Test
+    void sucursalFueraDeLaListaNoVuelve() {
+        List<VentasPorSucursalDto> filas = repository.ventasPorSucursal(
+                PRODUCTO_ID, INICIO, FIN, Collections.singletonList(2L));
+
+        assertTrue(filas.isEmpty());
+    }
+}

--- a/src/test/java/com/franco/dev/service/operaciones/MovimientoStockServiceCantidadSugeridaTest.java
+++ b/src/test/java/com/franco/dev/service/operaciones/MovimientoStockServiceCantidadSugeridaTest.java
@@ -1,0 +1,150 @@
+package com.franco.dev.service.operaciones;
+
+import com.franco.dev.domain.operaciones.dto.CantidadSugeridaPorSucursalDto;
+import com.franco.dev.domain.operaciones.dto.ComprasPorSucursalDto;
+import com.franco.dev.domain.operaciones.dto.VentasPorSucursalDto;
+import com.franco.dev.repository.operaciones.MovimientoStockRepository;
+import com.franco.dev.service.configuraciones.ModificacionService;
+import com.franco.dev.service.empresarial.SucursalService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Insumos de la cantidad sugerida: dos consultas agrupadas, no una por sucursal.
+ *
+ * El diálogo de ítem de compra necesita, por sucursal, cuatro números —cuánto se vendió, cuántas
+ * compras hubo y entre qué fechas—, y hasta ahora los sacaba bajándose hasta 1000 movimientos por
+ * sucursal y por tipo, en 2N requests encadenados. Acá se fija el contrato del reemplazo.
+ *
+ * El {@code verify} de cantidad de llamadas es parte del test y no un adorno: si alguien vuelve a
+ * consultar sucursal por sucursal, el resultado sigue dando bien y solo eso lo delata.
+ */
+class MovimientoStockServiceCantidadSugeridaTest {
+
+    private static final double DELTA = 0.0001;
+    private static final long PRODUCTO_ID = 77L;
+    private static final LocalDateTime INICIO = LocalDateTime.of(2025, 9, 1, 0, 0);
+    private static final LocalDateTime FIN = LocalDateTime.of(2025, 9, 30, 23, 59, 59);
+
+    private MovimientoStockRepository repository;
+    private MovimientoStockService service;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(MovimientoStockRepository.class);
+        service = new MovimientoStockService(
+                repository,
+                mock(ModificacionService.class),
+                mock(SucursalService.class),
+                mock(MovimientoStockLoteService.class),
+                mock(LoteFefoService.class),
+                mock(TransferenciaItemLoteService.class));
+    }
+
+    private void responde(List<VentasPorSucursalDto> ventas, List<ComprasPorSucursalDto> compras) {
+        when(repository.ventasPorSucursal(anyLong(), any(), any(), any())).thenReturn(ventas);
+        when(repository.comprasPorSucursal(anyLong(), any(), any(), any())).thenReturn(compras);
+    }
+
+    private List<CantidadSugeridaPorSucursalDto> ejecutar(List<Long> sucursales) {
+        return service.cantidadSugeridaPorSucursales(PRODUCTO_ID, INICIO, FIN, sucursales);
+    }
+
+    @Test
+    void mergeaVentasYComprasDeLaMismaSucursal() {
+        LocalDateTime primera = LocalDateTime.of(2025, 9, 2, 10, 0);
+        LocalDateTime ultima = LocalDateTime.of(2025, 9, 26, 10, 0);
+        responde(
+                Collections.singletonList(new VentasPorSucursalDto(1L, 120.0)),
+                Collections.singletonList(new ComprasPorSucursalDto(1L, 4L, primera, ultima)));
+
+        List<CantidadSugeridaPorSucursalDto> filas = ejecutar(Collections.singletonList(1L));
+
+        assertEquals(1, filas.size());
+        CantidadSugeridaPorSucursalDto fila = filas.get(0);
+        assertEquals(1L, fila.getSucursalId());
+        assertEquals(120.0, fila.getTotalVentas(), DELTA);
+        assertEquals(4L, fila.getCantidadCompras());
+        assertEquals(primera, fila.getPrimeraCompra());
+        assertEquals(ultima, fila.getUltimaCompra());
+    }
+
+    @Test
+    void sucursalSoloConVentasNoTieneCompras() {
+        responde(
+                Collections.singletonList(new VentasPorSucursalDto(2L, 50.0)),
+                Collections.emptyList());
+
+        CantidadSugeridaPorSucursalDto fila = ejecutar(Collections.singletonList(2L)).get(0);
+
+        assertEquals(50.0, fila.getTotalVentas(), DELTA);
+        assertEquals(0L, fila.getCantidadCompras());
+        assertNull(fila.getPrimeraCompra());
+        assertNull(fila.getUltimaCompra());
+    }
+
+    @Test
+    void sucursalSoloConComprasTieneVentasEnCero() {
+        LocalDateTime fecha = LocalDateTime.of(2025, 9, 5, 8, 30);
+        responde(
+                Collections.emptyList(),
+                Collections.singletonList(new ComprasPorSucursalDto(3L, 1L, fecha, fecha)));
+
+        CantidadSugeridaPorSucursalDto fila = ejecutar(Collections.singletonList(3L)).get(0);
+
+        assertEquals(0.0, fila.getTotalVentas(), DELTA);
+        assertEquals(1L, fila.getCantidadCompras());
+        assertEquals(fecha, fila.getUltimaCompra());
+    }
+
+    /**
+     * Una sucursal sin movimientos en el rango no vuelve en ningun GROUP BY. El diálogo la muestra
+     * en cero por su cuenta, igual que hace con el stock desde #208.
+     */
+    @Test
+    void sucursalSinMovimientosNoVuelveEnLaLista() {
+        responde(Collections.emptyList(), Collections.emptyList());
+
+        assertTrue(ejecutar(Arrays.asList(1L, 2L, 3L)).isEmpty());
+    }
+
+    @Test
+    void ordenaPorSucursalParaQueElResultadoSeaEstable() {
+        responde(
+                Arrays.asList(new VentasPorSucursalDto(9L, 1.0), new VentasPorSucursalDto(2L, 1.0)),
+                Collections.singletonList(new ComprasPorSucursalDto(5L, 1L, INICIO, INICIO)));
+
+        List<CantidadSugeridaPorSucursalDto> filas = ejecutar(Arrays.asList(9L, 2L, 5L));
+
+        assertEquals(Arrays.asList(2L, 5L, 9L),
+                filas.stream().map(CantidadSugeridaPorSucursalDto::getSucursalId).collect(java.util.stream.Collectors.toList()));
+    }
+
+    /**
+     * El punto del cambio: el costo no depende de cuantas sucursales pida el diálogo.
+     */
+    @Test
+    void consultaDosVecesSinImportarCuantasSucursales() {
+        responde(Collections.emptyList(), Collections.emptyList());
+
+        ejecutar(Arrays.asList(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L));
+
+        verify(repository, times(1)).ventasPorSucursal(anyLong(), any(), any(), any());
+        verify(repository, times(1)).comprasPorSucursal(anyLong(), any(), any(), any());
+    }
+}


### PR DESCRIPTION
Parte del central del issue GabFrank/frc-sistemas-integrados-angular#272. El PR del desktop es GabFrank/frc-sistemas-integrados-angular#274, y **depende de este**.

## Qué resuelve

El diálogo de ítem de compra calculaba la cantidad sugerida con **dos consultas encadenadas por distribución** —primero `COMPRA`/`TRANSFERENCIA` y, recién en su respuesta, `VENTA`—, cada una con `size: 1000` y escalonadas con `setTimeout(index * 10)`. Con 10 distribuciones eran 20 idas y vueltas en dos olas seriadas, y hasta 1000 filas por sucursal y por tipo para terminar en cuatro números por fila.

El algoritmo nunca necesitó las filas. Le alcanza con el total vendido, cuántas compras hubo y entre qué fechas: el promedio de las diferencias entre compras consecutivas **telescopa** a `(última - primera) / (cantidad - 1)`, así que las fechas del medio sobran.

Este PR agrega `cantidadSugeridaPorSucursales(productoId, inicio, fin, sucursalList)`, mismo molde que `stockPorSucursales` (#270). El desktop pasa de `1 + 2N` requests a 2.

### Por qué dos consultas y no una con `CASE`

`tipo_movimiento` es un enum de Postgres (`@Type(PostgreSQLEnumType)`), por eso todas las consultas de esta interfaz lo comparan con `cast(... as text)`. Un `SUM(case ...)` proyectado a un DTO con `new ...(...)` deja el tipo de retorno (`Double` vs `BigDecimal`) a merced de cómo lo infiera Hibernate 5.6; si infiere distinto, el constructor no matchea y el contexto no levanta.

Lo que había que bajar son los **requests HTTP**, no las consultas: las dos salen en el mismo request. Medido sobre `bodega3` (6,3 M de filas), el producto más movido de la base: **19 ms en caliente**. El planner usa `idx_movimiento_stock_fecha_tipo_producto`.

Detalle: `COUNT(ms.creadoEn)` y no `COUNT(ms)`, porque `MovimientoStock` tiene `@IdClass` y `count(ms)` genera un count de dos columnas que Postgres rechaza.

## Cambio de comportamiento: se filtra `estado = true`

`findByFilters`, que es lo que usaba el cliente, **no** filtra `estado`: la sugerida de hoy cuenta movimientos anulados —ventas canceladas (`VentaService:289`) y transferencias canceladas o rechazadas (`MovimientoStockService:307,322-327`)—. Una venta cancelada no es consumo.

Medido antes de mergear, sobre 794 pares producto/sucursal de los 40 productos más movidos de `bodega3`:

| | |
| --- | --- |
| pares evaluados | 794 |
| difieren | 3 |
| por ventas anuladas | 2 |
| por compras anuladas | 1 |
| **sin explicación** | **0** |

Diferencias de 1, 1 y 10 unidades.

## Cómo probarlo

Sin levantar nada, contra `bodega3`:

```bash
psql "postgresql://franco:franco@localhost:5551/bodega3" \
     -v producto=899 -f docs/utilitarios/comparar-cantidad-sugerida.sql
```

Muestra por sucursal lo que veía el diálogo antes y lo que ve ahora. Con el producto 899, sucursal 23, la sugerida baja de 278 a 268 por una compra anulada.

Con el server arriba:

```bash
TOKEN=$(curl -s -X POST http://localhost:8081/login -H 'Content-Type: application/json' \
  -d '{"nickname":"...","password":"..."}' | jq -r .token)

curl -s -X POST http://localhost:8081/graphql -H "Authorization: Bearer $TOKEN" \
  -H 'Content-Type: application/json' \
  -d '{"query":"{ cantidadSugeridaPorSucursales(productoId: 226, inicio: \"2025-09-01 00:00:00\", fin: \"2025-09-30 23:59:59\", sucursalList: [1,7,8,11]) { sucursalId totalVentas cantidadCompras primeraCompra ultimaCompra } }"}' | jq
```

Tests:

- `./mvnw clean verify -B -DskipFlyway=true` — 528 tests, verde.
- `MovimientoStockServiceCantidadSugeridaTest` — 6 tests del merge, incluido un `verify` de que se consulta el repositorio **exactamente dos veces** sin importar cuántas sucursales entren. Es el guard contra que alguien vuelva al bucle por sucursal: sin él, el resultado sigue dando bien y nada lo delata.
- `CantidadSugeridaQueriesIT` — opt-in, ejerce el JPQL contra un Postgres real. Es lo único que cubre el `cast` del enum, el `COUNT` con `@IdClass` y la proyección al DTO, que no fallan en el build sino recién cuando el JAR arranca. Corrido contra una base con el esquema aplicado: verde.

```bash
./mvnw test -Dtest=CantidadSugeridaQueriesIT -Dit.cantidadSugerida=true \
  -Dspring.datasource.url=jdbc:postgresql://localhost:5551/una_base_con_esquema
```

## Impacto en DB

**Ninguno.** No hay migraciones ni cambios de esquema. Los índices que las consultas necesitan ya existen.

## Impacto en rollback

**Ninguno.** Es puramente aditivo en la API GraphQL: un tipo y una query nuevos, nada eliminado ni renombrado. Un JAR anterior funciona igual.

**El central va primero en el deploy.** Con el desktop nuevo contra un central viejo la query no existe: el usuario ve el snackbar de error y la sugerida en 0. Degrada, no crashea.

## Riesgo

**Bajo.** `cantidadSugerida` es solo display: aparece únicamente en `add-edit-item-dialog.component.html:301-302`, no se autocompleta en `cantidadPedir` —ese input lo tipea el usuario—, no se persiste y ningún otro componente la consume. El peor caso es un número orientativo en pantalla distinto, nunca una cantidad comprada distinta.

## Nota aparte: la fórmula está rota, y no es esto

Al medir apareció algo que **no se toca en este PR**. Sobre los mismos 794 pares, sin una sola excepción:

- **716/716** pares con compras en la ventana → `sugerida = max(0, −stockActual)`
- **78/78** pares sin compras → `sugerida = max(0, totalVentas − stockActual)`

Cuando el producto tuvo compras en ese mes, **todo el historial de ventas se descarta**. Es una mezcla de unidades en `diasHastaProximaCompra = max(0, frecuenciaCompraDias - diasDesdeUltimaCompra)`: `ultimaCompra` sale de una ventana del mismo mes del **año pasado**, pero `diasDesdeUltimaCompra` se mide contra `new Date()`. Da ~350 días contra una frecuencia que como mucho es 30 → siempre negativo → clampeado a 0.

No se arregló acá a propósito: definir qué debería sugerir el sistema es una decisión de producto, y mezclarla haría imposible atribuir un movimiento de números a una causa u otra. Está reportado en el issue para tratarlo aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LK4FmmEuX51PphwgSz4WMJ
