### PR TITLE
feat(transferencia): avisar por subscription cuando se escanea el QR

### DIFF
--- a/src/main/java/com/franco/dev/graphql/operaciones/TransferenciaGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/TransferenciaGraphQL.java
@@ -11,6 +11,9 @@ import com.franco.dev.domain.operaciones.enums.TipoTransferencia;
 import com.franco.dev.domain.operaciones.enums.TransferenciaEstado;
 import com.franco.dev.domain.personas.Usuario;
 import com.franco.dev.graphql.operaciones.input.TransferenciaInput;
+import com.franco.dev.graphql.operaciones.publisher.TransferenciaQrEscaneadoPublisher;
+import com.franco.dev.graphql.operaciones.publisher.TransferenciaQrEscaneadoUpdate;
+import com.franco.dev.security.Unsecured;
 import com.franco.dev.service.empresarial.SucursalService;
 import com.franco.dev.service.impresion.ImpresionService;
 import com.franco.dev.service.operaciones.MovimientoStockService;
@@ -20,6 +23,8 @@ import com.franco.dev.service.personas.UsuarioService;
 import graphql.GraphQLException;
 import graphql.kickstart.tools.GraphQLMutationResolver;
 import graphql.kickstart.tools.GraphQLQueryResolver;
+import graphql.kickstart.tools.GraphQLSubscriptionResolver;
+import org.reactivestreams.Publisher;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -34,7 +39,7 @@ import java.util.Optional;
 import static com.franco.dev.utilitarios.DateUtils.stringToDate;
 
 @Component
-public class TransferenciaGraphQL implements GraphQLQueryResolver, GraphQLMutationResolver {
+public class TransferenciaGraphQL implements GraphQLQueryResolver, GraphQLMutationResolver, GraphQLSubscriptionResolver {
 
     @Autowired
     private TransferenciaService service;
@@ -63,6 +68,35 @@ public class TransferenciaGraphQL implements GraphQLQueryResolver, GraphQLMutati
 
     @Autowired
     private PlatformTransactionManager transactionManager;
+
+    @Autowired
+    private TransferenciaQrEscaneadoPublisher qrEscaneadoPublisher;
+
+    /**
+     * Avisa que se escaneó el QR de una transferencia.
+     *
+     * Va sin seguridad igual que {@code ventaCreditoQrAuth}: lo único que
+     * viaja son dos ids que el que escanea ya tenía delante en el QR, y lo
+     * único que provoca es que se cierre un diálogo. No lee ni modifica
+     * nada de la transferencia.
+     */
+    @Unsecured
+    public Boolean transferenciaQrEscaneado(Long id, Long sucursalId) {
+        try {
+            TransferenciaQrEscaneadoUpdate entity = new TransferenciaQrEscaneadoUpdate();
+            entity.setTransferenciaId(id);
+            entity.setSucursalId(sucursalId);
+            qrEscaneadoPublisher.publish(entity);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Unsecured
+    public Publisher<TransferenciaQrEscaneadoUpdate> transferenciaQrEscaneadoSub() {
+        return qrEscaneadoPublisher.getPublisher();
+    }
 
     public Optional<Transferencia> transferencia(Long id) {
         return service.findById(id);

--- a/src/main/java/com/franco/dev/graphql/operaciones/publisher/TransferenciaQrEscaneadoPublisher.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/publisher/TransferenciaQrEscaneadoPublisher.java
@@ -1,0 +1,48 @@
+package com.franco.dev.graphql.operaciones.publisher;
+
+import io.reactivex.rxjava3.core.BackpressureStrategy;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.ObservableEmitter;
+import io.reactivex.rxjava3.observables.ConnectableObservable;
+import lombok.extern.slf4j.Slf4j;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Component;
+
+/**
+ * Canal por el que viaja el aviso de escaneo hasta los desktops conectados.
+ *
+ * Sigue el mismo armado que {@code VentaCreditoQRAuthPublisher}: un
+ * observable caliente, sin persistencia. Un desktop que se suscribe después
+ * del escaneo no recibe el aviso, y está bien —para cuando eso pasa el
+ * diálogo que había que cerrar ya no existe.
+ */
+@Slf4j
+@Component
+public class TransferenciaQrEscaneadoPublisher {
+
+    private final Flowable<TransferenciaQrEscaneadoUpdate> publisher;
+
+    private ObservableEmitter<TransferenciaQrEscaneadoUpdate> emitter;
+
+    public TransferenciaQrEscaneadoPublisher() {
+        Observable<TransferenciaQrEscaneadoUpdate> observable = Observable.create(emitter -> {
+            this.emitter = emitter;
+        });
+
+        ConnectableObservable<TransferenciaQrEscaneadoUpdate> connectableObservable = observable.publish();
+        connectableObservable.connect();
+
+        publisher = connectableObservable.toFlowable(BackpressureStrategy.BUFFER);
+    }
+
+    public void publish(final TransferenciaQrEscaneadoUpdate entity) {
+        ModelMapper m = new ModelMapper();
+        TransferenciaQrEscaneadoUpdate entityUpdate = m.map(entity, TransferenciaQrEscaneadoUpdate.class);
+        emitter.onNext(entityUpdate);
+    }
+
+    public Flowable<TransferenciaQrEscaneadoUpdate> getPublisher() {
+        return publisher;
+    }
+}

--- a/src/main/java/com/franco/dev/graphql/operaciones/publisher/TransferenciaQrEscaneadoUpdate.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/publisher/TransferenciaQrEscaneadoUpdate.java
@@ -1,0 +1,19 @@
+package com.franco.dev.graphql.operaciones.publisher;
+
+import lombok.Data;
+
+/**
+ * Aviso de que alguien escaneó el QR de una transferencia desde el móvil.
+ *
+ * No representa ningún cambio de estado del negocio: la transferencia no se
+ * modifica al escanearla. Es solo la señal que le permite al desktop cerrar
+ * el diálogo del QR cuando ya cumplió su función, en vez de dejarlo abierto
+ * hasta que alguien lo cierre a mano.
+ */
+@Data
+public class TransferenciaQrEscaneadoUpdate {
+
+    private Long transferenciaId;
+
+    private Long sucursalId;
+}

--- a/src/main/resources/graphql/operaciones/transferencia.graphqls
+++ b/src/main/resources/graphql/operaciones/transferencia.graphqls
@@ -72,6 +72,16 @@ extend type Mutation {
     deleteTransferencia(id:ID!):Boolean!
     finalizarTransferencia(id:ID!, usuarioId:ID!):Boolean!
     avanzarEtapaTransferencia(id:ID!, etapa: EtapaTransferencia!, usuarioId:ID!):Boolean!
+    transferenciaQrEscaneado(id:ID!, sucursalId:ID!):Boolean
+}
+
+extend type Subscription {
+    transferenciaQrEscaneadoSub:TransferenciaQrEscaneadoUpdate
+}
+
+type TransferenciaQrEscaneadoUpdate {
+    transferenciaId:ID
+    sucursalId:ID
 }
 
 enum TransferenciaEstado {


### PR DESCRIPTION
Parte 1 de 3 de un cambio que cruza los tres repos. Los otros dos van en la rama del mismo nombre:

- `GabFrank/frc-sistemas-integrados-angular` — el botón en la lista y el cierre del diálogo
- `GabFrank/frc-mobile-pwa` — el aviso al escanear

## Qué resuelve

El desktop mostraba el QR de una transferencia y no tenía forma de enterarse de que ya lo habían escaneado: el diálogo quedaba abierto hasta que alguien lo cerraba a mano. Faltaba el canal de vuelta.

## Cómo

`transferenciaQrEscaneado(id, sucursalId)` recibe el aviso del móvil y lo republica por `transferenciaQrEscaneadoSub`, con el mismo armado que ya usa el QR de venta a crédito (`VentaCreditoQRAuthPublisher`).

Escanear no es un cambio de estado del negocio, así que no se toca la transferencia ni se persiste nada. El publisher es un observable caliente: un desktop que se suscribe tarde no recibe el aviso, y para entonces el diálogo que había que cerrar ya no existe.

## Compatibilidad

**Puramente aditivo.** Una mutation, una subscription y un type nuevos; no se modifica ni elimina nada existente. `frc-mobile` sigue escaneando transferencias sin ningún error — parsea el QR igual y usa `getTransferencia`, que no cambió. Lo único que no hace es avisar, así que con el cliente viejo el diálogo se cierra a mano como hasta ahora.

## Verificación

- Compila (`mvnw compile` y `test-compile`).
- Arranca con el schema nuevo: `Started FrancoSystemsApplication in 46s`. Si la mutation o la subscription estuvieran mal declaradas, graphql-kickstart abortaría el arranque.
- Probado de punta a punta con la PWA contra este central: se escanea el QR y el diálogo del desktop se cierra solo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)