### PR TITLE
fix(rrhh): no contar domingos en los dias de vacaciones

### DIFF
--- a/src/main/java/com/franco/dev/service/rrhh/VacacionService.java
+++ b/src/main/java/com/franco/dev/service/rrhh/VacacionService.java
@@ -12,6 +12,7 @@ import com.franco.dev.repository.rrhh.VacacionPeriodoRepository;
 import com.franco.dev.repository.rrhh.VacacionRepository;
 import com.franco.dev.repository.rrhh.VacacionVentaRepository;
 import com.franco.dev.service.CrudService;
+import com.franco.dev.service.rrhh.builder.VacacionPeriodoCalculator;
 import com.franco.dev.service.personas.FuncionarioService;
 import graphql.GraphQLException;
 import lombok.AllArgsConstructor;
@@ -109,7 +110,13 @@ public class VacacionService extends CrudService<Vacacion, VacacionRepository, L
                                             VacacionPeriodoEstado estado, String observacion) {
         Vacacion v = repository.findById(vacacionId)
                 .orElseThrow(() -> new GraphQLException("Vacacion no encontrada"));
-        int dias = (int) (ChronoUnit.DAYS.between(desde, hasta) + 1);
+        // Solo los dias laborables descuentan saldo: el domingo es dia libre. Antes se
+        // contaban los dias corridos, asi que asignar los 12 dias de vacaciones daba 13 o
+        // 14 (segun cuantos domingos cayeran adentro) y la solicitud se rechazaba.
+        int dias = VacacionPeriodoCalculator.diasLaborables(desde, hasta);
+        if (dias <= 0) {
+            throw new GraphQLException("El rango no contiene ningun dia laborable");
+        }
         // Contra el disponible real: los dias ya vendidos tampoco se pueden gozar.
         int disponibles = diasDisponibles(v);
         if (dias > disponibles) {
@@ -158,12 +165,15 @@ public class VacacionService extends CrudService<Vacacion, VacacionRepository, L
             Long funcionarioId = v.getFuncionario() != null ? v.getFuncionario().getId() : null;
             LocalDate d = p.getFechaDesde();
             while (funcionarioId != null && d != null && !d.isAfter(p.getFechaHasta())) {
-                Justificativo j = new Justificativo();
-                j.setFuncionario(v.getFuncionario());
-                j.setFecha(d);
-                j.setTipo(tipoVacacion);
-                j.setObservacion("VACACION (PERIODO #" + p.getId() + ")");
-                justificativoService.save(j);
+                // Los domingos no generan novedad: no son jornada, no se estan gozando.
+                if (VacacionPeriodoCalculator.esDiaLaborable(d)) {
+                    Justificativo j = new Justificativo();
+                    j.setFuncionario(v.getFuncionario());
+                    j.setFecha(d);
+                    j.setTipo(tipoVacacion);
+                    j.setObservacion("VACACION (PERIODO #" + p.getId() + ")");
+                    justificativoService.save(j);
+                }
                 d = d.plusDays(1);
             }
             p.setNovedadesGeneradas(true);

--- a/src/main/java/com/franco/dev/service/rrhh/builder/VacacionPeriodoCalculator.java
+++ b/src/main/java/com/franco/dev/service/rrhh/builder/VacacionPeriodoCalculator.java
@@ -1,0 +1,40 @@
+package com.franco.dev.service.rrhh.builder;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+
+/**
+ * Cálculo puro de los días que consume un período de vacaciones.
+ *
+ * <p>Acá se trabaja de lunes a sábado y el domingo es día libre, así que un período
+ * de vacaciones descuenta del saldo solo los días laborables del rango: 12 días de
+ * vacaciones abarcan 13 o 14 días corridos según cuántos domingos caigan en el medio.
+ * Contarlos corridos hacía que una asignación válida de 12 días se rechazara con
+ * "Los dias del periodo superan los dias disponibles".
+ *
+ * <p>Los feriados NO se excluyen: un feriado dentro de las vacaciones se consume como
+ * día de vacación. Sin dependencias de Spring/JPA para poder testearlo aislado.
+ */
+public final class VacacionPeriodoCalculator {
+
+    private VacacionPeriodoCalculator() {
+    }
+
+    /** Un día es laborable si no es domingo. */
+    public static boolean esDiaLaborable(LocalDate fecha) {
+        return fecha != null && fecha.getDayOfWeek() != DayOfWeek.SUNDAY;
+    }
+
+    /**
+     * Días laborables del rango [desde, hasta], ambos inclusive. Devuelve 0 si el rango
+     * es nulo o está invertido.
+     */
+    public static int diasLaborables(LocalDate desde, LocalDate hasta) {
+        if (desde == null || hasta == null || hasta.isBefore(desde)) return 0;
+        int dias = 0;
+        for (LocalDate d = desde; !d.isAfter(hasta); d = d.plusDays(1)) {
+            if (esDiaLaborable(d)) dias++;
+        }
+        return dias;
+    }
+}

--- a/src/test/java/com/franco/dev/service/rrhh/builder/VacacionPeriodoCalculatorTest.java
+++ b/src/test/java/com/franco/dev/service/rrhh/builder/VacacionPeriodoCalculatorTest.java
@@ -1,0 +1,69 @@
+package com.franco.dev.service.rrhh.builder;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class VacacionPeriodoCalculatorTest {
+
+    /**
+     * El caso que motivo el fix: al asignar 12 dias de vacaciones el rango de fechas
+     * abarca mas dias corridos que dias de saldo, porque los domingos son dia libre y
+     * no se descuentan. Antes se contaban corridos y la solicitud se rechazaba con
+     * "Los dias del periodo superan los dias disponibles: 12".
+     */
+    @Test
+    void doceDiasHabilesAbarcanMasDiasCorridos() {
+        // lunes 07/09 -> sabado 19/09: 13 dias corridos, 1 domingo en el medio
+        assertEquals(12, VacacionPeriodoCalculator.diasLaborables(
+                LocalDate.of(2026, 9, 7), LocalDate.of(2026, 9, 19)));
+        // martes 08/09 -> lunes 21/09: 14 dias corridos, 2 domingos en el medio
+        assertEquals(12, VacacionPeriodoCalculator.diasLaborables(
+                LocalDate.of(2026, 9, 8), LocalDate.of(2026, 9, 21)));
+    }
+
+    @Test
+    void unaSemanaCompletaSonSeisDias() {
+        LocalDate lunes = LocalDate.of(2026, 9, 7);
+        assertEquals(6, VacacionPeriodoCalculator.diasLaborables(lunes, lunes.plusDays(6)));
+    }
+
+    @Test
+    void rangoDeUnSoloDiaLaborable() {
+        LocalDate martes = LocalDate.of(2026, 9, 8);
+        assertEquals(1, VacacionPeriodoCalculator.diasLaborables(martes, martes));
+    }
+
+    @Test
+    void rangoDeUnSoloDomingoNoDescuentaNada() {
+        LocalDate domingo = LocalDate.of(2026, 9, 13);
+        assertEquals(0, VacacionPeriodoCalculator.diasLaborables(domingo, domingo));
+    }
+
+    @Test
+    void rangoQueEmpiezaYTerminaEnDomingo() {
+        LocalDate domingo = LocalDate.of(2026, 9, 13);
+        // domingo a domingo: 8 dias corridos, 6 laborables (los dos domingos no cuentan)
+        assertEquals(6, VacacionPeriodoCalculator.diasLaborables(domingo, domingo.plusDays(7)));
+    }
+
+    @Test
+    void rangoInvertidoOIncompletoDaCero() {
+        LocalDate lunes = LocalDate.of(2026, 9, 7);
+        assertEquals(0, VacacionPeriodoCalculator.diasLaborables(lunes, lunes.minusDays(1)));
+        assertEquals(0, VacacionPeriodoCalculator.diasLaborables(null, lunes));
+        assertEquals(0, VacacionPeriodoCalculator.diasLaborables(lunes, null));
+    }
+
+    @Test
+    void esDiaLaborableDistingueElDomingo() {
+        assertFalse(VacacionPeriodoCalculator.esDiaLaborable(LocalDate.of(2026, 9, 13)));
+        assertTrue(VacacionPeriodoCalculator.esDiaLaborable(LocalDate.of(2026, 9, 12)));
+        assertTrue(VacacionPeriodoCalculator.esDiaLaborable(LocalDate.of(2026, 9, 14)));
+        assertFalse(VacacionPeriodoCalculator.esDiaLaborable(null));
+    }
+}


### PR DESCRIPTION
Closes #280

## Qué resuelve

Al asignar una vacación de **12 días** el sistema la rechazaba con *"Los dias del periodo superan los dias disponibles: 12"*. El período contaba días corridos, y como acá se trabaja de lunes a sábado, 12 días de vacaciones abarcan 13 o 14 de calendario según cuántos domingos caigan en el rango.

`VacacionService.programarPeriodo:112` era el único punto de cálculo (`ChronoUnit.DAYS.between(desde, hasta) + 1`), compartido por el desktop (`VacacionGraphQL`) y mobile (`RrhhMobileService.solicitarVacacion`).

## Cambios

- **Nuevo `service/rrhh/builder/VacacionPeriodoCalculator`** — cálculo puro sin Spring (`esDiaLaborable`, `diasLaborables`), siguiendo el patrón de `VacacionDevengamientoCalculator` para poder testearlo aislado.
- **`programarPeriodo`** cuenta solo días laborables y rechaza un rango sin ninguno (antes se podía crear un período de un solo domingo).
- **`marcarGozada`** ya no genera novedad `Justificativo` de tipo VACACION en los domingos. Sin esto el conteo diría 12 pero quedarían 14 novedades cargadas.
- **7 tests** en `VacacionPeriodoCalculatorTest`.

Criterio acordado: se excluyen **solo los domingos** (un feriado dentro de las vacaciones se consume como día de vacación), el día de descanso queda fijo en código, y los períodos ya cargados conservan su `diasUsados` original.

## Cómo probarlo

Levantar el central (8081), el filial (8082) y el front, y entrar a **RRHH → Beneficios → Vacaciones**:

1. Sobre un funcionario con 12 días disponibles, programar el período **08/09/2026 → 21/09/2026** (14 días corridos, 2 domingos). Antes fallaba; ahora crea el período con **Días = 12**.
2. Aprobarlo y marcarlo como gozado → deben quedar **12 novedades de VACACION, ninguna en domingo**.

Verificado en la app + en base:

```
VACACION (PERIODO #3) | 12 novedades | domingos=0 | rango 2026-09-08 a 2026-09-21
VACACION (PERIODO #2) |  6 novedades | domingos=0 | rango 2026-09-14 a 2026-09-19
```

## Riesgo

**Bajo.** Sin migración Flyway, sin cambios de schema GraphQL. Cambia el resultado de `diasUsados` para períodos nuevos; los existentes no se tocan.

## Repo relacionado

PR complementario en `frc-sistemas-integrados-angular` (misma rama `fix/rrhh-vacaciones-dias-habiles`): agrega el preview "Días a descontar" en el diálogo. Es solo UI — este PR es el que corrige el cálculo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKCYBA6kiMEPLjFt3akz5s