### PR TITLE
fix(gastos): generar id impar al materializar el gasto de tesoreria

### DIFF
--- a/src/main/java/com/franco/dev/service/financiero/GastoTesoreriaService.java
+++ b/src/main/java/com/franco/dev/service/financiero/GastoTesoreriaService.java
@@ -10,6 +10,7 @@ import com.franco.dev.domain.personas.Usuario;
 import com.franco.dev.repository.financiero.GastoRepository;
 import com.franco.dev.service.operaciones.SolicitudPagoService;
 import com.franco.dev.service.personas.ProveedorService;
+import com.franco.dev.utilitarios.IdCentral;
 import graphql.GraphQLException;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -120,10 +121,15 @@ public class GastoTesoreriaService {
         gastoService.save(gasto);
     }
 
-    /** Id correlativo dentro de la sucursal 0, igual que el resto de las entidades de clave compuesta. */
+    /**
+     * Id correlativo dentro de la sucursal 0, igual que el resto de las entidades de clave
+     * compuesta, pero siempre IMPAR: en el central el trigger rechazar_id_de_filial (migracion
+     * V223.1) rechaza todo INSERT en financiero.gasto con id par, porque los pares los genera
+     * cada filial y chocarian al replicarse. Es el mismo criterio que usa DevolucionService al
+     * materializar su gasto.
+     */
     private Long siguienteIdServidor() {
-        Long maxId = gastoRepository.findMaxId(SUCURSAL_SERVIDOR);
-        return (maxId == null ? 0L : maxId) + 1;
+        return IdCentral.siguienteImpar(gastoRepository.findMaxId(SUCURSAL_SERVIDOR));
     }
 
     /**

--- a/src/test/java/com/franco/dev/service/financiero/GastoTesoreriaIdImparTest.java
+++ b/src/test/java/com/franco/dev/service/financiero/GastoTesoreriaIdImparTest.java
@@ -1,0 +1,96 @@
+package com.franco.dev.service.financiero;
+
+import com.franco.dev.domain.financiero.Gasto;
+import com.franco.dev.domain.financiero.Moneda;
+import com.franco.dev.domain.operaciones.SolicitudPago;
+import com.franco.dev.domain.operaciones.enums.TipoSolicitudPago;
+import com.franco.dev.repository.financiero.GastoRepository;
+import com.franco.dev.service.operaciones.SolicitudPagoService;
+import com.franco.dev.service.personas.ProveedorService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * El gasto materializado en la sucursal 0 tiene que nacer con id IMPAR: desde la migracion
+ * V223.1 el trigger rechazar_id_de_filial rechaza en el central cualquier INSERT en
+ * financiero.gasto con id par (ERRCODE check_violation), porque los pares los genera el filial.
+ *
+ * Con el max(id)+1 pelado, el primer gasto impar dejaba el maximo en impar y de ahi en adelante
+ * TODO pago de gasto pedia un id par y moria con ConstraintViolationException / constraint [null]
+ * -- el trigger levanta su propia excepcion, asi que Hibernate no encuentra nombre de constraint.
+ */
+class GastoTesoreriaIdImparTest {
+
+    private GastoRepository gastoRepository;
+    private GastoService gastoService;
+    private GastoTesoreriaService service;
+
+    @BeforeEach
+    void setUp() {
+        gastoRepository = mock(GastoRepository.class);
+        gastoService = mock(GastoService.class);
+        service = new GastoTesoreriaService(
+                mock(SolicitudPagoService.class),
+                mock(TipoGastoService.class),
+                mock(MonedaService.class),
+                mock(ProveedorService.class),
+                gastoRepository,
+                gastoService);
+    }
+
+    private SolicitudPago solicitudGastoPagada() {
+        SolicitudPago sp = new SolicitudPago();
+        sp.setId(451L);
+        sp.setTipo(TipoSolicitudPago.GASTO);
+        sp.setMontoPagado(BigDecimal.valueOf(28000));
+        Moneda gs = new Moneda();
+        gs.setId(1L);
+        sp.setMoneda(gs);
+        return sp;
+    }
+
+    private Long idMaterializadoConMaximo(Long maxId) {
+        when(gastoRepository.findFirstBySolicitudPagoId(451L)).thenReturn(null);
+        when(gastoRepository.findMaxId(GastoTesoreriaService.SUCURSAL_SERVIDOR)).thenReturn(maxId);
+
+        service.sincronizarDesdeSolicitudPago(solicitudGastoPagada());
+
+        ArgumentCaptor<Gasto> captor = ArgumentCaptor.forClass(Gasto.class);
+        verify(gastoService).save(captor.capture());
+        return captor.getValue().getId();
+    }
+
+    @Test
+    void conMaximoImparSaltaElParQueRechazaElTrigger() {
+        assertEquals(155L, idMaterializadoConMaximo(153L));
+    }
+
+    @Test
+    void conMaximoParTomaElImparSiguiente() {
+        assertEquals(153L, idMaterializadoConMaximo(152L));
+    }
+
+    @Test
+    void sinGastosPreviosEnLaSucursalCeroArrancaEnUno() {
+        assertEquals(1L, idMaterializadoConMaximo(null));
+    }
+
+    @Test
+    void elIdNuncaEsPar() {
+        for (long max = 0; max <= 20; max++) {
+            Long id = idMaterializadoConMaximo(max);
+            assertTrue(id % 2 == 1, "id par rechazado por el trigger: " + id + " (max=" + max + ")");
+            assertTrue(id > max, "el id tiene que ser mayor que el maximo: " + id + " (max=" + max + ")");
+            setUp();
+        }
+    }
+}


### PR DESCRIPTION
## Que resuelve

En produccion, confirmar el pago de un gasto desde la caja mayor fallaba siempre con:

```
could not execute statement; SQL [n/a]; constraint [null];
nested exception is org.hibernate.exception.ConstraintViolationException
```

El pago entero se revertia (es una sola transaccion), asi que el modulo quedaba inutilizable.

## Causa

La migracion `V223.1__particion_ids_central_impares.sql` (PR #289) agrego a `financiero.gasto` el trigger `rechazar_id_de_filial`: en el central ningun INSERT local puede llevar id par, porque los pares los genera cada filial y chocarian al replicarse.

`GastoTesoreriaService.siguienteIdServidor()` -- el que materializa el gasto en `financiero.gasto` al pagarlo desde la caja mayor -- seguia con el `max(id) + 1` pelado. Apenas un gasto quedo guardado con id impar, `max(id)` quedo impar, el siguiente calculado salio par, el trigger lo rechazo, no se inserto nada y `max(id)` siguio impar: **de ahi en adelante todo pago de gasto fallaba**. No era intermitente, quedaba trabado.

El mensaje inutil tiene su explicacion: el trigger levanta su propia excepcion con `ERRCODE = 'check_violation'` (23514) y un texto propio, asi que el extractor del dialecto de Hibernate 5.6 no encuentra el `violates check constraint "..."` que busca y reporta `constraint [null]`.

Reproducido en la base local (transaccion revertida, creando el trigger igual que la migracion):

```
ERROR:  El central no puede insertar en financiero.gasto con id par (154):
        los ids pares los genera el filial y chocarian al replicarse
```

La local esta en Flyway 222.3 -- V223.1 todavia no se aplico -- por eso solo se veia en produccion.

## Que cambia

`GastoTesoreriaService.siguienteIdServidor()` usa `IdCentral.siguienteImpar`, el mismo criterio que ya aplica `DevolucionService` cuando materializa su gasto. Un metodo, una linea.

Revisadas las otras 7 tablas que protege el trigger: `inicio_sesion` ya usa `IdCentral`, `marcacion` / `movimiento_stock` / `movimiento_stock_lote` manejan la paridad a mano, y `venta_tarjeta` / `maletin` / `movimiento_personas` generan por secuencia (la migracion les dejo `INCREMENT BY 2` arrancando en impar). `financiero.gasto` era la unica que quedaba suelta.

## Como testear

1. `./mvnw clean verify -B -DskipFlyway=true` -> **612 tests, 0 fallos**.
2. Test nuevo `GastoTesoreriaIdImparTest` (4 casos: maximo impar salta el par, maximo par, sin filas previas, y un barrido que verifica que el id nunca sale par). Antes del fix da rojo con `expected: <155> but was: <154>`.
3. Manual, contra una base con V223.1 aplicada: Caja mayor -> Registrar Egreso -> Pagar Gasto -> seleccionar una nota -> forma de pago -> Confirmar pago. Antes fallaba; ahora el gasto se materializa en `financiero.gasto` (sucursal 0) con id impar y aparece en la lista de gastos y en el grafico por categoria.

## Impacto en DB

Ninguno: no hay migracion. Solo cambia el id que el codigo elige al insertar. Los gastos ya guardados no se tocan y no hace falta reparar datos -- el fix desbloquea los proximos.

## Rollback

Sin riesgo: volver al JAR anterior reintroduce el bug, nada mas. No hay estado nuevo que revertir.

## Riesgo

**Bajo.** Un metodo privado de una linea + tests unitarios con mocks. No toca el motor de pago ni el movimiento de caja.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7G38wg7rDbqmkPZ2HpLtu
