### PR TITLE
fix(replicacion): repartir ids impares en el central para no cortar la replicacion

### DIFF
--- a/src/main/java/com/franco/dev/graphql/replication/LogicalReplicationGraphQL.java
+++ b/src/main/java/com/franco/dev/graphql/replication/LogicalReplicationGraphQL.java
@@ -7,6 +7,7 @@ import com.franco.dev.graphql.replication.types.ReplicationSetupState;
 import com.franco.dev.graphql.replication.types.ReplicationStatus;
 import com.franco.dev.graphql.replication.RemoveScope;
 import com.franco.dev.graphql.replication.RemoveTarget;
+import com.franco.dev.service.empresarial.AlineacionIdsFilialService;
 import com.franco.dev.service.empresarial.LogicalReplicationService;
 import com.franco.dev.service.empresarial.SucursalService;
 import graphql.kickstart.tools.GraphQLMutationResolver;
@@ -30,9 +31,12 @@ public class LogicalReplicationGraphQL implements GraphQLQueryResolver, GraphQLM
 
     @Autowired
     private LogicalReplicationService replicationService;
-    
+
     @Autowired
     private SucursalService sucursalService;
+
+    @Autowired
+    private AlineacionIdsFilialService alineacionIdsFilialService;
     
     // Paginated Query resolvers
     
@@ -661,6 +665,14 @@ public class LogicalReplicationGraphQL implements GraphQLQueryResolver, GraphQLM
         ReplicationStatus status = new ReplicationStatus();
         status.setSuccess(result.isSuccess());
         status.setMessage(result.getMessage());
+        return status;
+    }
+
+    public ReplicationStatus alinearSecuenciasFiliales() {
+        AlineacionIdsFilialService.Resultado result = alineacionIdsFilialService.alinearTodas();
+        ReplicationStatus status = new ReplicationStatus();
+        status.setSuccess(result.isSuccess());
+        status.setMessage(result.getMensaje());
         return status;
     }
 } 

--- a/src/main/java/com/franco/dev/service/configuracion/InicioSesionService.java
+++ b/src/main/java/com/franco/dev/service/configuracion/InicioSesionService.java
@@ -4,6 +4,7 @@ import com.franco.dev.domain.EmbebedPrimaryKey;
 import com.franco.dev.domain.configuracion.InicioSesion;
 import com.franco.dev.repository.configuracion.InicioSesionRepository;
 import com.franco.dev.service.CrudService;
+import com.franco.dev.utilitarios.IdCentral;
 import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -35,15 +36,21 @@ public class InicioSesionService extends CrudService<InicioSesion, InicioSesionR
     @org.springframework.beans.factory.annotation.Autowired
     private org.springframework.context.ApplicationEventPublisher publisher;
 
+    /**
+     * Una sesion con id par la abrio un filial. Si el central todavia no la tiene,
+     * no puede insertarla con ese id: cuando llegue el INSERT replicado del filial
+     * chocaria con inicio_sesion_pk y cortaria la replicacion entera. Pasa cuando
+     * un cliente conectado al central manda la sesion que el filial le devolvio.
+     */
+    boolean esSesionDeFilialQueElCentralNoTiene(InicioSesion entity) {
+        return IdCentral.esDeFilial(entity.getId())
+                && !repository.existsById(new EmbebedPrimaryKey(entity.getId(), entity.getSucursalId()));
+    }
+
     @Override
     @org.springframework.transaction.annotation.Transactional
     public InicioSesion save(InicioSesion entity) {
-        boolean isNew = entity.getId() == null;
         LocalDateTime now = LocalDateTime.now();
-
-        if (isNew) {
-            entity.setCreadoEn(now);
-        }
 
         if (entity.getSucursalId() == null) {
             if (entity.getSucursal() != null) {
@@ -53,13 +60,19 @@ public class InicioSesionService extends CrudService<InicioSesion, InicioSesionR
             }
         }
 
-        if (entity.getId() == null) {
-            Long lastId = repository.findMaxId(entity.getSucursalId());
-            long newId = (lastId == null ? 0L : lastId) + 1L;
-            if (newId % 2 == 0) {
-                newId++;
+        if (esSesionDeFilialQueElCentralNoTiene(entity)) {
+            if (entity.getHoraFin() != null) {
+                // Cierre de una sesion que el filial abrio y que todavia no llego
+                // por replicacion: aca no hay nada que cerrar.
+                return entity;
             }
-            entity.setId(newId);
+            entity.setId(null);
+        }
+
+        boolean isNew = entity.getId() == null;
+        if (isNew) {
+            entity.setCreadoEn(now);
+            entity.setId(IdCentral.siguienteImpar(repository.findMaxId(entity.getSucursalId())));
         }
 
         cerrarOtrasSesionesActivasDelDispositivo(entity, now);

--- a/src/main/java/com/franco/dev/service/empresarial/AlineacionIdsFilialService.java
+++ b/src/main/java/com/franco/dev/service/empresarial/AlineacionIdsFilialService.java
@@ -1,0 +1,135 @@
+package com.franco.dev.service.empresarial;
+
+import com.franco.dev.domain.empresarial.Sucursal;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Pone la secuencia de ids de cada filial por encima de lo que el central ya tiene.
+ *
+ * El central genera ids impares y los filiales pares (ver IdCentral y la migracion
+ * V223.1). La paridad evita choques con todo lo que se genere de ahora en mas,
+ * pero antes de este esquema el central genero ids pares para filas de sucursales
+ * de filiales: si un filial llegara a generar uno de esos, su INSERT replicado
+ * chocaria igual y cortaria la replicacion. Se corre una vez, despues de desplegar
+ * las migraciones de los dos lados; correrla de nuevo no hace dano.
+ */
+@Service
+public class AlineacionIdsFilialService {
+
+    private static final Logger logger = LoggerFactory.getLogger(AlineacionIdsFilialService.class);
+
+    /**
+     * Tablas que el filial replica al central y en las que el central tambien inserta.
+     */
+    static final List<Tabla> TABLAS = Arrays.asList(
+            new Tabla("configuraciones.inicio_sesion", true),
+            new Tabla("financiero.gasto", true),
+            new Tabla("financiero.venta_tarjeta", true),
+            new Tabla("financiero.maletin", false),
+            new Tabla("financiero.movimiento_personas", false));
+
+    private final JdbcTemplate jdbcTemplate;
+    private final SucursalService sucursalService;
+    private final LogicalReplicationService replicationService;
+
+    public AlineacionIdsFilialService(JdbcTemplate jdbcTemplate, SucursalService sucursalService,
+                                      LogicalReplicationService replicationService) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.sucursalService = sucursalService;
+        this.replicationService = replicationService;
+    }
+
+    /**
+     * Alinea todos los filiales activos. Un filial que no responde o que todavia no
+     * tiene la migracion no frena a los demas: queda anotado con su error.
+     */
+    public Resultado alinearTodas() {
+        List<Sucursal> sucursales = sucursalService.findAllExcludingServer().stream()
+                .filter(s -> Boolean.TRUE.equals(s.getActivo()) && s.getIp() != null && s.getPuerto() != null)
+                .filter(s -> s.getId() != null && s.getId() != 0)
+                .collect(Collectors.toList());
+
+        List<String> lineas = new ArrayList<>();
+        boolean todasOk = true;
+        for (Sucursal s : sucursales) {
+            String nombre = s.getNombre() + " (" + s.getId() + ")";
+            try {
+                lineas.add(nombre + ": " + alinear(s.getId()));
+            } catch (Exception e) {
+                todasOk = false;
+                logger.warn("Alineacion de ids para sucursal {} fallo: {}", s.getId(), e.getMessage());
+                lineas.add(nombre + ": ERROR " + e.getMessage());
+            }
+        }
+        return new Resultado(todasOk, lineas);
+    }
+
+    String alinear(Long sucursalId) {
+        List<String> partes = new ArrayList<>();
+        for (Tabla tabla : TABLAS) {
+            Long mayorPar = mayorIdParDelCentral(tabla, sucursalId);
+            Long proximo = replicationService.queryRemoteForObject(sucursalId,
+                    "SELECT configuraciones.alinear_secuencia_par(?::regclass, ?::regclass, ?)",
+                    Long.class, tabla.secuencia(), tabla.nombre, mayorPar == null ? 0L : mayorPar);
+            partes.add(tabla.nombre + " -> " + proximo);
+        }
+        return String.join(", ", partes);
+    }
+
+    /**
+     * Solo importan los pares: un impar lo genero el central y el filial nunca lo va a generar.
+     */
+    Long mayorIdParDelCentral(Tabla tabla, Long sucursalId) {
+        if (tabla.porSucursal) {
+            return jdbcTemplate.queryForObject(
+                    "SELECT MAX(id) FROM " + tabla.nombre + " WHERE id % 2 = 0 AND sucursal_id = ?",
+                    Long.class, sucursalId);
+        }
+        return jdbcTemplate.queryForObject(
+                "SELECT MAX(id) FROM " + tabla.nombre + " WHERE id % 2 = 0", Long.class);
+    }
+
+    static class Tabla {
+        final String nombre;
+        /**
+         * La clave del central incluye sucursal_id: el mayor par se busca solo
+         * entre las filas de esa sucursal. Si no, el id es unico en toda la tabla.
+         */
+        final boolean porSucursal;
+
+        Tabla(String nombre, boolean porSucursal) {
+            this.nombre = nombre;
+            this.porSucursal = porSucursal;
+        }
+
+        String secuencia() {
+            return nombre + "_id_seq";
+        }
+    }
+
+    public static class Resultado {
+        private final boolean success;
+        private final List<String> lineas;
+
+        Resultado(boolean success, List<String> lineas) {
+            this.success = success;
+            this.lineas = lineas;
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
+
+        public String getMensaje() {
+            return lineas.isEmpty() ? "No hay filiales activos con IP y puerto" : String.join("\n", lineas);
+        }
+    }
+}

--- a/src/main/java/com/franco/dev/service/empresarial/LogicalReplicationService.java
+++ b/src/main/java/com/franco/dev/service/empresarial/LogicalReplicationService.java
@@ -1287,6 +1287,28 @@ public class LogicalReplicationService {
             throw new RuntimeException("Error executing remote command: " + e.getMessage(), e);
         }
     }
+
+    /**
+     * Ejecuta una consulta en la base del filial y devuelve un solo valor. Usa la
+     * misma conexion que executeRemoteReplicationCommand.
+     */
+    public <T> T queryRemoteForObject(Long sucursalId, String sql, Class<T> tipo, Object... args) {
+        Sucursal sucursal = sucursalService.findById(sucursalId)
+            .orElseThrow(() -> new RuntimeException("Sucursal with ID " + sucursalId + " not found"));
+
+        if (sucursal.getIp() == null || sucursal.getPuerto() == null) {
+            throw new RuntimeException("Sucursal is missing IP or port information");
+        }
+
+        JdbcTemplate remoteJdbc = createRemoteJdbcTemplate(
+            sucursal.getIp(),
+            sucursal.getPuerto(),
+            getBranchDbName(),
+            dbUsername,
+            dbPassword
+        );
+        return remoteJdbc.queryForObject(sql, tipo, args);
+    }
     
     /**
      * Toggle a subscription on a remote branch

--- a/src/main/java/com/franco/dev/service/operaciones/DevolucionService.java
+++ b/src/main/java/com/franco/dev/service/operaciones/DevolucionService.java
@@ -28,6 +28,7 @@ import com.franco.dev.domain.personas.Usuario;
 import com.franco.dev.domain.productos.Codigo;
 import com.franco.dev.domain.productos.Presentacion;
 import com.franco.dev.service.productos.CodigoService;
+import com.franco.dev.utilitarios.IdCentral;
 import com.franco.dev.utilitarios.PresentacionUtils;
 import com.franco.dev.repository.financiero.GastoRepository;
 import com.franco.dev.repository.financiero.TipoGastoRepository;
@@ -533,8 +534,8 @@ public class DevolucionService extends CrudService<Devolucion, DevolucionReposit
                 ? config.getTipoGastoMerma() : TIPO_GASTO_MERMA;
 
         Long sucId = d.getSucursalOrigen().getId();
-        Long maxId = gastoRepository.findMaxId(sucId);
-        Long nuevoId = (maxId == null ? 0L : maxId) + 1;
+        // Impar: los pares los genera el filial de esa sucursal (ver IdCentral).
+        Long nuevoId = IdCentral.siguienteImpar(gastoRepository.findMaxId(sucId));
 
         Gasto gasto = new Gasto();
         gasto.setId(nuevoId);

--- a/src/main/java/com/franco/dev/utilitarios/IdCentral.java
+++ b/src/main/java/com/franco/dev/utilitarios/IdCentral.java
@@ -1,0 +1,34 @@
+package com.franco.dev.utilitarios;
+
+/**
+ * Reparto de ids entre el central y los filiales en las tablas que el filial
+ * replica al central: el central genera impares y cada filial genera pares con
+ * su secuencia (INCREMENT BY 2). Como las paridades no se cruzan, un id generado
+ * de un lado nunca choca con uno generado del otro, y la replicacion no se corta
+ * por la clave primaria.
+ *
+ * Es el mismo esquema que ya usan marcacion, movimiento_stock y
+ * movimiento_stock_lote. En la base del central lo refuerza el trigger
+ * rechazar_id_de_filial (migracion V223.1), que rechaza cualquier
+ * INSERT local con id par en todas esas tablas.
+ */
+public final class IdCentral {
+
+    private IdCentral() {
+    }
+
+    /**
+     * Proximo id impar mayor que {@code maximo}.
+     */
+    public static long siguienteImpar(Long maximo) {
+        long siguiente = (maximo == null ? 0L : maximo) + 1L;
+        return siguiente % 2 == 0 ? siguiente + 1 : siguiente;
+    }
+
+    /**
+     * Un id par lo genero un filial.
+     */
+    public static boolean esDeFilial(Long id) {
+        return id != null && id % 2 == 0;
+    }
+}

--- a/src/main/resources/db/migration/V223.1__particion_ids_central_impares.sql
+++ b/src/main/resources/db/migration/V223.1__particion_ids_central_impares.sql
@@ -1,0 +1,85 @@
+-- Reparto de ids entre el central y los filiales en las tablas que el filial
+-- replica al central: el central genera impares y cada filial genera pares
+-- (migracion espejo en el filial). Si los dos lados generan en el mismo espacio,
+-- el INSERT replicado del filial choca con la clave primaria y la suscripcion
+-- filial -> central se corta entera (issue #287).
+--
+-- Es el esquema que ya usan marcacion, movimiento_stock y movimiento_stock_lote.
+-- Aca se completa para las tablas que quedaron afuera.
+
+-- 1. Las secuencias del central pasan a generar solo impares, siguiendo desde el
+--    mayor valor ya usado (en la tabla o en la secuencia).
+DO $$
+DECLARE
+    t       record;
+    maximo  bigint;
+    proximo bigint;
+BEGIN
+    FOR t IN SELECT * FROM (VALUES
+            ('configuraciones.inicio_sesion_id_seq', 'configuraciones.inicio_sesion'),
+            ('financiero.venta_tarjeta_id_seq', 'financiero.venta_tarjeta'),
+            ('financiero.maletin_id_seq', 'financiero.maletin'),
+            ('financiero.movimiento_personas_id_seq', 'financiero.movimiento_personas')
+        ) AS v(secuencia, tabla)
+    LOOP
+        IF to_regclass(t.secuencia) IS NULL OR to_regclass(t.tabla) IS NULL THEN
+            CONTINUE;
+        END IF;
+        EXECUTE format('SELECT GREATEST(COALESCE((SELECT MAX(id) FROM %s), 0), (SELECT last_value FROM %s))',
+                       t.tabla, t.secuencia) INTO maximo;
+        proximo := maximo + 1;
+        IF proximo % 2 = 0 THEN
+            proximo := proximo + 1;
+        END IF;
+        EXECUTE format('ALTER SEQUENCE %s INCREMENT BY 2', t.secuencia);
+        PERFORM setval(t.secuencia::regclass, proximo, false);
+    END LOOP;
+END;
+$$;
+
+-- 2. La base rechaza cualquier INSERT local con id par, venga del codigo, de un
+--    id que manda un cliente o de un script. Los triggers comunes NO se disparan
+--    en los workers de replicacion (corren con session_replication_role =
+--    replica), asi que las filas que llegan del filial pasan igual.
+--    Para una reparacion manual que copie filas del filial a mano, correr antes
+--    SET session_replication_role = replica en esa sesion.
+CREATE OR REPLACE FUNCTION configuraciones.rechazar_id_de_filial() RETURNS trigger
+    LANGUAGE plpgsql AS
+$$
+BEGIN
+    IF NEW.id % 2 = 0 THEN
+        RAISE EXCEPTION 'El central no puede insertar en %.% con id par (%): los ids pares los genera el filial y chocarian al replicarse',
+            TG_TABLE_SCHEMA, TG_TABLE_NAME, NEW.id
+            USING ERRCODE = 'check_violation';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+--    marcacion, movimiento_stock y movimiento_stock_lote ya usaban el reparto,
+--    pero nada impedia que un id par entrara por otro camino (por ejemplo
+--    saveMovimientoStock con un id que manda el cliente): tambien van aca.
+DO $$
+DECLARE
+    tabla text;
+BEGIN
+    FOREACH tabla IN ARRAY ARRAY[
+            'configuraciones.inicio_sesion',
+            'financiero.gasto',
+            'financiero.venta_tarjeta',
+            'financiero.maletin',
+            'financiero.movimiento_personas',
+            'administrativo.marcacion',
+            'operaciones.movimiento_stock',
+            'operaciones.movimiento_stock_lote'
+        ]
+    LOOP
+        IF to_regclass(tabla) IS NULL THEN
+            CONTINUE;
+        END IF;
+        EXECUTE format('DROP TRIGGER IF EXISTS rechazar_id_de_filial ON %s', tabla);
+        EXECUTE format('CREATE TRIGGER rechazar_id_de_filial BEFORE INSERT ON %s '
+                           || 'FOR EACH ROW EXECUTE FUNCTION configuraciones.rechazar_id_de_filial()', tabla);
+    END LOOP;
+END;
+$$;

--- a/src/main/resources/graphql/replication/replication.graphqls
+++ b/src/main/resources/graphql/replication/replication.graphqls
@@ -163,4 +163,8 @@ extend type Mutation {
     
     # Sync existing publications with replication_table (add missing tables on central and all filiales)
     syncPublicationsWithReplicationTable: ReplicationStatus!
+
+    # Pone la secuencia de ids de cada filial por encima de los ids pares que el central ya tiene.
+    # Una vez, despues de desplegar V223.1 en el central y la migracion espejo en los filiales.
+    alinearSecuenciasFiliales: ReplicationStatus!
 } 

--- a/src/test/java/com/franco/dev/service/configuracion/InicioSesionServiceIdImparTest.java
+++ b/src/test/java/com/franco/dev/service/configuracion/InicioSesionServiceIdImparTest.java
@@ -1,0 +1,102 @@
+package com.franco.dev.service.configuracion;
+
+import com.franco.dev.domain.EmbebedPrimaryKey;
+import com.franco.dev.domain.configuracion.InicioSesion;
+import com.franco.dev.repository.configuracion.InicioSesionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * El filial genera los ids de inicio_sesion de su sucursal (pares) y los
+ * replica al central. Si el central insertara un id que el filial tambien va a
+ * generar, la replicacion choca con inicio_sesion_pk y se corta entera. Por eso
+ * el central solo inserta impares, y nunca inserta un par que le manda un cliente.
+ */
+class InicioSesionServiceIdImparTest {
+
+    private InicioSesionRepository repository;
+    private InicioSesionService service;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(InicioSesionRepository.class);
+        service = new InicioSesionService(repository, mock(ApplicationEventPublisher.class));
+        when(repository.save(any(InicioSesion.class))).thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    private InicioSesion sesion(Long id, Long sucursalId) {
+        InicioSesion sesion = new InicioSesion();
+        sesion.setId(id);
+        sesion.setSucursalId(sucursalId);
+        return sesion;
+    }
+
+    private void elCentralTiene(long id, long sucursalId, boolean existe) {
+        when(repository.existsById(new EmbebedPrimaryKey(id, sucursalId))).thenReturn(existe);
+    }
+
+    @Test
+    void unaSesionNuevaDelCentralEsImparAunqueElMaximoVengaDelFilial() {
+        when(repository.findMaxId(2L)).thenReturn(7064L);
+
+        assertEquals(7065L, service.save(sesion(null, 2L)).getId());
+    }
+
+    @Test
+    void siguePorImparesDespuesDeOtraSesionDelCentral() {
+        when(repository.findMaxId(2L)).thenReturn(7065L);
+
+        assertEquals(7067L, service.save(sesion(null, 2L)).getId());
+    }
+
+    @Test
+    void reabrirUnaSesionQueElCentralYaTieneConservaSuId() {
+        elCentralTiene(7062L, 2L, true);
+
+        InicioSesion guardada = service.save(sesion(7062L, 2L));
+
+        assertEquals(7062L, guardada.getId(), "es un UPDATE de la fila que ya llego del filial");
+        verify(repository, never()).findMaxId(anyLong());
+    }
+
+    @Test
+    void unaSesionImparDelCentralNoSeConsulta() {
+        InicioSesion guardada = service.save(sesion(7069L, 2L));
+
+        assertEquals(7069L, guardada.getId());
+        verify(repository, never()).existsById(any(EmbebedPrimaryKey.class));
+    }
+
+    @Test
+    void abrirConUnIdDeFilialQueElCentralNoTieneCreaUnaSesionImpar() {
+        elCentralTiene(7064L, 2L, false);
+        when(repository.findMaxId(2L)).thenReturn(7063L);
+
+        InicioSesion guardada = service.save(sesion(7064L, 2L));
+
+        assertEquals(7065L, guardada.getId(),
+                "insertar el 7064 haria chocar el INSERT que el filial todavia no replico");
+    }
+
+    @Test
+    void cerrarUnaSesionDeFilialQueElCentralNoTieneNoEscribeNada() {
+        elCentralTiene(7064L, 2L, false);
+        InicioSesion cierre = sesion(7064L, 2L);
+        cierre.setHoraFin(LocalDateTime.of(2026, 9, 11, 18, 0));
+
+        service.save(cierre);
+
+        verify(repository, never()).save(any(InicioSesion.class));
+    }
+}

--- a/src/test/java/com/franco/dev/service/empresarial/AlineacionIdsFilialServiceTest.java
+++ b/src/test/java/com/franco/dev/service/empresarial/AlineacionIdsFilialServiceTest.java
@@ -1,0 +1,107 @@
+package com.franco.dev.service.empresarial;
+
+import com.franco.dev.domain.empresarial.Sucursal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AlineacionIdsFilialServiceTest {
+
+    private static final String FUNCION = "SELECT configuraciones.alinear_secuencia_par(?::regclass, ?::regclass, ?)";
+
+    private JdbcTemplate central;
+    private SucursalService sucursalService;
+    private LogicalReplicationService replicationService;
+    private AlineacionIdsFilialService service;
+
+    @BeforeEach
+    void setUp() {
+        central = mock(JdbcTemplate.class);
+        sucursalService = mock(SucursalService.class);
+        replicationService = mock(LogicalReplicationService.class);
+        service = new AlineacionIdsFilialService(central, sucursalService, replicationService);
+        when(replicationService.queryRemoteForObject(anyLong(), anyString(), eq(Long.class), any(), any(), any()))
+                .thenReturn(100L);
+    }
+
+    private Sucursal sucursal(Long id, boolean activa, String ip) {
+        Sucursal s = new Sucursal();
+        s.setId(id);
+        s.setNombre("SUC " + id);
+        s.setActivo(activa);
+        s.setIp(ip);
+        s.setPuerto(ip == null ? null : 5432);
+        return s;
+    }
+
+    @Test
+    void usaElMayorParDelCentralDeEsaSucursal() {
+        when(central.queryForObject(contains("inicio_sesion WHERE id % 2 = 0 AND sucursal_id"), eq(Long.class), eq(2L)))
+                .thenReturn(7064L);
+
+        service.alinear(2L);
+
+        verify(replicationService).queryRemoteForObject(2L, FUNCION, Long.class,
+                "configuraciones.inicio_sesion_id_seq", "configuraciones.inicio_sesion", 7064L);
+    }
+
+    @Test
+    void enLasTablasDeIdGlobalMiraTodaLaTabla() {
+        when(central.queryForObject(contains("financiero.maletin WHERE id % 2 = 0"), eq(Long.class)))
+                .thenReturn(24L);
+
+        service.alinear(2L);
+
+        verify(replicationService).queryRemoteForObject(2L, FUNCION, Long.class,
+                "financiero.maletin_id_seq", "financiero.maletin", 24L);
+    }
+
+    @Test
+    void sinParesEnElCentralMandaCero() {
+        service.alinear(2L);
+
+        verify(replicationService).queryRemoteForObject(2L, FUNCION, Long.class,
+                "financiero.gasto_id_seq", "financiero.gasto", 0L);
+    }
+
+    @Test
+    void unFilialQueFallaNoFrenaALosDemas() {
+        when(sucursalService.findAllExcludingServer()).thenReturn(Arrays.asList(
+                sucursal(2L, true, "10.0.0.2"), sucursal(3L, true, "10.0.0.3")));
+        when(replicationService.queryRemoteForObject(eq(2L), anyString(), eq(Long.class), any(), any(), any()))
+                .thenThrow(new RuntimeException("function does not exist"));
+
+        AlineacionIdsFilialService.Resultado resultado = service.alinearTodas();
+
+        assertFalse(resultado.isSuccess());
+        assertTrue(resultado.getMensaje().contains("SUC 2 (2): ERROR function does not exist"));
+        assertTrue(resultado.getMensaje().contains("SUC 3 (3): configuraciones.inicio_sesion -> 100"));
+    }
+
+    @Test
+    void ignoraSucursalesInactivasOSinIp() {
+        when(sucursalService.findAllExcludingServer()).thenReturn(Arrays.asList(
+                sucursal(4L, false, "10.0.0.4"), sucursal(5L, true, null)));
+
+        AlineacionIdsFilialService.Resultado resultado = service.alinearTodas();
+
+        assertTrue(resultado.isSuccess());
+        assertEquals("No hay filiales activos con IP y puerto", resultado.getMensaje());
+        verify(replicationService, never()).queryRemoteForObject(anyLong(), anyString(), eq(Long.class), any(), any(), any());
+    }
+}

--- a/src/test/java/com/franco/dev/utilitarios/IdCentralTest.java
+++ b/src/test/java/com/franco/dev/utilitarios/IdCentralTest.java
@@ -1,0 +1,29 @@
+package com.franco.dev.utilitarios;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class IdCentralTest {
+
+    @Test
+    void sinFilasPreviasArrancaEnUno() {
+        assertEquals(1L, IdCentral.siguienteImpar(null));
+        assertEquals(1L, IdCentral.siguienteImpar(0L));
+    }
+
+    @Test
+    void siempreDevuelveUnImparMayorQueElMaximo() {
+        assertEquals(7065L, IdCentral.siguienteImpar(7064L), "el maximo par vino del filial");
+        assertEquals(7067L, IdCentral.siguienteImpar(7065L), "el maximo impar lo genero el central");
+    }
+
+    @Test
+    void losParesSonDelFilial() {
+        assertTrue(IdCentral.esDeFilial(7064L));
+        assertFalse(IdCentral.esDeFilial(7065L));
+        assertFalse(IdCentral.esDeFilial(null));
+    }
+}


### PR DESCRIPTION
> **Va junto con el PR del filial:** https://github.com/GabFrank/franco-system-backend-filial/pull/124 (misma rama, `V94.1`).

## Qué resuelve

La replicación **filial → central** se cortaba por choques de clave primaria: el central generaba ids en el mismo espacio que los filiales en `inicio_sesion`, `gasto`, `venta_tarjeta`, `maletin` y `movimiento_personas`. Cuando el filial replicaba una fila con un id que el central ya había usado, el apply worker fallaba en bucle y la suscripción entera quedaba parada (#287).

Este PR completa el reparto que ya usaban `marcacion`, `movimiento_stock` y `movimiento_stock_lote`: **el central genera impares y los filiales pares**. Va junto con el PR espejo del filial (misma rama, `V94.1`).

## Cambios

- **`IdCentral`**: calcula el próximo impar. Lo usan `InicioSesionService` y la merma de gasto de `DevolucionService`, que antes asignaban `MAX(id)+1`.
- **`inicio_sesion`** ya no inserta una sesión con id par (de filial) que el central todavía no tiene: si es un cierre no hace nada; si es una apertura, crea una sesión nueva con id impar.
- **`V223.1`**:
  - pasa a impares (`INCREMENT BY 2`) las secuencias de `inicio_sesion`, `venta_tarjeta`, `maletin` y `movimiento_personas`, siguiendo desde el mayor valor usado;
  - crea el trigger `rechazar_id_de_filial`, que rechaza cualquier **INSERT local** con id par en `inicio_sesion`, `gasto`, `venta_tarjeta`, `maletin`, `movimiento_personas`, `marcacion`, `movimiento_stock` y `movimiento_stock_lote`. Los triggers comunes no se disparan en la replicación, así que las filas que llegan del filial pasan igual.
- **Mutation `alinearSecuenciasFiliales`** (`AlineacionIdsFilialService`): deja la secuencia de cada filial por encima de los ids pares que el central ya tiene (creados antes de este esquema). Reporta el resultado por sucursal y sigue si una no responde.

## Cómo probar

- `./mvnw clean verify -B -DskipFlyway=true` → 608 tests, 0 fallos (tests nuevos: `IdCentralTest`, `InicioSesionServiceIdImparTest`, `AlineacionIdsFilialServiceTest`).
- Probado en local con central (`V223.1`) + filial (`V94.1`) + desktop:
  - una sesión del desktop en modo local se crea en el filial con id par, cierra con `hora_fin` y llega al central por replicación;
  - un INSERT local con id par en el central es rechazado con el mensaje del trigger;
  - las secuencias del central quedan en impares.
- Verificado en bases descartables con una suscripción real: el trigger **no** se dispara en la copia inicial (tablesync) ni en la replicación normal (apply).

## Impacto en DB

`V223.1`: `ALTER SEQUENCE ... INCREMENT BY 2` + `setval`, `CREATE OR REPLACE FUNCTION` y `CREATE TRIGGER` en 8 tablas. Es idempotente y no borra ni modifica datos ni columnas.

## Despliegue

1. Desplegar el central y los filiales cerca en el tiempo. El orden no importa: en la ventana entre uno y otro el riesgo es el mismo que hoy y afecta a la replicación, no a las ventas (el trigger vive solo en el central).
2. Con el central desplegado, correr `alinearSecuenciasFiliales` **una vez en cada central** (bodega y farmacia), desde el central real. Si un filial todavía no tiene `V94.1` aparece con error en el reporte; se puede volver a correr.
3. ⚠️ **Nunca correr esa mutation desde un central local**: la base local tiene las IP reales de los filiales.

## Rollback

- Revertir el JAR no revierte la migración. Las secuencias en incremento 2 siguen funcionando con el código anterior.
- Si el trigger llegara a bloquear algo inesperado, se apaga en segundos sin desplegar:

```sql
DO $$ DECLARE t text; BEGIN
  FOREACH t IN ARRAY ARRAY['configuraciones.inicio_sesion','financiero.gasto','financiero.venta_tarjeta',
    'financiero.maletin','financiero.movimiento_personas','administrativo.marcacion',
    'operaciones.movimiento_stock','operaciones.movimiento_stock_lote']
  LOOP EXECUTE format('ALTER TABLE %s DISABLE TRIGGER rechazar_id_de_filial', t); END LOOP;
END $$;
```

## Riesgo

**Medio**: toca tablas operativas. Mitigado porque todos los caminos de inserción del central en esas tablas generan impares (revisado en el código y en los datos de alpha: ninguna fila creada por el central tiene id par), el trigger no afecta a la replicación y hay un apagado inmediato.

## Fuera de alcance

- Divergencia de datos por `REPLICA IDENTITY FULL` cuando el central modifica filas que vienen del filial.
- Monitoreo de la replicación (alertar cuando un worker entra en crash-loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3E5c8fSzVWdwV2LSuePAm
