### PR TITLE
feat(gastos): gastos de caja mayor en los reportes y solicitud dirigida a SERVIDOR

### DIFF
--- a/src/main/java/com/franco/dev/domain/financiero/Gasto.java
+++ b/src/main/java/com/franco/dev/domain/financiero/Gasto.java
@@ -88,6 +88,16 @@ public class Gasto extends EmbeddedEntity implements Serializable {
             @JoinColumn(name = "pre_gasto_sucursal_id", referencedColumnName = "sucursal_id")
     })
     private PreGasto preGasto;
+
+    /**
+     * Solicitud de pago (CPP) que dio origen al gasto, cuando el gasto se pago desde la caja
+     * mayor y no desde una caja fisica. Es el gasto de tesoreria: no tiene caja ni responsable,
+     * vive en la sucursal 0 (SERVIDOR) y lo mantiene GastoTesoreriaService.
+     *
+     * NULL en todos los gastos de caja fisica.
+     */
+    @Column(name = "solicitud_pago_id")
+    private Long solicitudPagoId;
 }
 
 

--- a/src/main/java/com/franco/dev/graphql/financiero/GastoGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/GastoGraphQL.java
@@ -123,6 +123,7 @@ public class GastoGraphQL implements GraphQLQueryResolver, GraphQLMutationResolv
     public Boolean deleteGasto(Long id, Long sucId) {
         Gasto gasto = service.findByIdAndSucursalId(id, sucId);
         if (gasto != null) {
+            validarNoEsDeCajaMayor(gasto, "eliminar");
             return service.delete(gasto);
         } else {
             throw new GraphQLException("No se pudo eliminar el gasto");
@@ -132,9 +133,24 @@ public class GastoGraphQL implements GraphQLQueryResolver, GraphQLMutationResolv
     public Boolean cancelarGasto(Long id, Long sucId) {
         Gasto gasto = service.findByIdAndSucursalId(id, sucId);
         if (gasto != null) {
+            validarNoEsDeCajaMayor(gasto, "cancelar");
             return service.cancelarGasto(gasto);
         } else {
             throw new GraphQLException("No se pudo cancelar el gasto");
+        }
+    }
+
+    /**
+     * Un gasto pagado desde la caja mayor es el espejo de su solicitud de pago: la fuente de
+     * verdad es la solicitud, y GastoTesoreriaService lo mantiene sincronizado. Tocarlo por
+     * separado dejaria el gasto cancelado con el pago intacto (y la proxima sincronizacion lo
+     * revertiria), asi que se corta aca con un mensaje que dice donde se hace de verdad.
+     */
+    private void validarNoEsDeCajaMayor(Gasto gasto, String accion) {
+        if (gasto.getSolicitudPagoId() != null) {
+            throw new GraphQLException("Este gasto se pagó desde la caja mayor: para " + accion
+                    + "lo hay que anular el pago del gasto #" + gasto.getSolicitudPagoId()
+                    + " en la caja mayor.");
         }
     }
 

--- a/src/main/java/com/franco/dev/graphql/financiero/PreGastoGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/financiero/PreGastoGraphQL.java
@@ -173,14 +173,18 @@ public class PreGastoGraphQL implements GraphQLQueryResolver, GraphQLMutationRes
         if (input.getSucursalCajaId() != null) {
             e.setSucursalCaja(sucursalService.findById(input.getSucursalCajaId()).orElse(null));
         }
-        if (input.getSucursalId() != null && input.getSucursalId() > 0) {
+        // La sucursal vale si EXISTE, no si es > 0: la sucursal 0 (SERVIDOR) es un destino
+        // legitimo para una solicitud que se va a cobrar desde la caja mayor y no de una caja
+        // fisica. Antes se rechazaba por el signo y no habia forma de dirigir un gasto al
+        // central desde ningun cliente.
+        if (input.getSucursalId() != null && sucursalService.findById(input.getSucursalId()).isPresent()) {
             e.setSucursalId(input.getSucursalId());
-        } else if (e.getSucursalCaja() != null && e.getSucursalCaja().getId() != null
-                && e.getSucursalCaja().getId() > 0) {
-            // Fallback: usar sucursal de caja cuando el frontend no envía sucursalId.
+        } else if (e.getSucursalCaja() != null && e.getSucursalCaja().getId() != null) {
+            // Fallback: usar sucursal de caja cuando el frontend no envía sucursalId (el
+            // escritorio manda solo esa).
             e.setSucursalId(e.getSucursalCaja().getId());
         }
-        if (e.getSucursalId() == null || e.getSucursalId() <= 0) {
+        if (e.getSucursalId() == null) {
             throw new GraphQLException("Debe indicar una sucursal válida para registrar la solicitud.");
         }
         e.setCajaId(input.getCajaId());

--- a/src/main/java/com/franco/dev/repository/financiero/GastoRepository.java
+++ b/src/main/java/com/franco/dev/repository/financiero/GastoRepository.java
@@ -109,4 +109,11 @@ public interface GastoRepository extends HelperRepository<Gasto, EmbebedPrimaryK
 
         Gasto findFirstByPreGastoIdAndPreGastoSucursalIdOrderByCreadoEnDescIdDesc(Long preGastoId,
                         Long preGastoSucursalId);
+
+        /**
+         * Gasto de tesoreria materializado a partir de una solicitud de pago de tipo GASTO
+         * (pagada desde la caja mayor). Hay a lo sumo uno: lo garantiza el indice unico
+         * uk_gasto_solicitud_pago.
+         */
+        Gasto findFirstBySolicitudPagoId(Long solicitudPagoId);
 }

--- a/src/main/java/com/franco/dev/service/financiero/GastoService.java
+++ b/src/main/java/com/franco/dev/service/financiero/GastoService.java
@@ -87,7 +87,9 @@ public class GastoService extends CrudService<Gasto, GastoRepository, EmbebedPri
             Long sucId) {
         java.time.LocalDateTime fechaInicio = stringToDate(inicio);
         java.time.LocalDateTime fechaFin = stringToDate(fin);
-        Long sucursalIdFiltro = (sucId != null && sucId > 0) ? sucId : null;
+        // sucId 0 es la sucursal SERVIDOR (gastos pagados desde la caja mayor), no el
+        // centinela de "todas": null es el unico que significa todas.
+        Long sucursalIdFiltro = (sucId != null && sucId >= 0) ? sucId : null;
         List<Object[]> results = sucursalIdFiltro != null
                 ? repository.gastosPorCategoria(fechaInicio, fechaFin, sucursalIdFiltro)
                 : repository.gastosPorCategoriaSinSucursal(fechaInicio, fechaFin);
@@ -105,7 +107,8 @@ public class GastoService extends CrudService<Gasto, GastoRepository, EmbebedPri
     public List<com.franco.dev.domain.financiero.GastoPorMes> gastosPorMes(Integer anio, Long sucId) {
         java.time.LocalDateTime inicio = java.time.LocalDateTime.of(anio, 1, 1, 0, 0);
         java.time.LocalDateTime fin = java.time.LocalDateTime.of(anio, 12, 31, 23, 59, 59);
-        Long sucursalIdFiltro = (sucId != null && sucId > 0) ? sucId : null;
+        // Idem gastosPorCategoria: 0 es SERVIDOR, no "todas".
+        Long sucursalIdFiltro = (sucId != null && sucId >= 0) ? sucId : null;
         List<Object[]> results = sucursalIdFiltro != null
                 ? repository.gastosPorMes(inicio, fin, sucursalIdFiltro)
                 : repository.gastosPorMesSinSucursal(inicio, fin);

--- a/src/main/java/com/franco/dev/service/financiero/GastoTesoreriaService.java
+++ b/src/main/java/com/franco/dev/service/financiero/GastoTesoreriaService.java
@@ -1,10 +1,13 @@
 package com.franco.dev.service.financiero;
 
+import com.franco.dev.domain.financiero.Gasto;
 import com.franco.dev.domain.financiero.Moneda;
 import com.franco.dev.domain.financiero.TipoGasto;
 import com.franco.dev.domain.operaciones.SolicitudPago;
+import com.franco.dev.domain.operaciones.enums.TipoSolicitudPago;
 import com.franco.dev.domain.personas.Proveedor;
 import com.franco.dev.domain.personas.Usuario;
+import com.franco.dev.repository.financiero.GastoRepository;
 import com.franco.dev.service.operaciones.SolicitudPagoService;
 import com.franco.dev.service.personas.ProveedorService;
 import graphql.GraphQLException;
@@ -12,6 +15,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 /**
@@ -26,10 +30,22 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class GastoTesoreriaService {
 
+    /**
+     * Sucursal 0 (SERVIDOR). Los gastos de caja mayor no pertenecen a ninguna sucursal fisica.
+     * Ojo que no es "SUC. CENTRAL", que es la filial 1.
+     */
+    public static final Long SUCURSAL_SERVIDOR = 0L;
+
+    private static final Long MONEDA_GUARANI = 1L;
+    private static final Long MONEDA_REAL = 2L;
+    private static final Long MONEDA_DOLAR = 3L;
+
     private final SolicitudPagoService solicitudPagoService;
     private final TipoGastoService tipoGastoService;
     private final MonedaService monedaService;
     private final ProveedorService proveedorService;
+    private final GastoRepository gastoRepository;
+    private final GastoService gastoService;
 
     @Transactional
     public SolicitudPago crearGastoParaPago(Long tipoGastoId, String descripcion, Long monedaId, Double monto,
@@ -53,5 +69,89 @@ public class GastoTesoreriaService {
 
         return solicitudPagoService.crearSolicitudGasto(
                 beneficiario, categoria, moneda, monto, descripcion.trim(), fechaVencimiento, usuario);
+    }
+
+    /**
+     * Refleja en {@code financiero.gasto} el estado de pago de una solicitud de tipo GASTO, para
+     * que el gasto pagado desde la caja mayor aparezca en el grafico "Gastos por Categoria" y en
+     * la lista de gastos: las dos leen esa tabla, no {@code operaciones.solicitud_pago}.
+     *
+     * <p>El gasto materializado vive en la <b>sucursal 0</b> (SERVIDOR), sin caja ni
+     * responsable, y queda vinculado a su solicitud por {@code solicitud_pago_id} (unico). Es un
+     * espejo de solo lectura: la fuente de verdad de la deuda sigue siendo la solicitud.</p>
+     *
+     * <p>Lo invoca el motor de pago en los dos sentidos, igual que
+     * {@code PreGastoService.sincronizarDesdeSolicitudPago}: al pagar se crea o se actualiza con
+     * lo efectivamente pagado, y al anular el pago se marca cancelado (no se borra: asi el numero
+     * de gasto no se reusa y queda la trazabilidad). No-op para compras y para RRHH.</p>
+     */
+    @Transactional
+    public void sincronizarDesdeSolicitudPago(SolicitudPago sp) {
+        if (sp == null || sp.getTipo() != TipoSolicitudPago.GASTO) return;
+
+        BigDecimal pagado = sp.getMontoPagado() != null ? sp.getMontoPagado() : BigDecimal.ZERO;
+        Gasto gasto = gastoRepository.findFirstBySolicitudPagoId(sp.getId());
+
+        // Anulacion: la solicitud vuelve a deber todo. El gasto se cancela, no se borra.
+        if (pagado.signum() <= 0) {
+            if (gasto != null && !Boolean.TRUE.equals(gasto.getCancelado())) {
+                gasto.setCancelado(true);
+                gastoRepository.save(gasto);
+            }
+            return;
+        }
+
+        if (gasto == null) {
+            gasto = new Gasto();
+            gasto.setId(siguienteIdServidor());
+            gasto.setSucursalId(SUCURSAL_SERVIDOR);
+            gasto.setSolicitudPagoId(sp.getId());
+            gasto.setActivo(true);
+            gasto.setFinalizado(true);
+        }
+
+        // Una anulacion parcial (quedo saldo pagado) rehabilita el gasto por el monto que sigue en pie.
+        gasto.setCancelado(false);
+        gasto.setTipoGasto(sp.getTipoGasto());
+        gasto.setUsuario(sp.getUsuario());
+        gasto.setObservacion(observacionDe(sp));
+        aplicarMonto(gasto, sp, pagado.doubleValue());
+
+        gastoService.save(gasto);
+    }
+
+    /** Id correlativo dentro de la sucursal 0, igual que el resto de las entidades de clave compuesta. */
+    private Long siguienteIdServidor() {
+        Long maxId = gastoRepository.findMaxId(SUCURSAL_SERVIDOR);
+        return (maxId == null ? 0L : maxId) + 1;
+    }
+
+    /**
+     * El monto va a la columna de su moneda, como cualquier gasto de caja. Los reportes agregados
+     * suman {@code retiro_gs}, asi que un gasto en dolares o reales se ve en la lista pero no en
+     * el grafico -- es exactamente lo que ya pasa con los gastos de caja fisica en otra moneda.
+     */
+    private void aplicarMonto(Gasto gasto, SolicitudPago sp, Double monto) {
+        Long monedaId = sp.getMoneda() != null ? sp.getMoneda().getId() : MONEDA_GUARANI;
+        gasto.setRetiroGs(MONEDA_GUARANI.equals(monedaId) ? monto : 0.0);
+        gasto.setRetiroRs(MONEDA_REAL.equals(monedaId) ? monto : 0.0);
+        gasto.setRetiroDs(MONEDA_DOLAR.equals(monedaId) ? monto : 0.0);
+        gasto.setVueltoGs(0.0);
+        gasto.setVueltoRs(0.0);
+        gasto.setVueltoDs(0.0);
+    }
+
+    /**
+     * Misma descripcion que muestra el movimiento de la caja mayor ("#446 - BENEFICIARIO - detalle"),
+     * menos la categoria, que en el gasto es una columna propia.
+     */
+    private String observacionDe(SolicitudPago sp) {
+        String beneficiario = "\u2014";
+        if (sp.getProveedor() != null && sp.getProveedor().getPersona() != null
+                && sp.getProveedor().getPersona().getNombre() != null) {
+            beneficiario = sp.getProveedor().getPersona().getNombre();
+        }
+        String detalle = sp.getObservaciones() != null ? sp.getObservaciones() : "";
+        return "#" + sp.getId() + " - " + beneficiario + " - " + detalle;
     }
 }

--- a/src/main/java/com/franco/dev/service/financiero/PagoProveedorService.java
+++ b/src/main/java/com/franco/dev/service/financiero/PagoProveedorService.java
@@ -63,6 +63,7 @@ public class PagoProveedorService {
     private final TesoreriaSecurityService seguridad;
     private final com.franco.dev.repository.financiero.MovimientoBancarioRepository movimientoBancarioRepository;
     private final PreGastoService preGastoService;
+    private final GastoTesoreriaService gastoTesoreriaService;
     // Sin ciclo: ValeService no conoce el motor de pago (el que sí lo usa es ValeTesoreriaService).
     private final com.franco.dev.service.rrhh.ValeService valeService;
     private final com.franco.dev.service.rrhh.LiquidacionSueldoService liquidacionSueldoService;
@@ -534,6 +535,9 @@ public class PagoProveedorService {
             }
             // Si el gasto vino de un PreGasto (workflow de aprobación), sincronizar su estado.
             preGastoService.sincronizarDesdeSolicitudPago(sp);
+            // Un gasto pagado desde la caja mayor se materializa en financiero.gasto (sucursal 0),
+            // que es lo que leen el gráfico por categoría y la lista de gastos.
+            gastoTesoreriaService.sincronizarDesdeSolicitudPago(sp);
             // Si la obligación era de un vale de RRHH, dejarlo CONFIRMADO (es lo que mira la
             // liquidación para descontarlo del sueldo).
             valeService.sincronizarDesdeSolicitudPago(sp);
@@ -620,6 +624,8 @@ public class PagoProveedorService {
             solicitudPagoService.desmarcarNotasComoPagadas(sp.getId());
             // Si es un gasto con PreGasto, revertir su estado (PAGADO → ENVIADO_A_TESORERIA).
             preGastoService.sincronizarDesdeSolicitudPago(sp);
+            // El gasto materializado queda cancelado: deja de sumar en el gráfico y en la lista.
+            gastoTesoreriaService.sincronizarDesdeSolicitudPago(sp);
             // Si era el pago de un vale, vuelve a quedar pendiente de entrega (CONFIRMADO → SOLICITADO).
             valeService.sincronizarDesdeSolicitudPago(sp);
             // Idem para los demas conceptos de RRHH pagables desde el hub de la caja

--- a/src/main/java/com/franco/dev/service/financiero/PreGastoService.java
+++ b/src/main/java/com/franco/dev/service/financiero/PreGastoService.java
@@ -76,6 +76,12 @@ import static com.franco.dev.utilitarios.DateUtils.stringToDate;
 @RequiredArgsConstructor
 public class PreGastoService extends CrudService<PreGasto, PreGastoRepository, EmbebedPrimaryKey> {
 
+    /**
+     * Sucursal 0. No es un local: no tiene caja fisica, asi que una solicitud dirigida ahi solo
+     * se puede cobrar desde la caja mayor. Ojo que no es "SUC. CENTRAL", que es la filial 1.
+     */
+    public static final Long SUCURSAL_SERVIDOR = 0L;
+
     private final PreGastoRepository repository;
     private final EnteFinancieroService enteFinancieroService;
     private final EnteCuotaService enteCuotaService;
@@ -130,11 +136,12 @@ public class PreGastoService extends CrudService<PreGasto, PreGastoRepository, E
         }
 
         if (entity.getId() == null) {
-            Long sucursalId = entity.getSucursalId() != null ? entity.getSucursalId() : currentSucursalId; // Default
-                                                                                                           // sucursal
-                                                                                                           // from
-                                                                                                           // config
-            if (sucursalId == null || sucursalId <= 0) {
+            // Default: la sucursal configurada del server. La sucursal 0 (SERVIDOR) es un
+            // destino valido —el gasto se cobra desde la caja mayor—, asi que se corta por
+            // ausencia y no por signo. Sin sucursal sigue siendo un error: nunca un default
+            // silencioso.
+            Long sucursalId = entity.getSucursalId() != null ? entity.getSucursalId() : currentSucursalId;
+            if (sucursalId == null) {
                 throw new RuntimeException("No se puede crear la solicitud sin una sucursal válida.");
             }
             Long maxId = repository.findMaxId(sucursalId);
@@ -528,6 +535,14 @@ public class PreGastoService extends CrudService<PreGasto, PreGastoRepository, E
         PreGasto preGasto = repository.findByIdAndSucursalId(input.getPreGastoId(), input.getSucursalId());
         if (preGasto == null) {
             throw new RuntimeException("Solicitud de gasto no encontrada.");
+        }
+        // La sucursal 0 (SERVIDOR) no tiene ninguna pdv_caja: su plata sale de la caja mayor.
+        // Se corta antes que el resto de las validaciones para no terminar diciendole al
+        // operador "registre el gasto en la caja local", que es justo lo que no puede hacer.
+        if (SUCURSAL_SERVIDOR.equals(preGasto.getSucursalId())) {
+            throw new RuntimeException(
+                    "Esta solicitud es de SERVIDOR: se cobra desde la caja mayor (Enviar a tesorería), "
+                            + "no por retiro de caja.");
         }
         if (preGasto.getEstado() != EstadoPreGasto.AUTORIZADO) {
             throw new RuntimeException("La solicitud no está autorizada para retiro.");

--- a/src/main/java/com/franco/dev/service/grafico/GraficoAggregationService.java
+++ b/src/main/java/com/franco/dev/service/grafico/GraficoAggregationService.java
@@ -36,6 +36,7 @@ import static com.franco.dev.service.grafico.GraficoPeriodoUtil.esMultiPeriodo;
 import static com.franco.dev.service.grafico.GraficoPeriodoUtil.extraerAnho;
 import static com.franco.dev.service.grafico.GraficoPeriodoUtil.fusionarSucursalesTexto;
 import static com.franco.dev.service.grafico.GraficoPeriodoUtil.normalizarSucIds;
+import static com.franco.dev.service.grafico.GraficoPeriodoUtil.normalizarSucIdsConServidor;
 import static com.franco.dev.service.grafico.GraficoPeriodoUtil.normalizarUsuarioIds;
 import static com.franco.dev.utilitarios.DateUtils.stringToDate;
 
@@ -105,7 +106,8 @@ public class GraficoAggregationService {
             List<Long> sucIds) {
         validarPeriodos(periodos);
         boolean multiPeriodo = esMultiPeriodo(periodos);
-        List<Long> sucursales = normalizarSucIds(sucIds);
+        // Con servidor: los gastos pagados desde la caja mayor viven en la sucursal 0.
+        List<Long> sucursales = normalizarSucIdsConServidor(sucIds);
 
         Map<String, GastoPorCategoria> mapa = new LinkedHashMap<>();
 

--- a/src/main/java/com/franco/dev/service/grafico/GraficoPeriodoUtil.java
+++ b/src/main/java/com/franco/dev/service/grafico/GraficoPeriodoUtil.java
@@ -27,6 +27,27 @@ public final class GraficoPeriodoUtil {
         return ids.isEmpty() ? Collections.singletonList(null) : ids;
     }
 
+    /**
+     * Igual que {@link #normalizarSucIds(List)} pero acepta la <b>sucursal 0</b> (SERVIDOR) como
+     * una sucursal mas.
+     *
+     * <p>En casi todo el sistema {@code sucursalId <= 0} es el centinela de "todas las sucursales"
+     * ({@code VentaItemService}, {@code CobroDetalleService}, etc.), asi que dejar pasar el 0 ahi
+     * convertiria un filtro en un total. Pero los gastos pagados desde la caja mayor viven
+     * literalmente en la sucursal 0, y sin esto no se podrian mirar solos. Usar unicamente en los
+     * reportes de gastos.</p>
+     */
+    public static List<Long> normalizarSucIdsConServidor(List<Long> sucIds) {
+        if (sucIds == null || sucIds.isEmpty()) {
+            return Collections.singletonList(null);
+        }
+        List<Long> ids = sucIds.stream()
+                .filter(id -> id != null && id >= 0)
+                .distinct()
+                .collect(Collectors.toList());
+        return ids.isEmpty() ? Collections.singletonList(null) : ids;
+    }
+
     public static List<Long> normalizarUsuarioIds(List<Long> usuarioIds) {
         if (usuarioIds == null || usuarioIds.isEmpty()) {
             return Collections.emptyList();

--- a/src/main/resources/db/migration/V221.3__gasto_desde_caja_mayor.sql
+++ b/src/main/resources/db/migration/V221.3__gasto_desde_caja_mayor.sql
@@ -1,0 +1,55 @@
+-- Gastos pagados desde la caja mayor: materializarlos en financiero.gasto.
+--
+-- Un gasto de tesoreria nace como operaciones.solicitud_pago (tipo GASTO) y se salda contra una
+-- caja virtual. Vivia solo ahi, asi que no aparecia ni en el grafico "Gastos por Categoria" ni en
+-- la lista de gastos: las dos leen financiero.gasto. Se materializa en la sucursal 0 (SERVIDOR),
+-- sin caja ni responsable, vinculado a su solicitud por solicitud_pago_id.
+--
+-- De aca en adelante lo mantiene GastoTesoreriaService (al pagar y al anular). Esta migracion
+-- agrega la columna y trae los gastos ya pagados.
+--
+-- Central-only: operaciones.solicitud_pago no existe en las filiales.
+
+ALTER TABLE financiero.gasto
+    ADD COLUMN IF NOT EXISTS solicitud_pago_id bigint;
+
+COMMENT ON COLUMN financiero.gasto.solicitud_pago_id IS
+    'Solicitud de pago (CPP) que origino el gasto cuando se pago desde la caja mayor. NULL en los gastos de caja fisica.';
+
+-- A lo sumo un gasto por solicitud: es lo que hace idempotente la sincronizacion.
+CREATE UNIQUE INDEX IF NOT EXISTS uk_gasto_solicitud_pago
+    ON financiero.gasto (solicitud_pago_id)
+    WHERE solicitud_pago_id IS NOT NULL;
+
+-- Backfill de los gastos ya pagados desde la caja mayor.
+-- El id es correlativo dentro de la sucursal 0, como el resto de las claves compuestas.
+INSERT INTO financiero.gasto (
+    id, sucursal_id, solicitud_pago_id, tipo_gasto_id, usuario_id, observacion,
+    creado_en, activo, finalizado, cancelado,
+    retiro_gs, retiro_rs, retiro_ds, vuelto_gs, vuelto_rs, vuelto_ds
+)
+SELECT
+    (SELECT COALESCE(MAX(g.id), 0) FROM financiero.gasto g WHERE g.sucursal_id = 0)
+        + ROW_NUMBER() OVER (ORDER BY sp.id),
+    0,
+    sp.id,
+    sp.tipo_gasto_id,
+    sp.usuario_id,
+    '#' || sp.id || ' - ' || COALESCE(NULLIF(per.nombre, ''), '—') || ' - ' || COALESCE(sp.observaciones, ''),
+    COALESCE(p.creado_en, sp.fecha_solicitud),
+    true,
+    true,
+    false,
+    CASE WHEN sp.moneda_id = 1 THEN sp.monto_pagado ELSE 0 END,
+    CASE WHEN sp.moneda_id = 2 THEN sp.monto_pagado ELSE 0 END,
+    CASE WHEN sp.moneda_id = 3 THEN sp.monto_pagado ELSE 0 END,
+    0, 0, 0
+FROM operaciones.solicitud_pago sp
+LEFT JOIN operaciones.pago p       ON p.id  = sp.pago_id
+LEFT JOIN personas.proveedor pr    ON pr.id = sp.proveedor_id
+LEFT JOIN personas.persona per     ON per.id = pr.persona_id
+WHERE sp.tipo = 'GASTO'
+  AND COALESCE(sp.monto_pagado, 0) > 0
+  AND NOT EXISTS (
+      SELECT 1 FROM financiero.gasto g WHERE g.solicitud_pago_id = sp.id
+  );

--- a/src/test/java/com/franco/dev/service/financiero/PagoProveedorServiceTest.java
+++ b/src/test/java/com/franco/dev/service/financiero/PagoProveedorServiceTest.java
@@ -64,12 +64,16 @@ class PagoProveedorServiceTest {
                 mock(com.franco.dev.service.rrhh.LiquidacionFinalService.class);
         com.franco.dev.service.rrhh.AguinaldoService aguinaldoService =
                 mock(com.franco.dev.service.rrhh.AguinaldoService.class);
+        // Espeja el gasto pagado desde la caja mayor en financiero.gasto; estos tests miran el
+        // motor de pago, no el espejo.
+        GastoTesoreriaService gastoTesoreriaService = mock(GastoTesoreriaService.class);
         // El ACL de cajas acota detalleDePago; estos tests no lo ejercitan.
         TesoreriaSecurityService seguridad = mock(TesoreriaSecurityService.class);
         service = new PagoProveedorService(solicitudPagoService, pagoService, tesoreriaService, bancoLedgerService,
                 chequeGestionService, chequeraRepo, cajaVirtualRepository, monedaRepository, detalleRepo,
                 seguridad, movBancarioRepo,
-                preGastoService, valeService, liquidacionSueldoService, liquidacionFinalService, aguinaldoService);
+                preGastoService, gastoTesoreriaService, valeService, liquidacionSueldoService,
+                liquidacionFinalService, aguinaldoService);
 
         com.franco.dev.domain.personas.Persona persona = new com.franco.dev.domain.personas.Persona(); persona.setNombre("PROV X");
         Proveedor prov = new Proveedor(); prov.setId(7L); prov.setPersona(persona);

--- a/src/test/java/com/franco/dev/service/financiero/PreGastoRetiroServidorTest.java
+++ b/src/test/java/com/franco/dev/service/financiero/PreGastoRetiroServidorTest.java
@@ -1,0 +1,138 @@
+package com.franco.dev.service.financiero;
+
+import com.franco.dev.domain.financiero.PreGasto;
+import com.franco.dev.domain.financiero.enums.EstadoPreGasto;
+import com.franco.dev.graphql.financiero.input.EjecutarRetiroPreGastoInput;
+import com.franco.dev.repository.financiero.GastoRepository;
+import com.franco.dev.repository.financiero.PreGastoRepository;
+import com.franco.dev.service.activos.EnteService;
+import com.franco.dev.service.activos.InmuebleService;
+import com.franco.dev.service.activos.MuebleService;
+import com.franco.dev.service.activos.VehiculoService;
+import com.franco.dev.service.administrativo.AutorizacionAuditService;
+import com.franco.dev.service.equipos.EquipoService;
+import com.franco.dev.service.operaciones.SolicitudPagoService;
+import com.franco.dev.service.personas.FuncionarioService;
+import com.franco.dev.service.personas.PersonaService;
+import com.franco.dev.service.personas.ProveedorService;
+import com.franco.dev.service.personas.UsuarioService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Una solicitud dirigida a SERVIDOR (sucursal 0) se cobra desde la caja mayor, no por retiro de
+ * caja: la sucursal 0 no tiene ninguna pdv_caja. Sin este corte el flujo moria mas adelante con
+ * "Debe registrar el gasto en la caja local", que manda al operador a hacer justo lo que no puede.
+ */
+class PreGastoRetiroServidorTest {
+
+    private PreGastoRepository repository;
+    private PreGastoService service;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(PreGastoRepository.class);
+        service = new PreGastoService(
+                repository,
+                mock(EnteFinancieroService.class),
+                mock(EnteCuotaService.class),
+                mock(SolicitudPagoService.class),
+                mock(ProveedorService.class),
+                mock(UsuarioService.class),
+                mock(PersonaService.class),
+                mock(FuncionarioService.class),
+                mock(AutorizacionAuditService.class),
+                mock(MuebleService.class),
+                mock(EnteService.class),
+                mock(InmuebleService.class),
+                mock(VehiculoService.class),
+                mock(EquipoService.class),
+                mock(GastoRepository.class),
+                mock(PreGastoDetalleFinanzasService.class),
+                mock(PdvCajaService.class),
+                mock(MonedaService.class),
+                mock(TipoGastoService.class),
+                mock(TipoGastoModuloReglasService.class));
+    }
+
+    /** PreGasto listo para retirar, salvo por la sucursal. */
+    private PreGasto preGastoAutorizado(Long sucursalId) {
+        PreGasto pg = new PreGasto();
+        pg.setId(1L);
+        pg.setSucursalId(sucursalId);
+        pg.setEstado(EstadoPreGasto.AUTORIZADO);
+        pg.setRetiroConfirmadoEn(LocalDateTime.now());
+        return pg;
+    }
+
+    private EjecutarRetiroPreGastoInput input(Long sucursalId) {
+        EjecutarRetiroPreGastoInput in = new EjecutarRetiroPreGastoInput();
+        in.setPreGastoId(1L);
+        in.setSucursalId(sucursalId);
+        in.setGastoRegistroId(77L);
+        in.setCajaId(5L);
+        return in;
+    }
+
+    @Test
+    void retiroDeCajaRechazadoParaSolicitudDeServidor() {
+        when(repository.findByIdAndSucursalId(1L, 0L)).thenReturn(preGastoAutorizado(0L));
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> service.ejecutarRetiro(input(0L)));
+
+        assertTrue(ex.getMessage().toUpperCase().contains("SERVIDOR"),
+                "El mensaje tiene que nombrar a SERVIDOR: " + ex.getMessage());
+        assertTrue(ex.getMessage().toLowerCase().contains("caja mayor"),
+                "El mensaje tiene que mandar a la caja mayor: " + ex.getMessage());
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    void seCreaLaSolicitudDirigidaAServidor() {
+        when(repository.findMaxId(0L)).thenReturn(null);
+        when(repository.save(any(PreGasto.class))).thenAnswer(i -> i.getArgument(0));
+
+        PreGasto nueva = new PreGasto();
+        nueva.setSucursalId(0L);
+
+        PreGasto guardada = service.save(nueva);
+
+        assertEquals(0L, guardada.getSucursalId());
+        assertEquals(1L, guardada.getId(), "El correlativo de SERVIDOR arranca en 1 como el de cualquier sucursal");
+        assertEquals(EstadoPreGasto.PENDIENTE, guardada.getEstado());
+    }
+
+    @Test
+    void sigueRechazandoLaSolicitudSinNingunaSucursal() {
+        // Aceptar el 0 no puede convertirse en "cualquier cosa vale": sin sucursal sigue siendo
+        // un error, no un default silencioso.
+        PreGasto nueva = new PreGasto();
+        nueva.setSucursalId(null);
+
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> service.save(nueva));
+
+        assertTrue(ex.getMessage().toLowerCase().contains("sucursal"), ex.getMessage());
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    void retiroDeCajaSigueValidoParaUnaFilial() {
+        when(repository.findByIdAndSucursalId(1L, 3L)).thenReturn(preGastoAutorizado(3L));
+
+        // No llega a completarse (los colaboradores son mocks), pero NO puede cortar por el
+        // guardarraíl de SERVIDOR: una filial sí retira de su caja.
+        try {
+            service.ejecutarRetiro(input(3L));
+        } catch (RuntimeException ex) {
+            String msg = ex.getMessage() != null ? ex.getMessage() : "";
+            assertFalse(msg.toUpperCase().contains("SERVIDOR"),
+                    "Una filial no puede caer en el corte de SERVIDOR: " + msg);
+        }
+    }
+}


### PR DESCRIPTION
## Qué resuelve

Dos huecos del módulo de gastos que dejaban plata fuera de los reportes.

**1. Los gastos pagados desde la caja mayor no existían para los reportes.** Un gasto de tesorería nace como `operaciones.solicitud_pago` (tipo `GASTO`) y se salda contra la caja virtual — nunca se escribía en `financiero.gasto`, que es la tabla que leen el gráfico "Gastos por Categoría", la lista de gastos, gastos por mes, ingreso-vs-gasto y el Excel. En la base de dev eran **148 gastos por 269.154.595 Gs invisibles**.

Ahora el motor de pago materializa el gasto en `financiero.gasto` (sucursal 0, SERVIDOR: sin caja ni responsable), vinculado a su solicitud por `solicitud_pago_id`. `GastoTesoreriaService` lo sincroniza en los dos sentidos, igual que `PreGastoService`: al pagar se crea o se actualiza con lo efectivamente pagado, y al anular el pago se marca cancelado — no se borra, para no reusar el número de gasto. Con eso quedan cubiertos todos los consumidores de una, sin tocar cada consulta.

Cancelar o eliminar un gasto espejado desde la lista se rechaza con un mensaje que apunta a anular el pago en la caja mayor: hacerlo por separado dejaba el gasto cancelado con el pago intacto.

**2. Una solicitud de gasto no se podía dirigir a SERVIDOR.** El central la rechazaba en dos lugares distintos, los dos por el signo del id: `PreGastoGraphQL.savePreGasto` (por `sucursalId` y por el fallback de `sucursalCajaId`, que es el camino del escritorio) y `PreGastoService.save`. Ahora la sucursal vale si **existe**, no si es `> 0`.

Aceptar el `0` no se vuelve "cualquier cosa vale": sin sucursal sigue siendo error y nunca un default silencioso. Importa porque el central corre con `sucursalId=0` en la config, así que un fallback flojo mandaría a SERVIDOR toda solicitud a la que un cliente le olvide la sucursal. Hay un test que lo fija.

Se suma un guardarraíl en `ejecutarRetiro`: la sucursal 0 no tiene ninguna `pdv_caja`, así que su solicitud no puede salir por retiro de caja. Corta antes que el resto de las validaciones para no terminar diciendo "registre el gasto en la caja local", que es justo lo que no se puede hacer.

## Cómo probarlo

1. Pagar un gasto desde la caja mayor → aparece en el gráfico "Gastos por Categoría" y en la lista de gastos, bajo la sucursal SERVIDOR.
2. Anular ese pago → el gasto queda cancelado y deja de sumar.
3. Intentar cancelarlo desde la lista de gastos → lo rechaza con el mensaje que manda a la caja mayor.
4. Crear una solicitud de gasto dirigida a SERVIDOR y enviarla a tesorería → aparece en "Pagar Gasto".
5. `./mvnw test` → 556 tests en verde.

## Impacto en DB

`V221.3` agrega `financiero.gasto.solicitud_pago_id` (nullable) con índice único parcial, y backfillea los gastos ya pagados desde la caja mayor. Es **central-only** (`operaciones.solicitud_pago` no existe en la filial) e idempotente. `financiero.gasto` se replica `BRANCH_TO_MAIN`, o sea que el central es el **suscriptor**: una columna extra de su lado no rompe la replicación, y las filas con `sucursal_id = 0` no se publican a ninguna filial.

## Rollback

La migración solo agrega. Al volver al JAR anterior la columna queda sin usar y los gastos backfilleados siguen siendo filas válidas de `financiero.gasto`; lo único que se pierde es la sincronización de los pagos nuevos.

## Riesgo

Bajo.

## Orden de merge

Este PR va **primero**. Los de `frc-sistemas-integrados-angular` y `frc-mobile-pwa` dependen de él y no hacen nada útil hasta que este central esté desplegado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qaFBtY1kHp3pryr8hGCz1