### PR TITLE
feat(solicitud-pago): cancelar desde compras, devolver desde tesorería y estado DEVUELTO

### DIFF
--- a/src/main/java/com/franco/dev/domain/operaciones/enums/SolicitudPagoEstado.java
+++ b/src/main/java/com/franco/dev/domain/operaciones/enums/SolicitudPagoEstado.java
@@ -6,6 +6,7 @@ import java.util.List;
 public enum SolicitudPagoEstado {
     PENDIENTE,  // Borrador: creada pero aún no finalizada/validada. NO pagable.
     SOLICITADO, // Validada y lista para pagar. Es lo que ven los diálogos de pago.
+    DEVUELTO,   // Tesorería la devolvió a compras con un motivo. NO pagable: compras la corrige y la reenvía, o la cancela.
     PARCIAL,    // When a partial payment has been made
     CONCLUIDO,  // When the payment has been completed (pagada)
     CANCELADO;  // When the payment has been cancelled

--- a/src/main/java/com/franco/dev/graphql/operaciones/SolicitudPagoGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/SolicitudPagoGraphQL.java
@@ -296,6 +296,11 @@ public class SolicitudPagoGraphQL implements GraphQLQueryResolver, GraphQLMutati
             throw errorParaMostrar(new IllegalStateException("Los pagos se registran desde la caja mayor"
                     + " (Pagar Compras): una solicitud no se marca como pagada a mano."));
         }
+        // DEVUELTO pide motivo y rol de tesorería: solo entra por devolverSolicitudPago.
+        if (estado == SolicitudPagoEstado.DEVUELTO) {
+            throw errorParaMostrar(new IllegalStateException(
+                    "Para devolver una solicitud a compras usá \"Devolver a compras\" en Pagar Compras."));
+        }
         try {
             return solicitudPagoService.actualizarEstado(id, estado);
         } catch (Exception e) {

--- a/src/main/java/com/franco/dev/graphql/operaciones/SolicitudPagoGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/SolicitudPagoGraphQL.java
@@ -290,6 +290,12 @@ public class SolicitudPagoGraphQL implements GraphQLQueryResolver, GraphQLMutati
      * Update estado of solicitud pago
      */
     public SolicitudPago actualizarEstadoSolicitudPago(Long id, SolicitudPagoEstado estado) {
+        // PARCIAL / CONCLUIDO los fija el pago de la caja mayor (PagoProveedorService, que llama al
+        // servicio directo). Marcarlos a mano dejaba las notas pagadas sin que saliera plata.
+        if (estado == SolicitudPagoEstado.PARCIAL || estado == SolicitudPagoEstado.CONCLUIDO) {
+            throw errorParaMostrar(new IllegalStateException("Los pagos se registran desde la caja mayor"
+                    + " (Pagar Compras): una solicitud no se marca como pagada a mano."));
+        }
         try {
             return solicitudPagoService.actualizarEstado(id, estado);
         } catch (Exception e) {

--- a/src/main/java/com/franco/dev/graphql/operaciones/SolicitudPagoGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/operaciones/SolicitudPagoGraphQL.java
@@ -13,6 +13,7 @@ import com.franco.dev.domain.personas.Proveedor;
 import com.franco.dev.domain.personas.Usuario;
 import com.franco.dev.service.financiero.FormaPagoService;
 import com.franco.dev.service.financiero.MonedaService;
+import com.franco.dev.service.financiero.TesoreriaSecurityService;
 import com.franco.dev.service.operaciones.SolicitudPagoDetalleService;
 import com.franco.dev.service.operaciones.SolicitudPagoNotaRecepcionService;
 import com.franco.dev.service.operaciones.SolicitudPagoService;
@@ -69,6 +70,9 @@ public class SolicitudPagoGraphQL implements GraphQLQueryResolver, GraphQLMutati
 
     @Autowired
     private SolicitudPagoDetalleService solicitudPagoDetalleService;
+
+    @Autowired
+    private TesoreriaSecurityService tesoreriaSecurityService;
 
     // ========== QUERIES ==========
 
@@ -291,6 +295,37 @@ public class SolicitudPagoGraphQL implements GraphQLQueryResolver, GraphQLMutati
         } catch (Exception e) {
             throw new RuntimeException("Error al actualizar estado de solicitud de pago: " + e.getMessage(), e);
         }
+    }
+
+    /**
+     * Compras cancela su solicitud, con motivo. Las reglas (sin pagos, solo compras) viven en
+     * {@link SolicitudPagoService#cancelar}. No exige rol: compras no tiene uno propio y su
+     * pantalla tampoco lo pide.
+     */
+    public SolicitudPago cancelarSolicitudPago(Long id, String motivo) {
+        try {
+            return solicitudPagoService.cancelar(id, motivo, tesoreriaSecurityService.currentUsuario());
+        } catch (IllegalStateException | IllegalArgumentException e) {
+            throw errorParaMostrar(e);
+        }
+    }
+
+    /** Tesorería devuelve a compras una solicitud que no va a pagar (SOLICITADO → PENDIENTE), con motivo. */
+    public SolicitudPago devolverSolicitudPago(Long id, String motivo) {
+        tesoreriaSecurityService.requirePagarCpp();
+        try {
+            return solicitudPagoService.devolverACompras(id, motivo, tesoreriaSecurityService.currentUsuario());
+        } catch (IllegalStateException | IllegalArgumentException e) {
+            throw errorParaMostrar(e);
+        }
+    }
+
+    /**
+     * Error de negocio listo para mostrar: GraphqlExceptionHandler desanida los GraphQLError, así
+     * que el mensaje llega al cliente sin el prefijo "Exception while fetching data".
+     */
+    private static graphql.GraphqlErrorException errorParaMostrar(RuntimeException e) {
+        return graphql.GraphqlErrorException.newErrorException().message(e.getMessage()).build();
     }
 
     /**

--- a/src/main/java/com/franco/dev/service/operaciones/SolicitudPagoService.java
+++ b/src/main/java/com/franco/dev/service/operaciones/SolicitudPagoService.java
@@ -452,8 +452,10 @@ public class SolicitudPagoService extends CrudService<SolicitudPago, SolicitudPa
         SolicitudPago solicitud = findById(solicitudId).orElseThrow(
             () -> new IllegalArgumentException("Solicitud de pago no encontrada: " + solicitudId)
         );
-        if (solicitud.getEstado() != SolicitudPagoEstado.PENDIENTE) {
-            throw new IllegalStateException("Solo se pueden editar solicitudes en estado PENDIENTE");
+        // Una devuelta se corrige antes de reenviarla, igual que un borrador.
+        if (solicitud.getEstado() != SolicitudPagoEstado.PENDIENTE
+                && solicitud.getEstado() != SolicitudPagoEstado.DEVUELTO) {
+            throw new IllegalStateException("Solo se pueden editar solicitudes en borrador (PENDIENTE) o devueltas por tesorería");
         }
         Moneda moneda = monedaRepository.findById(monedaId)
             .orElseThrow(() -> new IllegalArgumentException("Moneda no encontrada"));
@@ -522,8 +524,9 @@ public class SolicitudPagoService extends CrudService<SolicitudPago, SolicitudPa
 
     /**
      * Tesorería devuelve a compras una solicitud que no va a pagar (falta la factura, monto mal
-     * cargado): vuelve a PENDIENTE (borrador), sale del diálogo de pago y compras la corrige o la
-     * cancela. Tesorería no cancela: el que paga no decide qué se debe.
+     * cargado): queda DEVUELTO, sale del diálogo de pago y conserva sus notas. Compras la corrige
+     * y la reenvía (DEVUELTO → SOLICITADO), o la cancela. Tesorería no cancela: el que paga no
+     * decide qué se debe.
      */
     @Transactional
     public SolicitudPago devolverACompras(Long solicitudId, String motivo, Usuario usuario) {
@@ -533,7 +536,7 @@ public class SolicitudPagoService extends CrudService<SolicitudPago, SolicitudPa
             throw new IllegalStateException("Solo se puede devolver a compras una solicitud enviada (SOLICITADO); "
                 + solicitud.getNumeroSolicitud() + " está en " + solicitud.getEstado() + ".");
         }
-        return cambiarEstado(solicitud, SolicitudPagoEstado.PENDIENTE,
+        return cambiarEstado(solicitud, SolicitudPagoEstado.DEVUELTO,
             "DEVUELTA A COMPRAS" + firma(usuario) + ": " + motivoLimpio);
     }
 
@@ -548,9 +551,10 @@ public class SolicitudPagoService extends CrudService<SolicitudPago, SolicitudPa
                 solicitud.getEstado() + " a " + nuevoEstado);
         }
         
-        // Volver atrás desde "solicitada" (cancelar o devolver a borrador) solo vale para compras
-        // y sin plata entregada.
-        if (nuevoEstado == SolicitudPagoEstado.CANCELADO || nuevoEstado == SolicitudPagoEstado.PENDIENTE) {
+        // Volver atrás desde "solicitada" (cancelar, devolver a compras o reabrir como borrador)
+        // solo vale para compras y sin plata entregada.
+        if (nuevoEstado == SolicitudPagoEstado.CANCELADO || nuevoEstado == SolicitudPagoEstado.PENDIENTE
+                || nuevoEstado == SolicitudPagoEstado.DEVUELTO) {
             exigirSolicitudDeCompra(solicitud);
             exigirSinPagos(solicitud, nuevoEstado);
         }
@@ -579,7 +583,8 @@ public class SolicitudPagoService extends CrudService<SolicitudPago, SolicitudPa
     private boolean isValidStateTransition(SolicitudPagoEstado estadoActual, SolicitudPagoEstado nuevoEstado) {
         // Define valid transitions.
         // PENDIENTE (borrador) → SOLICITADO (solicitar) o CANCELADO.
-        // SOLICITADO (validada) → PENDIENTE (reabrir), o pagos/cancelación.
+        // SOLICITADO (validada) → PENDIENTE (reabrir), DEVUELTO (tesorería la devuelve), o pagos/cancelación.
+        // DEVUELTO → SOLICITADO (compras la corrige y la reenvía) o CANCELADO.
         switch (estadoActual) {
             case PENDIENTE:
                 return nuevoEstado == SolicitudPagoEstado.SOLICITADO ||
@@ -588,8 +593,12 @@ public class SolicitudPagoService extends CrudService<SolicitudPago, SolicitudPa
                        nuevoEstado == SolicitudPagoEstado.CANCELADO;
             case SOLICITADO:
                 return nuevoEstado == SolicitudPagoEstado.PENDIENTE ||
+                       nuevoEstado == SolicitudPagoEstado.DEVUELTO ||
                        nuevoEstado == SolicitudPagoEstado.PARCIAL ||
                        nuevoEstado == SolicitudPagoEstado.CONCLUIDO ||
+                       nuevoEstado == SolicitudPagoEstado.CANCELADO;
+            case DEVUELTO:
+                return nuevoEstado == SolicitudPagoEstado.SOLICITADO ||
                        nuevoEstado == SolicitudPagoEstado.CANCELADO;
             case PARCIAL:
                 return nuevoEstado == SolicitudPagoEstado.CONCLUIDO ||

--- a/src/main/java/com/franco/dev/service/operaciones/SolicitudPagoService.java
+++ b/src/main/java/com/franco/dev/service/operaciones/SolicitudPagoService.java
@@ -8,6 +8,7 @@ import com.franco.dev.domain.operaciones.SolicitudPago;
 import com.franco.dev.domain.operaciones.SolicitudPagoNotaRecepcion;
 import com.franco.dev.domain.operaciones.enums.NotaRecepcionEstado;
 import com.franco.dev.domain.operaciones.enums.SolicitudPagoEstado;
+import com.franco.dev.domain.operaciones.enums.TipoSolicitudPago;
 import com.franco.dev.domain.financiero.Cambio;
 import com.franco.dev.domain.financiero.FormaPago;
 import com.franco.dev.domain.financiero.Moneda;
@@ -503,9 +504,41 @@ public class SolicitudPagoService extends CrudService<SolicitudPago, SolicitudPa
      */
     @Transactional
     public SolicitudPago actualizarEstado(Long solicitudId, SolicitudPagoEstado nuevoEstado) {
-        SolicitudPago solicitud = findById(solicitudId).orElseThrow(
-            () -> new IllegalArgumentException("Solicitud de pago no encontrada: " + solicitudId)
-        );
+        return cambiarEstado(buscarSolicitud(solicitudId), nuevoEstado, null);
+    }
+
+    /**
+     * Compras cancela su solicitud: la deuda ya no corresponde (nota mal cargada, devolución,
+     * factura anulada). Libera las notas para armar otra solicitud. Solo sin pagos registrados:
+     * con plata entregada, cancelar dejaría el egreso de caja sin deuda que lo respalde y las
+     * notas libres para pagarse dos veces; en ese caso primero se anula el pago desde la caja.
+     */
+    @Transactional
+    public SolicitudPago cancelar(Long solicitudId, String motivo, Usuario usuario) {
+        String motivoLimpio = exigirMotivo(motivo, "cancelar");
+        return cambiarEstado(buscarSolicitud(solicitudId), SolicitudPagoEstado.CANCELADO,
+            "CANCELADA" + firma(usuario) + ": " + motivoLimpio);
+    }
+
+    /**
+     * Tesorería devuelve a compras una solicitud que no va a pagar (falta la factura, monto mal
+     * cargado): vuelve a PENDIENTE (borrador), sale del diálogo de pago y compras la corrige o la
+     * cancela. Tesorería no cancela: el que paga no decide qué se debe.
+     */
+    @Transactional
+    public SolicitudPago devolverACompras(Long solicitudId, String motivo, Usuario usuario) {
+        String motivoLimpio = exigirMotivo(motivo, "devolver");
+        SolicitudPago solicitud = buscarSolicitud(solicitudId);
+        if (solicitud.getEstado() != SolicitudPagoEstado.SOLICITADO) {
+            throw new IllegalStateException("Solo se puede devolver a compras una solicitud enviada (SOLICITADO); "
+                + solicitud.getNumeroSolicitud() + " está en " + solicitud.getEstado() + ".");
+        }
+        return cambiarEstado(solicitud, SolicitudPagoEstado.PENDIENTE,
+            "DEVUELTA A COMPRAS" + firma(usuario) + ": " + motivoLimpio);
+    }
+
+    private SolicitudPago cambiarEstado(SolicitudPago solicitud, SolicitudPagoEstado nuevoEstado, String observacion) {
+        Long solicitudId = solicitud.getId();
         if (solicitud.getEstado() == SolicitudPagoEstado.CANCELADO) {
             throw new IllegalStateException("Una solicitud cancelada no puede cambiar de estado");
         }
@@ -515,6 +548,16 @@ public class SolicitudPagoService extends CrudService<SolicitudPago, SolicitudPa
                 solicitud.getEstado() + " a " + nuevoEstado);
         }
         
+        // Volver atrás desde "solicitada" (cancelar o devolver a borrador) solo vale para compras
+        // y sin plata entregada.
+        if (nuevoEstado == SolicitudPagoEstado.CANCELADO || nuevoEstado == SolicitudPagoEstado.PENDIENTE) {
+            exigirSolicitudDeCompra(solicitud);
+            exigirSinPagos(solicitud, nuevoEstado);
+        }
+        if (observacion != null) {
+            agregarObservacion(solicitud, observacion);
+        }
+
         solicitud.setEstado(nuevoEstado);
         
         // If changing to CONCLUIDO, mark notas as paid
@@ -572,16 +615,56 @@ public class SolicitudPagoService extends CrudService<SolicitudPago, SolicitudPa
                 .filter(n -> n != null)
                 .map(n -> "Nº" + (n.getNumero() != null ? n.getNumero() : n.getId()))
                 .collect(Collectors.joining(", "));
-            String observacionCancelado = "CANCELADO - Notas vinculadas al cancelar (liberadas): " + numerosNotas;
-            String obsActual = solicitud.getObservaciones();
-            solicitud.setObservaciones(
-                (obsActual != null && !obsActual.trim().isEmpty())
-                    ? obsActual.trim() + " | " + observacionCancelado
-                    : observacionCancelado
-            );
+            agregarObservacion(solicitud, "CANCELADO - Notas vinculadas al cancelar (liberadas): " + numerosNotas);
         }
         solicitudPagoNotaRecepcionService.eliminarTodasRelaciones(solicitudId);
         solicitud.setMontoTotal(0.0);
+    }
+
+    /** Las solicitudes de gasto y de RRHH se gestionan desde su módulo (pre-gasto, vale, liquidación). */
+    private void exigirSolicitudDeCompra(SolicitudPago solicitud) {
+        TipoSolicitudPago tipo = solicitud.getTipo();
+        if (tipo != null && tipo != TipoSolicitudPago.COMPRA) {
+            throw new IllegalStateException("La solicitud " + solicitud.getNumeroSolicitud() + " es de "
+                + tipo + ": se gestiona desde su propio módulo, no desde compras.");
+        }
+    }
+
+    /**
+     * PARCIAL cuenta como pagada aunque no tenga monto: puede venir de "Marcar como pago parcial",
+     * que registra un pago hecho por fuera del sistema.
+     */
+    private void exigirSinPagos(SolicitudPago solicitud, SolicitudPagoEstado nuevoEstado) {
+        java.math.BigDecimal pagado = solicitud.getMontoPagado();
+        boolean tienePagos = solicitud.getEstado() == SolicitudPagoEstado.PARCIAL
+            || (pagado != null && pagado.signum() > 0);
+        if (tienePagos) {
+            String accion = nuevoEstado == SolicitudPagoEstado.CANCELADO ? "cancelarla" : "devolverla";
+            throw new IllegalStateException("La solicitud " + solicitud.getNumeroSolicitud()
+                + " ya tiene pagos registrados. Primero hay que anular el pago desde la caja mayor"
+                + " (Anular pago a proveedor) y después " + accion + ".");
+        }
+    }
+
+    private String exigirMotivo(String motivo, String accion) {
+        if (motivo == null || motivo.trim().isEmpty()) {
+            throw new IllegalArgumentException("Indicá el motivo para " + accion + " la solicitud.");
+        }
+        return motivo.trim().toUpperCase();
+    }
+
+    private static String firma(Usuario usuario) {
+        return (usuario != null && usuario.getNickname() != null) ? " POR " + usuario.getNickname() : "";
+    }
+
+    private void agregarObservacion(SolicitudPago solicitud, String texto) {
+        String actual = solicitud.getObservaciones();
+        solicitud.setObservaciones((actual != null && !actual.trim().isEmpty()) ? actual.trim() + " | " + texto : texto);
+    }
+
+    private SolicitudPago buscarSolicitud(Long solicitudId) {
+        return findById(solicitudId).orElseThrow(
+            () -> new IllegalArgumentException("Solicitud de pago no encontrada: " + solicitudId));
     }
 
     /**

--- a/src/main/resources/db/migration/V222.3__solicitud_pago_estado_devuelto.sql
+++ b/src/main/resources/db/migration/V222.3__solicitud_pago_estado_devuelto.sql
@@ -1,0 +1,7 @@
+-- Estado DEVUELTO de la solicitud de pago: tesorería no cancela, devuelve a compras la
+-- solicitud que no va a pagar (falta la factura, monto mal cargado). Compras la corrige y
+-- la reenvía (DEVUELTO → SOLICITADO) o la cancela. Conserva sus notas mientras tanto.
+--
+-- Idempotente: ADD VALUE IF NOT EXISTS no falla si el valor ya existe (mismo patrón que
+-- V194.5, que agregó SOLICITADO a este mismo tipo).
+ALTER TYPE operaciones.solicitud_pago_estado ADD VALUE IF NOT EXISTS 'DEVUELTO' AFTER 'SOLICITADO';

--- a/src/main/resources/graphql/operaciones/solicitud-pago.graphqls
+++ b/src/main/resources/graphql/operaciones/solicitud-pago.graphqls
@@ -196,6 +196,7 @@ extend type Mutation {
 enum SolicitudPagoEstado {
     PENDIENTE
     SOLICITADO
+    DEVUELTO
     PARCIAL
     CONCLUIDO
     CANCELADO

--- a/src/main/resources/graphql/operaciones/solicitud-pago.graphqls
+++ b/src/main/resources/graphql/operaciones/solicitud-pago.graphqls
@@ -160,6 +160,12 @@ extend type Mutation {
     
     # Update estado of solicitud pago
     actualizarEstadoSolicitudPago(id: ID!, estado: SolicitudPagoEstado!): SolicitudPago!
+
+    # Compras cancela la solicitud y libera sus notas. Solo sin pagos registrados; el motivo es obligatorio.
+    cancelarSolicitudPago(id: ID!, motivo: String!): SolicitudPago!
+
+    # Tesorería devuelve a compras una solicitud SOLICITADO que no va a pagar (vuelve a PENDIENTE).
+    devolverSolicitudPago(id: ID!, motivo: String!): SolicitudPago!
     
     # Add nota recepcion to solicitud pago
     agregarNotaASolicitudPago(

--- a/src/test/java/com/franco/dev/service/operaciones/SolicitudPagoServiceCancelacionTest.java
+++ b/src/test/java/com/franco/dev/service/operaciones/SolicitudPagoServiceCancelacionTest.java
@@ -1,0 +1,149 @@
+package com.franco.dev.service.operaciones;
+
+import com.franco.dev.domain.operaciones.SolicitudPago;
+import com.franco.dev.domain.operaciones.enums.SolicitudPagoEstado;
+import com.franco.dev.domain.operaciones.enums.TipoSolicitudPago;
+import com.franco.dev.domain.personas.Usuario;
+import com.franco.dev.repository.financiero.FormaPagoRepository;
+import com.franco.dev.repository.financiero.MonedaRepository;
+import com.franco.dev.repository.operaciones.NotaRecepcionRepository;
+import com.franco.dev.repository.operaciones.SolicitudPagoRepository;
+import com.franco.dev.service.financiero.CambioService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+/**
+ * Cancelar (compras) y devolver a compras (tesorería) una solicitud de pago. Quién puede hacer
+ * cada cosa lo decide el resolver; acá se fijan las reglas de plata: con pagos registrados no se
+ * cancela ni se devuelve, primero se anula el pago desde la caja.
+ */
+class SolicitudPagoServiceCancelacionTest {
+
+    private SolicitudPagoRepository repository;
+    private SolicitudPagoNotaRecepcionService notaRecepcionService;
+    private SolicitudPagoService service;
+    private SolicitudPago sp;
+    private Usuario usuario;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(SolicitudPagoRepository.class);
+        notaRecepcionService = mock(SolicitudPagoNotaRecepcionService.class);
+        service = new SolicitudPagoService(repository, notaRecepcionService,
+                mock(NotaRecepcionRepository.class), mock(ProcesoEtapaService.class),
+                mock(RecepcionMercaderiaNotaService.class), mock(RecepcionMercaderiaService.class),
+                mock(MonedaRepository.class), mock(FormaPagoRepository.class), mock(CambioService.class));
+
+        sp = new SolicitudPago();
+        sp.setId(18L);
+        sp.setNumeroSolicitud("SP-000018");
+        sp.setTipo(TipoSolicitudPago.COMPRA);
+        sp.setEstado(SolicitudPagoEstado.SOLICITADO);
+        sp.setMontoTotal(8057655.0);
+        sp.setMontoPagado(BigDecimal.ZERO);
+        when(repository.findById(18L)).thenReturn(Optional.of(sp));
+        when(repository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        usuario = new Usuario();
+        usuario.setNickname("JPEREZ");
+    }
+
+    @Test
+    void cancelarSinPagosLiberaLasNotasYGuardaElMotivo() {
+        SolicitudPago r = service.cancelar(18L, "  nota mal cargada ", usuario);
+
+        assertEquals(SolicitudPagoEstado.CANCELADO, r.getEstado());
+        assertTrue(r.getObservaciones().contains("CANCELADA POR JPEREZ: NOTA MAL CARGADA"), r.getObservaciones());
+        verify(notaRecepcionService).eliminarTodasRelaciones(18L);
+    }
+
+    @Test
+    void cancelarConPagoParcialSeRechazaSinTocarNada() {
+        sp.setEstado(SolicitudPagoEstado.PARCIAL);
+        sp.setMontoPagado(new BigDecimal("3000000"));
+
+        IllegalStateException e = assertThrows(IllegalStateException.class,
+                () -> service.cancelar(18L, "ya no se debe", usuario));
+
+        assertTrue(e.getMessage().contains("anular el pago"), e.getMessage());
+        assertEquals(SolicitudPagoEstado.PARCIAL, sp.getEstado());
+        verify(notaRecepcionService, never()).eliminarTodasRelaciones(anyLong());
+        verify(repository, never()).save(any());
+    }
+
+    /** La mutation genérica de estado (la usan los clientes viejos) pasa por la misma regla. */
+    @Test
+    void laMutationGenericaTampocoCancelaConPagos() {
+        sp.setEstado(SolicitudPagoEstado.PARCIAL);
+        sp.setMontoPagado(new BigDecimal("3000000"));
+
+        assertThrows(IllegalStateException.class,
+                () -> service.actualizarEstado(18L, SolicitudPagoEstado.CANCELADO));
+        verify(notaRecepcionService, never()).eliminarTodasRelaciones(anyLong());
+    }
+
+    /** Un PARCIAL marcado a mano (pagado por fuera del sistema) tampoco se cancela, aunque no tenga monto. */
+    @Test
+    void unParcialSinMontoPagadoTampocoSeCancela() {
+        sp.setEstado(SolicitudPagoEstado.PARCIAL);
+        sp.setMontoPagado(null);
+
+        assertThrows(IllegalStateException.class, () -> service.cancelar(18L, "x", usuario));
+        assertEquals(SolicitudPagoEstado.PARCIAL, sp.getEstado());
+    }
+
+    @Test
+    void cancelarSinMotivoSeRechaza() {
+        assertThrows(IllegalArgumentException.class, () -> service.cancelar(18L, "   ", usuario));
+        assertEquals(SolicitudPagoEstado.SOLICITADO, sp.getEstado());
+    }
+
+    /** Un gasto o un documento de RRHH se gestiona desde su módulo: cancelarlo acá dejaría el origen colgado. */
+    @Test
+    void noSeCancelaUnaSolicitudDeGasto() {
+        sp.setTipo(TipoSolicitudPago.GASTO);
+
+        assertThrows(IllegalStateException.class, () -> service.cancelar(18L, "no va", usuario));
+        assertEquals(SolicitudPagoEstado.SOLICITADO, sp.getEstado());
+    }
+
+    /** Las solicitudes viejas no tienen tipo: son de compra. */
+    @Test
+    void unaSolicitudSinTipoSeTrataComoCompra() {
+        sp.setTipo(null);
+
+        assertEquals(SolicitudPagoEstado.CANCELADO, service.cancelar(18L, "x", usuario).getEstado());
+    }
+
+    @Test
+    void devolverVuelveABorradorConElMotivoYSinLiberarNotas() {
+        SolicitudPago r = service.devolverACompras(18L, "falta la factura", usuario);
+
+        assertEquals(SolicitudPagoEstado.PENDIENTE, r.getEstado());
+        assertTrue(r.getObservaciones().contains("DEVUELTA A COMPRAS POR JPEREZ: FALTA LA FACTURA"), r.getObservaciones());
+        verify(notaRecepcionService, never()).eliminarTodasRelaciones(anyLong());
+    }
+
+    @Test
+    void soloSeDevuelveUnaSolicitudEnviada() {
+        sp.setEstado(SolicitudPagoEstado.PENDIENTE);
+
+        assertThrows(IllegalStateException.class, () -> service.devolverACompras(18L, "x", usuario));
+    }
+
+    @Test
+    void noSeDevuelveConPagosRegistrados() {
+        sp.setMontoPagado(new BigDecimal("100"));
+
+        assertThrows(IllegalStateException.class, () -> service.devolverACompras(18L, "x", usuario));
+        assertEquals(SolicitudPagoEstado.SOLICITADO, sp.getEstado());
+    }
+}

--- a/src/test/java/com/franco/dev/service/operaciones/SolicitudPagoServiceCancelacionTest.java
+++ b/src/test/java/com/franco/dev/service/operaciones/SolicitudPagoServiceCancelacionTest.java
@@ -124,10 +124,10 @@ class SolicitudPagoServiceCancelacionTest {
     }
 
     @Test
-    void devolverVuelveABorradorConElMotivoYSinLiberarNotas() {
+    void devolverLaDejaDevueltaConElMotivoYSinLiberarNotas() {
         SolicitudPago r = service.devolverACompras(18L, "falta la factura", usuario);
 
-        assertEquals(SolicitudPagoEstado.PENDIENTE, r.getEstado());
+        assertEquals(SolicitudPagoEstado.DEVUELTO, r.getEstado());
         assertTrue(r.getObservaciones().contains("DEVUELTA A COMPRAS POR JPEREZ: FALTA LA FACTURA"), r.getObservaciones());
         verify(notaRecepcionService, never()).eliminarTodasRelaciones(anyLong());
     }
@@ -135,8 +135,39 @@ class SolicitudPagoServiceCancelacionTest {
     @Test
     void soloSeDevuelveUnaSolicitudEnviada() {
         sp.setEstado(SolicitudPagoEstado.PENDIENTE);
-
         assertThrows(IllegalStateException.class, () -> service.devolverACompras(18L, "x", usuario));
+
+        sp.setEstado(SolicitudPagoEstado.DEVUELTO);
+        assertThrows(IllegalStateException.class, () -> service.devolverACompras(18L, "x", usuario));
+    }
+
+    /** Compras corrige la devuelta y la reenvía: vuelve a la cola de pagos. */
+    @Test
+    void unaDevueltaSeReenviaATesoreria() {
+        sp.setEstado(SolicitudPagoEstado.DEVUELTO);
+
+        assertEquals(SolicitudPagoEstado.SOLICITADO,
+                service.actualizarEstado(18L, SolicitudPagoEstado.SOLICITADO).getEstado());
+    }
+
+    @Test
+    void unaDevueltaSePuedeCancelarYLiberaSusNotas() {
+        sp.setEstado(SolicitudPagoEstado.DEVUELTO);
+
+        assertEquals(SolicitudPagoEstado.CANCELADO, service.cancelar(18L, "no corresponde", usuario).getEstado());
+        verify(notaRecepcionService).eliminarTodasRelaciones(18L);
+    }
+
+    /** Una devuelta no se paga ni vuelve a borrador: primero se reenvía. */
+    @Test
+    void unaDevueltaSoloSaleReenviadaOCancelada() {
+        sp.setEstado(SolicitudPagoEstado.DEVUELTO);
+
+        assertThrows(IllegalStateException.class,
+                () -> service.actualizarEstado(18L, SolicitudPagoEstado.CONCLUIDO));
+        assertThrows(IllegalStateException.class,
+                () -> service.actualizarEstado(18L, SolicitudPagoEstado.PENDIENTE));
+        assertEquals(SolicitudPagoEstado.DEVUELTO, sp.getEstado());
     }
 
     @Test


### PR DESCRIPTION
## Qué resuelve

Define quién cancela una solicitud de pago: **compras**, que la arma. Tesorería no cancela: **devuelve a compras** la solicitud que no va a pagar, con un motivo.

- `cancelarSolicitudPago(id, motivo)`: libera las notas. El motivo es obligatorio y queda firmado en observaciones (`CANCELADA POR <usuario>: ...`).
- `devolverSolicitudPago(id, motivo)`: exige `TESORERIA CPP PAGAR`. La solicitud queda en el estado nuevo **`DEVUELTO`**, conserva sus notas y sale de Pagar Compras. Compras la corrige y la reenvía (`DEVUELTO → SOLICITADO`) o la cancela. Una devuelta se puede editar, como un borrador.
- Ninguna de las dos acciones se permite con pagos registrados (`PARCIAL` o `montoPagado > 0`): primero se anula el pago desde la caja mayor. **Antes, cancelar un `PARCIAL` liberaba las notas sin revertir la plata ya pagada**, y esas notas podían pagarse otra vez.
- Solo aplica a solicitudes de compra: las de gasto y RRHH se gestionan desde su propio módulo.
- `actualizarEstadoSolicitudPago` ya no acepta `PARCIAL` ni `CONCLUIDO`: marcar una solicitud como pagada a mano dejaba las notas pagadas sin que saliera plata. El pago de la caja mayor no usa esa mutation, así que no le afecta. Tampoco acepta `DEVUELTO`, que entra solo por su mutation.

## Cómo probar

- `./mvnw test -DskipFlyway=true -Dtest='SolicitudPagoServiceCancelacionTest,PagoProveedorServiceTest,SchemaSinCamposDuplicadosTest,SchemaEnumsSincronizadosTest'` → 13 / 12 / 1 / 1 en verde.
- A mano, con el desktop del PR que depende de este:
  1. Caja mayor → Pagar Compras → **Devolver a compras** en una solicitud: pide motivo, la saca de la lista y queda **Devuelta**.
  2. Gestión de compras → reenviarla con **Solicitar**: vuelve a Pagar Compras.
  3. Cancelar una solicitud `SOLICITADO` o `DEVUELTO` desde Gestión de compras: pide motivo y libera las notas.
  4. Intentar cancelar o devolver una con pago parcial: el central responde "ya tiene pagos registrados, primero hay que anular el pago desde la caja mayor".

## Impacto en DB

Migración `V222.3__solicitud_pago_estado_devuelto.sql`:

```sql
ALTER TYPE operaciones.solicitud_pago_estado ADD VALUE IF NOT EXISTS 'DEVUELTO' AFTER 'SOLICITADO';
```

- Es idempotente y solo agrega un valor al enum; es el mismo patrón que `V194.5`.
- Va solo en el central: la filial no tiene la tabla, y `solicitud_pago` no está en la replicación.
- ⚠️ No se corrió contra ninguna base todavía, y el CI no valida migraciones.

## Impacto en rollback

- El JAR anterior no conoce `DEVUELTO`: si ya hay filas en ese estado, fallaría al leerlas.
- Antes de volver atrás: `UPDATE operaciones.solicitud_pago SET estado = 'PENDIENTE' WHERE estado = 'DEVUELTO';`
- El valor queda en el tipo de Postgres (no se puede quitar), pero no molesta.

## Riesgo

**Medio.** Cambian las reglas de transición de estado de la solicitud:
- Los desktops viejos que cancelen por la mutation genérica siguen funcionando, salvo con pagos.
- "Marcar como pagada" a mano deja de funcionar, a propósito.

**Pendiente:** cancelar no exige rol, porque compras no tiene uno propio (hoy su pantalla tampoco lo chequea).

**Se mergea primero:** el PR del desktop y el de la PWA dependen de este.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WmXNteNRH9DxKm7K6Zqp2t
