### PR TITLE
fix(rrhh): anular un pago con monto negativo devolvia la plata al reves

### DIFF
--- a/src/main/java/com/franco/dev/service/financiero/MovimientoCajaVirtualService.java
+++ b/src/main/java/com/franco/dev/service/financiero/MovimientoCajaVirtualService.java
@@ -64,4 +64,18 @@ public class MovimientoCajaVirtualService {
     public MovimientoCajaVirtual anularMovimiento(Long movimientoId, String motivo, Usuario usuario) {
         return tesoreriaService.anular(movimientoId, motivo, usuario);
     }
+
+    /**
+     * Contra-movimiento que revierte el efecto de un movimiento, sin el guard cross-módulo:
+     * lo llama el módulo dueño de la operación al anularla (RRHH, CPP...).
+     *
+     * <p>Existe para que los dueños no armen el AJUSTE a mano. Hacerlo a mano se ve simétrico
+     * pero no lo es: el egreso entra por {@code abs().negate()} y el AJUSTE conserva el signo,
+     * así que copiar el monto sin negar solo revierte cuando el monto es positivo — con un
+     * monto negativo vuelve a descontar. {@code TesoreriaService.revertir} recalcula el efecto
+     * y lo niega, y además marca el original como inactivo.</p>
+     */
+    public MovimientoCajaVirtual revertirMovimiento(Long movimientoId, String motivo, Usuario usuario) {
+        return tesoreriaService.revertir(tesoreriaService.findMovimiento(movimientoId), motivo, usuario);
+    }
 }

--- a/src/main/java/com/franco/dev/service/rrhh/LiquidacionFinalService.java
+++ b/src/main/java/com/franco/dev/service/rrhh/LiquidacionFinalService.java
@@ -588,6 +588,15 @@ public class LiquidacionFinalService extends CrudService<LiquidacionFinal, Liqui
     public LiquidacionFinal pagar(Long id, Long cajaVirtualId) {
         LiquidacionFinal lf = repository.findById(id).orElseThrow(() -> new GraphQLException("Liquidacion final no encontrada"));
         if (lf.getEstado() != LiquidacionFinalEstado.APROBADA) throw new GraphQLException("Solo se paga una APROBADA");
+        // Total negativo = los descuentos superan a los haberes: el funcionario le debe a la
+        // empresa y no hay finiquito que pagarle. Sin este corte el EGRESO se postea con la
+        // cantidad negada y saca de la caja justamente lo que habria que cobrar.
+        BigDecimal total = lf.getTotalLiquidado() != null ? lf.getTotalLiquidado() : BigDecimal.ZERO;
+        if (total.signum() < 0) {
+            throw new GraphQLException("El finiquito #" + lf.getId() + " tiene total negativo ("
+                    + total.toPlainString() + "): los descuentos superan a los haberes, no hay nada que pagar."
+                    + " Corrija los items o cobre la diferencia por separado.");
+        }
 
         CajaVirtual caja = cajaVirtualService.findById(cajaVirtualId)
                 .orElseThrow(() -> new GraphQLException("Caja Mayor no encontrada"));
@@ -737,19 +746,15 @@ public class LiquidacionFinalService extends CrudService<LiquidacionFinal, Liqui
         LiquidacionFinal lf = repository.findById(id).orElseThrow(() -> new GraphQLException("Liquidacion final no encontrada"));
         if (lf.getEstado() == LiquidacionFinalEstado.ANULADA) return lf;
         if (lf.getEstado() == LiquidacionFinalEstado.PAGADA && lf.getCajaVirtualId() != null) {
-            CajaVirtual caja = cajaVirtualService.findById(lf.getCajaVirtualId())
-                    .orElseThrow(() -> new GraphQLException("Caja Mayor no encontrada"));
-            MovimientoCajaVirtual rev = new MovimientoCajaVirtual();
-            rev.setCajaVirtual(caja);
-            rev.setTipoMovimiento(CajaVirtualTipoMovimiento.AJUSTE);
-            rev.setCantidad(lf.getTotalLiquidado() != null ? lf.getTotalLiquidado().doubleValue() : 0.0);
-            rev.setMoneda(lf.getMoneda());
-            rev.setReferenciaId(lf.getId());
-            rev.setOrigenTipo(OrigenMovimientoTipo.RRHH_LIQUIDACION_FINAL);
-            rev.setOrigenId(lf.getId());
-            rev.setDescripcion("ANULACION LIQUIDACION FINAL #" + lf.getId());
-            rev.setActivo(true);
-            movimientoCajaVirtualService.registrarMovimiento(rev);
+            if (lf.getMovimientoCajaVirtualId() == null) {
+                throw new GraphQLException("El finiquito #" + lf.getId() + " esta pagado contra una caja"
+                        + " pero no tiene movimiento asociado: no se puede revertir sin dejar la caja descuadrada.");
+            }
+            // La reversa la arma tesoreria, que recalcula el efecto del movimiento original y lo
+            // niega. Copiar el total a mano en un AJUSTE solo revierte cuando el total es
+            // positivo: con total negativo vuelve a descontar en vez de devolver.
+            movimientoCajaVirtualService.revertirMovimiento(lf.getMovimientoCajaVirtualId(),
+                    "ANULACION LIQUIDACION FINAL #" + lf.getId(), lf.getUsuario());
             // Revertir el saldado de vales/cuotas.
             aplicarEfectosCruzados(lf, false);
         }

--- a/src/main/java/com/franco/dev/service/rrhh/LiquidacionSueldoService.java
+++ b/src/main/java/com/franco/dev/service/rrhh/LiquidacionSueldoService.java
@@ -519,6 +519,16 @@ public class LiquidacionSueldoService extends CrudService<LiquidacionSueldo, Liq
     public LiquidacionSueldo pagar(Long id, Long cajaVirtualId) {
         LiquidacionSueldo liq = repository.findById(id).orElseThrow(() -> new GraphQLException("Liquidacion no encontrada"));
         if (liq.getEstado() != LiquidacionSueldoEstado.APROBADA) throw new GraphQLException("Solo se paga una liquidacion APROBADA");
+        // Neto negativo = los descuentos superan a los haberes, o sea que el funcionario le debe
+        // a la empresa: no hay nada que pagarle. Sin este corte el egreso se postea con la
+        // cantidad negada (EGRESO entra por abs().negate()) y termina sacando de la caja
+        // justamente la plata que habria que cobrar.
+        BigDecimal neto = liq.getTotalNeto() != null ? liq.getTotalNeto() : BigDecimal.ZERO;
+        if (neto.signum() < 0) {
+            throw new GraphQLException("La liquidacion #" + liq.getId() + " tiene neto negativo ("
+                    + neto.toPlainString() + "): los descuentos superan a los haberes, no hay nada que pagar."
+                    + " Corrija los items o cobre la diferencia por separado.");
+        }
 
         CajaVirtual caja = cajaVirtualService.findById(cajaVirtualId)
                 .orElseThrow(() -> new GraphQLException("Caja Mayor no encontrada"));
@@ -555,19 +565,15 @@ public class LiquidacionSueldoService extends CrudService<LiquidacionSueldo, Liq
         LiquidacionSueldo liq = repository.findById(id).orElseThrow(() -> new GraphQLException("Liquidacion no encontrada"));
         if (liq.getEstado() == LiquidacionSueldoEstado.ANULADA) return liq;
         if (liq.getEstado() == LiquidacionSueldoEstado.PAGADA && liq.getCajaVirtualId() != null) {
-            CajaVirtual caja = cajaVirtualService.findById(liq.getCajaVirtualId())
-                    .orElseThrow(() -> new GraphQLException("Caja Mayor no encontrada"));
-            MovimientoCajaVirtual rev = new MovimientoCajaVirtual();
-            rev.setCajaVirtual(caja);
-            rev.setTipoMovimiento(CajaVirtualTipoMovimiento.AJUSTE);
-            rev.setCantidad(liq.getTotalNeto() != null ? liq.getTotalNeto().doubleValue() : 0.0);
-            rev.setMoneda(liq.getMoneda());
-            rev.setReferenciaId(liq.getId());
-            rev.setOrigenTipo(OrigenMovimientoTipo.RRHH_LIQUIDACION_SUELDO);
-            rev.setOrigenId(liq.getId());
-            rev.setDescripcion("ANULACION LIQUIDACION #" + liq.getId());
-            rev.setActivo(true);
-            movimientoCajaVirtualService.registrarMovimiento(rev);
+            if (liq.getMovimientoCajaVirtualId() == null) {
+                throw new GraphQLException("La liquidacion #" + liq.getId() + " esta pagada contra una caja"
+                        + " pero no tiene movimiento asociado: no se puede revertir sin dejar la caja descuadrada.");
+            }
+            // La reversa la arma tesoreria, que recalcula el efecto del movimiento original y lo
+            // niega. Armar el AJUSTE a mano copiando el neto solo revierte cuando el neto es
+            // positivo: con neto negativo vuelve a descontar en vez de devolver.
+            movimientoCajaVirtualService.revertirMovimiento(liq.getMovimientoCajaVirtualId(),
+                    "ANULACION LIQUIDACION #" + liq.getId(), liq.getUsuario());
             aplicarEfectosCruzados(liq, false);
         }
         liq.setEstado(LiquidacionSueldoEstado.ANULADA);

--- a/src/main/java/com/franco/dev/service/rrhh/ValeService.java
+++ b/src/main/java/com/franco/dev/service/rrhh/ValeService.java
@@ -214,20 +214,15 @@ public class ValeService extends CrudService<Vale, ValeRepository, Long> {
 
     private void revertirEgresoCaja(Vale vale) {
         if (vale.getCajaVirtualId() == null) return;
-        CajaVirtual caja = cajaVirtualService.findById(vale.getCajaVirtualId())
-                .orElseThrow(() -> new GraphQLException("Caja Mayor no encontrada"));
-        MovimientoCajaVirtual rev = new MovimientoCajaVirtual();
-        rev.setCajaVirtual(caja);
-        rev.setTipoMovimiento(CajaVirtualTipoMovimiento.AJUSTE);
-        rev.setCantidad(vale.getMonto() != null ? vale.getMonto().doubleValue() : 0.0);
-        rev.setMoneda(vale.getMoneda());
-        rev.setReferenciaId(vale.getId());
-        rev.setOrigenTipo(OrigenMovimientoTipo.RRHH_VALE);
-        rev.setOrigenId(vale.getId());
-        rev.setDescripcion("ANULACION VALE #" + vale.getId());
-        rev.setUsuario(vale.getUsuario());
-        rev.setActivo(true);
-        movimientoCajaVirtualService.registrarMovimiento(rev);
+        if (vale.getMovimientoCajaVirtualId() == null) {
+            throw new GraphQLException("El vale #" + vale.getId() + " esta confirmado contra una caja"
+                    + " pero no tiene movimiento asociado: no se puede revertir sin dejar la caja descuadrada.");
+        }
+        // La reversa la arma tesoreria, que recalcula el efecto del movimiento original, lo niega
+        // y marca el original como inactivo. Copiar el monto a mano en un AJUSTE solo revierte
+        // cuando el monto es positivo, y deja el movimiento original sin tachar.
+        movimientoCajaVirtualService.revertirMovimiento(vale.getMovimientoCajaVirtualId(),
+                "ANULACION VALE #" + vale.getId(), vale.getUsuario());
     }
 
     /** Sufijo " - NOMBRE" para las descripciones de los movimientos (vacio si no hay). */

--- a/src/test/java/com/franco/dev/service/rrhh/ContraAsientoRrhhTest.java
+++ b/src/test/java/com/franco/dev/service/rrhh/ContraAsientoRrhhTest.java
@@ -1,0 +1,242 @@
+package com.franco.dev.service.rrhh;
+
+import com.franco.dev.domain.financiero.CajaVirtual;
+import com.franco.dev.domain.financiero.CajaVirtualSaldo;
+import com.franco.dev.domain.financiero.Moneda;
+import com.franco.dev.domain.financiero.MovimientoCajaVirtual;
+import com.franco.dev.domain.rrhh.LiquidacionFinal;
+import com.franco.dev.domain.rrhh.Vale;
+import com.franco.dev.domain.rrhh.enums.LiquidacionFinalEstado;
+import com.franco.dev.domain.rrhh.enums.ValeEstado;
+import com.franco.dev.repository.financiero.CajaVirtualRepository;
+import com.franco.dev.repository.financiero.CajaVirtualSaldoRepository;
+import com.franco.dev.repository.financiero.MonedaRepository;
+import com.franco.dev.repository.financiero.MovimientoCajaVirtualRepository;
+import com.franco.dev.repository.financiero.PagoSolicitudDetalleRepository;
+import com.franco.dev.repository.financiero.VentaCreditoRepository;
+import com.franco.dev.repository.rrhh.*;
+import com.franco.dev.service.financiero.CajaVirtualService;
+import com.franco.dev.service.financiero.MonedaService;
+import com.franco.dev.service.financiero.MovimientoCajaVirtualService;
+import com.franco.dev.service.financiero.TesoreriaSecurityService;
+import com.franco.dev.service.financiero.TesoreriaService;
+import com.franco.dev.service.personas.ClienteService;
+import com.franco.dev.service.personas.FuncionarioService;
+import com.franco.dev.service.personas.UsuarioService;
+import graphql.GraphQLException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Contra-asientos de los otros dos modulos de RRHH que mueven la Caja Mayor: finiquito y
+ * vale. Los tres armaban el AJUSTE de anulacion a mano copiando el monto sin negarlo, que
+ * solo revierte de casualidad cuando el monto es positivo.
+ *
+ * <p>Igual que {@link LiquidacionSueldoNetoNegativoTest}, usa la tesoreria REAL para poder
+ * asertar sobre el saldo y no sobre un mock de la fachada.</p>
+ */
+class ContraAsientoRrhhTest {
+
+    private static final Long CAJA_ID = 1L;
+    private static final Long MONEDA_ID = 10L;
+    private static final BigDecimal SALDO_INICIAL = new BigDecimal("5000000");
+
+    private CajaVirtual caja;
+    private Moneda gs;
+    private CajaVirtualSaldo saldo;
+    private MovimientoCajaVirtualService movimientoCajaVirtualService;
+    private CajaVirtualService cajaVirtualService;
+
+    private LiquidacionFinalRepository finiquitoRepository;
+    private LiquidacionFinalService finiquitoService;
+    private ValeRepository valeRepository;
+    private ValeService valeService;
+
+    @BeforeEach
+    void setUp() {
+        caja = new CajaVirtual();
+        caja.setId(CAJA_ID);
+        caja.setPermiteSaldoNegativo(false);
+
+        gs = new Moneda();
+        gs.setId(MONEDA_ID);
+        gs.setDenominacion("GUARANIES");
+
+        saldo = new CajaVirtualSaldo();
+        saldo.setCajaVirtual(caja);
+        saldo.setMoneda(gs);
+        saldo.setSaldo(SALDO_INICIAL);
+
+        CajaVirtualSaldoRepository saldoRepository = mock(CajaVirtualSaldoRepository.class);
+        CajaVirtualRepository cajaVirtualRepository = mock(CajaVirtualRepository.class);
+        MovimientoCajaVirtualRepository movimientoRepository = mock(MovimientoCajaVirtualRepository.class);
+        com.franco.dev.repository.empresarial.ConfiguracionGeneralRepository configRepository =
+                mock(com.franco.dev.repository.empresarial.ConfiguracionGeneralRepository.class);
+        when(configRepository.findAll()).thenReturn(Collections.emptyList());
+
+        when(cajaVirtualRepository.findById(CAJA_ID)).thenReturn(Optional.of(caja));
+        when(cajaVirtualRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+        when(saldoRepository.lockByCajaVirtualIdAndMonedaId(CAJA_ID, MONEDA_ID)).thenReturn(Optional.of(saldo));
+        when(saldoRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+        AtomicLong secuencia = new AtomicLong(100L);
+        when(movimientoRepository.save(any())).thenAnswer(i -> {
+            MovimientoCajaVirtual m = i.getArgument(0);
+            if (m.getId() == null) m.setId(secuencia.incrementAndGet());
+            when(movimientoRepository.findById(m.getId())).thenReturn(Optional.of(m));
+            return m;
+        });
+
+        TesoreriaService tesoreria = new TesoreriaService(saldoRepository, mock(TesoreriaSecurityService.class),
+                cajaVirtualRepository, mock(MonedaRepository.class), movimientoRepository, configRepository);
+        movimientoCajaVirtualService = new MovimientoCajaVirtualService(movimientoRepository, tesoreria);
+
+        cajaVirtualService = mock(CajaVirtualService.class);
+        when(cajaVirtualService.findById(CAJA_ID)).thenReturn(Optional.of(caja));
+
+        finiquitoRepository = mock(LiquidacionFinalRepository.class);
+        when(finiquitoRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+        finiquitoService = new LiquidacionFinalService(
+                finiquitoRepository,
+                mock(PagoSolicitudDetalleRepository.class),
+                mock(LiquidacionFinalItemRepository.class),
+                mock(FuncionarioService.class),
+                mock(LiquidacionSueldoRepository.class),
+                mock(VacacionRepository.class),
+                mock(ConfiguracionRrhhService.class),
+                cajaVirtualService,
+                movimientoCajaVirtualService,
+                mock(MonedaService.class),
+                mock(UsuarioService.class),
+                mock(ValeRepository.class),
+                mock(PrestamoRepository.class),
+                mock(PrestamoCuotaRepository.class),
+                mock(ClienteService.class),
+                mock(VentaCreditoRepository.class),
+                mock(PenalizacionRepository.class),
+                mock(CreditoConvenioService.class),
+                mock(AguinaldoRepository.class),
+                mock(BaseRemunerativaService.class));
+
+        valeRepository = mock(ValeRepository.class);
+        when(valeRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+        valeService = new ValeService(
+                valeRepository,
+                cajaVirtualService,
+                movimientoCajaVirtualService,
+                mock(UsuarioService.class),
+                mock(PagoSolicitudDetalleRepository.class));
+    }
+
+    // ─────────────────────────────── finiquito ───────────────────────────────
+
+    /** Un finiquito cuyo total da negativo no se paga: el funcionario le debe a la empresa. */
+    @Test
+    void noSePuedePagarUnFiniquitoConTotalNegativo() {
+        LiquidacionFinal lf = finiquito(new BigDecimal("-800000"), LiquidacionFinalEstado.APROBADA);
+
+        GraphQLException e = assertThrows(GraphQLException.class, () -> finiquitoService.pagar(77L, CAJA_ID));
+        assertTrue(e.getMessage().toLowerCase().contains("negativo"),
+                "el mensaje tiene que explicar por que no se paga, dijo: " + e.getMessage());
+        assertEquals(0, SALDO_INICIAL.compareTo(saldo.getSaldo()),
+                "no tenia que moverse plata, la caja quedo en " + saldo.getSaldo());
+        assertEquals(LiquidacionFinalEstado.APROBADA, lf.getEstado());
+    }
+
+    /** Finiquito ya pagado con total negativo (dato viejo): anularlo devuelve la plata. */
+    @Test
+    void anularUnFiniquitoConTotalNegativoDevuelveLaPlataALaCaja() {
+        LiquidacionFinal lf = finiquito(new BigDecimal("-800000"), LiquidacionFinalEstado.PAGADA);
+        MovimientoCajaVirtual pago = posteaEgreso(lf.getTotalLiquidado(),
+                com.franco.dev.domain.financiero.enums.OrigenMovimientoTipo.RRHH_LIQUIDACION_FINAL, lf.getId());
+        lf.setCajaVirtualId(CAJA_ID);
+        lf.setMovimientoCajaVirtualId(pago.getId());
+
+        finiquitoService.anular(77L);
+
+        assertEquals(0, SALDO_INICIAL.compareTo(saldo.getSaldo()),
+                "la anulacion tenia que dejar la caja en " + SALDO_INICIAL + ", quedo en " + saldo.getSaldo());
+        assertFalse(Boolean.TRUE.equals(pago.getActivo()),
+                "el movimiento original tenia que quedar inactivo");
+    }
+
+    /** El finiquito normal se sigue anulando sin dejar rastro en el saldo. */
+    @Test
+    void anularUnFiniquitoNormalSigueDevolviendoLaPlata() {
+        LiquidacionFinal lf = finiquito(new BigDecimal("2000000"), LiquidacionFinalEstado.PAGADA);
+        MovimientoCajaVirtual pago = posteaEgreso(lf.getTotalLiquidado(),
+                com.franco.dev.domain.financiero.enums.OrigenMovimientoTipo.RRHH_LIQUIDACION_FINAL, lf.getId());
+        lf.setCajaVirtualId(CAJA_ID);
+        lf.setMovimientoCajaVirtualId(pago.getId());
+        assertEquals(0, new BigDecimal("3000000").compareTo(saldo.getSaldo()));
+
+        finiquitoService.anular(77L);
+
+        assertEquals(0, SALDO_INICIAL.compareTo(saldo.getSaldo()),
+                "la caja quedo en " + saldo.getSaldo());
+    }
+
+    // ───────────────────────────────── vale ──────────────────────────────────
+
+    /** Anular un vale confirmado devuelve a la caja exactamente lo que salio. */
+    @Test
+    void anularUnValeDevuelveLaPlataALaCaja() {
+        Vale vale = new Vale();
+        vale.setId(31L);
+        vale.setEstado(ValeEstado.CONFIRMADO);
+        vale.setMonto(new BigDecimal("300000"));
+        vale.setMoneda(gs);
+        when(valeRepository.findById(31L)).thenReturn(Optional.of(vale));
+
+        MovimientoCajaVirtual pago = posteaEgreso(vale.getMonto(),
+                com.franco.dev.domain.financiero.enums.OrigenMovimientoTipo.RRHH_VALE, vale.getId());
+        vale.setCajaVirtualId(CAJA_ID);
+        vale.setMovimientoCajaVirtualId(pago.getId());
+        assertEquals(0, new BigDecimal("4700000").compareTo(saldo.getSaldo()));
+
+        valeService.anular(31L);
+
+        assertEquals(0, SALDO_INICIAL.compareTo(saldo.getSaldo()),
+                "la caja quedo en " + saldo.getSaldo());
+        assertEquals(ValeEstado.ANULADO, vale.getEstado());
+        assertFalse(Boolean.TRUE.equals(pago.getActivo()),
+                "el movimiento original tenia que quedar inactivo");
+    }
+
+    // ──────────────────────────────── helpers ────────────────────────────────
+
+    private LiquidacionFinal finiquito(BigDecimal total, LiquidacionFinalEstado estado) {
+        LiquidacionFinal lf = new LiquidacionFinal();
+        lf.setId(77L);
+        lf.setEstado(estado);
+        lf.setTotalLiquidado(total);
+        lf.setMoneda(gs);
+        when(finiquitoRepository.findById(77L)).thenReturn(Optional.of(lf));
+        return lf;
+    }
+
+    /** Postea el egreso del pago por el mismo camino que usan los servicios. */
+    private MovimientoCajaVirtual posteaEgreso(BigDecimal monto,
+                                               com.franco.dev.domain.financiero.enums.OrigenMovimientoTipo origen,
+                                               Long origenId) {
+        MovimientoCajaVirtual mov = new MovimientoCajaVirtual();
+        mov.setCajaVirtual(caja);
+        mov.setTipoMovimiento(com.franco.dev.domain.financiero.enums.CajaVirtualTipoMovimiento.EGRESO);
+        mov.setCantidad(monto.doubleValue());
+        mov.setMoneda(gs);
+        mov.setReferenciaId(origenId);
+        mov.setOrigenTipo(origen);
+        mov.setOrigenId(origenId);
+        mov.setActivo(true);
+        return movimientoCajaVirtualService.registrarMovimiento(mov);
+    }
+}

--- a/src/test/java/com/franco/dev/service/rrhh/LiquidacionSueldoNetoNegativoTest.java
+++ b/src/test/java/com/franco/dev/service/rrhh/LiquidacionSueldoNetoNegativoTest.java
@@ -1,0 +1,227 @@
+package com.franco.dev.service.rrhh;
+
+import com.franco.dev.domain.financiero.CajaVirtual;
+import com.franco.dev.domain.financiero.CajaVirtualSaldo;
+import com.franco.dev.domain.financiero.Moneda;
+import com.franco.dev.domain.financiero.MovimientoCajaVirtual;
+import com.franco.dev.domain.financiero.enums.CajaVirtualTipoMovimiento;
+import com.franco.dev.domain.financiero.enums.OrigenMovimientoTipo;
+import com.franco.dev.domain.rrhh.LiquidacionSueldo;
+import com.franco.dev.domain.rrhh.enums.LiquidacionSueldoEstado;
+import com.franco.dev.repository.financiero.CajaVirtualRepository;
+import com.franco.dev.repository.financiero.CajaVirtualSaldoRepository;
+import com.franco.dev.repository.financiero.MonedaRepository;
+import com.franco.dev.repository.financiero.MovimientoCajaVirtualRepository;
+import com.franco.dev.repository.rrhh.*;
+import com.franco.dev.service.administrativo.JornadaService;
+import com.franco.dev.service.financiero.CajaVirtualService;
+import com.franco.dev.service.financiero.MonedaService;
+import com.franco.dev.service.financiero.MovimientoCajaVirtualService;
+import com.franco.dev.service.financiero.TesoreriaSecurityService;
+import com.franco.dev.service.financiero.TesoreriaService;
+import com.franco.dev.service.personas.FuncionarioService;
+import com.franco.dev.service.personas.UsuarioService;
+import graphql.GraphQLException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Liquidacion con neto negativo: el funcionario le debe a la empresa (descuentos &gt;
+ * haberes), asi que no hay nada que pagarle.
+ *
+ * <p>Usa el {@link TesoreriaService} REAL (solo con los repositorios mockeados) en vez de
+ * un mock de {@link MovimientoCajaVirtualService}, porque lo que hay que probar es el
+ * efecto sobre el saldo de la caja, no que se haya llamado a tal metodo. Con un mock de la
+ * fachada el test asertaria sobre el mock y pasaria igual con el contra-asiento mal
+ * firmado, que es justamente el bug.</p>
+ */
+class LiquidacionSueldoNetoNegativoTest {
+
+    private static final Long CAJA_ID = 1L;
+    private static final Long MONEDA_ID = 10L;
+    private static final BigDecimal SALDO_INICIAL = new BigDecimal("5000000");
+
+    private LiquidacionSueldoRepository repository;
+    private LiquidacionItemRepository itemRepository;
+    private LiquidacionSueldoService service;
+    private MovimientoCajaVirtualService movimientoCajaVirtualService;
+
+    private CajaVirtual caja;
+    private Moneda gs;
+    private CajaVirtualSaldo saldo;
+    private LiquidacionSueldo liq;
+
+    @BeforeEach
+    void setUp() {
+        caja = new CajaVirtual();
+        caja.setId(CAJA_ID);
+        caja.setPermiteSaldoNegativo(false);
+
+        gs = new Moneda();
+        gs.setId(MONEDA_ID);
+        gs.setDenominacion("GUARANIES");
+
+        saldo = new CajaVirtualSaldo();
+        saldo.setCajaVirtual(caja);
+        saldo.setMoneda(gs);
+        saldo.setSaldo(SALDO_INICIAL);
+
+        // --- Tesoreria real, repositorios mockeados ---
+        CajaVirtualSaldoRepository saldoRepository = mock(CajaVirtualSaldoRepository.class);
+        CajaVirtualRepository cajaVirtualRepository = mock(CajaVirtualRepository.class);
+        MonedaRepository monedaRepository = mock(MonedaRepository.class);
+        MovimientoCajaVirtualRepository movimientoRepository = mock(MovimientoCajaVirtualRepository.class);
+        com.franco.dev.repository.empresarial.ConfiguracionGeneralRepository configRepository =
+                mock(com.franco.dev.repository.empresarial.ConfiguracionGeneralRepository.class);
+        when(configRepository.findAll()).thenReturn(Collections.emptyList());
+
+        when(cajaVirtualRepository.findById(CAJA_ID)).thenReturn(Optional.of(caja));
+        when(cajaVirtualRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+        when(saldoRepository.lockByCajaVirtualIdAndMonedaId(CAJA_ID, MONEDA_ID)).thenReturn(Optional.of(saldo));
+        when(saldoRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+        // Los movimientos posteados quedan recuperables por id: la anulacion busca el original.
+        AtomicLong secuencia = new AtomicLong(100L);
+        when(movimientoRepository.save(any())).thenAnswer(i -> {
+            MovimientoCajaVirtual m = i.getArgument(0);
+            if (m.getId() == null) m.setId(secuencia.incrementAndGet());
+            when(movimientoRepository.findById(m.getId())).thenReturn(Optional.of(m));
+            return m;
+        });
+
+        TesoreriaService tesoreria = new TesoreriaService(saldoRepository, mock(TesoreriaSecurityService.class),
+                cajaVirtualRepository, monedaRepository, movimientoRepository, configRepository);
+        movimientoCajaVirtualService =
+                new MovimientoCajaVirtualService(movimientoRepository, tesoreria);
+
+        CajaVirtualService cajaVirtualService = mock(CajaVirtualService.class);
+        when(cajaVirtualService.findById(CAJA_ID)).thenReturn(Optional.of(caja));
+
+        repository = mock(LiquidacionSueldoRepository.class);
+        when(repository.save(any())).thenAnswer(i -> i.getArgument(0));
+        itemRepository = mock(LiquidacionItemRepository.class);
+        when(itemRepository.findByLiquidacionIdOrderByIdAsc(any())).thenReturn(Collections.emptyList());
+
+        service = new LiquidacionSueldoService(
+                repository,
+                itemRepository,
+                mock(FuncionarioService.class),
+                mock(MonedaService.class),
+                mock(ConfiguracionRrhhService.class),
+                mock(HoraExtraRepository.class),
+                mock(PenalizacionRepository.class),
+                mock(JustificativoRepository.class),
+                mock(ValeRepository.class),
+                mock(BonoRepository.class),
+                mock(AguinaldoRepository.class),
+                mock(VacacionRepository.class),
+                mock(VacacionVentaRepository.class),
+                mock(PrestamoRepository.class),
+                mock(PrestamoCuotaRepository.class),
+                cajaVirtualService,
+                movimientoCajaVirtualService,
+                mock(UsuarioService.class),
+                mock(com.franco.dev.repository.financiero.PagoSolicitudDetalleRepository.class),
+                mock(JornadaService.class),
+                mock(CreditoConvenioService.class),
+                mock(LiquidacionConceptoService.class),
+                mock(PlatformTransactionManager.class),
+                mock(javax.persistence.EntityManager.class));
+
+        liq = new LiquidacionSueldo();
+        liq.setId(486L);
+        liq.setPeriodo("2026-09");
+        liq.setMoneda(gs);
+        liq.setEstado(LiquidacionSueldoEstado.APROBADA);
+        liq.setTotalHaberes(new BigDecimal("8"));
+        liq.setTotalDescuentos(new BigDecimal("1000008"));
+        liq.setTotalNeto(new BigDecimal("-1000000"));
+        when(repository.findById(486L)).thenReturn(Optional.of(liq));
+    }
+
+    /**
+     * Un neto negativo significa que el funcionario le debe a la empresa. Pagarlo saca esa
+     * plata de la caja al reves: el egreso se postea con la cantidad negada y termina
+     * descontando lo que en realidad habria que cobrar.
+     */
+    @Test
+    void noSePuedePagarUnaLiquidacionConNetoNegativo() {
+        GraphQLException e = assertThrows(GraphQLException.class,
+                () -> service.pagar(486L, CAJA_ID));
+        assertTrue(e.getMessage().toLowerCase().contains("neto negativo"),
+                "el mensaje tiene que explicar por que no se paga, dijo: " + e.getMessage());
+        assertEquals(0, SALDO_INICIAL.compareTo(saldo.getSaldo()),
+                "no tenia que moverse plata, la caja quedo en " + saldo.getSaldo());
+        assertEquals(LiquidacionSueldoEstado.APROBADA, liq.getEstado(),
+                "la liquidacion no tenia que quedar pagada");
+    }
+
+    /**
+     * El caso que se escapo a produccion: liquidaciones con neto negativo que ya se pagaron
+     * antes de la validacion. Anularlas tiene que devolver la plata, no volver a sacarla.
+     */
+    @Test
+    void anularUnPagoConNetoNegativoDevuelveLaPlataALaCaja() {
+        MovimientoCajaVirtual pago = pagoYaPosteado();
+        BigDecimal saldoTrasPago = saldo.getSaldo();
+
+        service.anular(486L);
+
+        assertEquals(0, SALDO_INICIAL.compareTo(saldo.getSaldo()),
+                "la anulacion tenia que dejar la caja como antes del pago (" + SALDO_INICIAL
+                        + "), quedo en " + saldo.getSaldo() + " partiendo de " + saldoTrasPago);
+        assertEquals(LiquidacionSueldoEstado.ANULADA, liq.getEstado());
+        assertFalse(Boolean.TRUE.equals(pago.getActivo()),
+                "el movimiento original tenia que quedar inactivo para que la UI lo tache");
+    }
+
+    /** Una liquidacion normal se sigue pagando y anulando sin dejar rastro en el saldo. */
+    @Test
+    void anularUnPagoConNetoPositivoSigueDevolviendoLaPlata() {
+        liq.setTotalHaberes(new BigDecimal("1500000"));
+        liq.setTotalDescuentos(BigDecimal.ZERO);
+        liq.setTotalNeto(new BigDecimal("1500000"));
+
+        service.pagar(486L, CAJA_ID);
+        assertEquals(0, new BigDecimal("3500000").compareTo(saldo.getSaldo()),
+                "el pago tenia que sacar 1.500.000, la caja quedo en " + saldo.getSaldo());
+
+        service.anular(486L);
+        assertEquals(0, SALDO_INICIAL.compareTo(saldo.getSaldo()),
+                "la anulacion tenia que devolver los 1.500.000, la caja quedo en " + saldo.getSaldo());
+    }
+
+    /**
+     * Deja la liquidacion como la dejaba el pago antes de la validacion: PAGADA, con el
+     * egreso de neto negativo ya posteado en la caja. Postea por el mismo camino que usaba
+     * {@code pagar()} para que el saldo quede exactamente igual que en produccion.
+     */
+    private MovimientoCajaVirtual pagoYaPosteado() {
+        MovimientoCajaVirtual mov = new MovimientoCajaVirtual();
+        mov.setCajaVirtual(caja);
+        mov.setTipoMovimiento(CajaVirtualTipoMovimiento.EGRESO);
+        mov.setCantidad(liq.getTotalNeto().doubleValue());
+        mov.setMoneda(gs);
+        mov.setReferenciaId(liq.getId());
+        mov.setOrigenTipo(OrigenMovimientoTipo.RRHH_LIQUIDACION_SUELDO);
+        mov.setOrigenId(liq.getId());
+        mov.setDescripcion("PAGO SALARIO " + liq.getPeriodo() + " - LIQ #" + liq.getId());
+        mov.setActivo(true);
+        MovimientoCajaVirtual posteado = movimientoCajaVirtualService.registrarMovimiento(mov);
+
+        liq.setEstado(LiquidacionSueldoEstado.PAGADA);
+        liq.setCajaVirtualId(CAJA_ID);
+        liq.setMovimientoCajaVirtualId(posteado.getId());
+        return posteado;
+    }
+}


### PR DESCRIPTION
## Qué resuelve

Los tres módulos de RRHH que mueven la Caja Mayor (liquidación de sueldo, finiquito y vale) armaban el contra-asiento de anulación **a mano**, copiando el monto en un `AJUSTE` sin negarlo. Se ve simétrico pero no lo es: el `EGRESO` entra por `abs().negate()` y el `AJUSTE` **conserva el signo**, así que la reversa sólo funcionaba de casualidad cuando el monto era positivo.

Caso reportado — liquidación con neto **-1.000.000** (descuentos > haberes, un `FALTANTE DE CAJA` manual):

| # | Movimiento | Cantidad | Saldo |
|---|---|---|---|
| 4 | EGRESO `PAGO SALARIO - LIQ #486` | **-1.000.000** | 4.900.000 |
| 5 | AJUSTE `ANULACION LIQUIDACION #486` | **-1.000.000** | **3.900.000** |

Se evaporaron 2.000.000: el pago sacó de la caja la plata que en realidad había que **cobrar**, y la anulación la volvió a sacar en vez de devolverla.

Son dos defectos:

1. **`pagar()` no validaba el signo.** Un neto negativo significa que el funcionario le debe a la empresa: no hay nada que pagarle.
2. **`anular()` no negaba el contra-asiento.**

## Cambios

- **`MovimientoCajaVirtualService`** — nueva fachada `revertirMovimiento(id, motivo, usuario)` hacia `TesoreriaService.revertir()`, que recalcula el efecto del movimiento original, lo niega y marca el original como inactivo. Es el mismo camino que ya usaban `OperacionFinancieraService` y `PagoProveedorService`.
- **`LiquidacionSueldoService`** — `pagar()` rechaza neto < 0 con mensaje explicativo; `anular()` usa `revertirMovimiento`.
- **`LiquidacionFinalService`** — ídem para finiquitos (`totalLiquidado`).
- **`ValeService`** — la reversa del vale pasa por el mismo lugar.

Efecto lateral que se corrige de paso: el movimiento original ahora queda `activo = false` con el contra-asiento apuntándole (`referencia_id`, `origen_tipo = ANULACION`). Antes el pago quedaba activo y sin trazabilidad.

## Cómo probarlo

Tests nuevos (escritos primero, vistos fallar por el motivo correcto — reproducen `5.000.000 → 4.000.000 → 3.000.000`):

- `LiquidacionSueldoNetoNegativoTest`
- `ContraAsientoRrhhTest`

Ambos usan el `TesoreriaService` **real** (sólo repositorios mockeados) para asertar sobre el saldo de la caja y no sobre un mock de la fachada — con un mock el test pasaría igual con el contra-asiento mal firmado.

```
./mvnw clean verify -B -DskipFlyway=true
```
→ **559 tests, 0 fallas**, BUILD SUCCESS.

Verificado además en la app corriendo: liquidación con neto +100.000 → pago 3.900.000 → 3.800.000; anulación → **3.900.000**, con el original tachado.

## Impacto en DB

Ninguno. No hay migración.

Los datos ya pagados con monto negativo se anulan bien con este cambio: la validación nueva corta el ingreso del caso, y la reversa corregida limpia lo que quedó.

## Impacto en rollback

Ninguno: sin cambio de esquema, el JAR anterior funciona contra la misma DB.

## Riesgo

**Bajo.** El camino feliz (neto positivo) queda idéntico y está cubierto por test de regresión. Lo único que cambia de comportamiento observable es que un pago con neto negativo ahora falla con mensaje claro en vez de descuadrar la caja.

## Cross-repo

Va con el PR del desktop (`frc-sistemas-integrados-angular`, misma rama `fix/rrhh-anulacion-neto-negativo`), que deshabilita el botón Pagar cuando el neto es negativo. Son independientes: este PR corta por backend igual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pzdw2BNooFrHGTd8UWictB