### PR TITLE
fix(replicacion): dejar de bajar administrativo.jornada a las filiales

### DIFF
--- a/src/main/resources/db/migration/V224.3__jornada_deja_de_replicar_a_filiales.sql
+++ b/src/main/resources/db/migration/V224.3__jornada_deja_de_replicar_a_filiales.sql
@@ -1,0 +1,69 @@
+-- administrativo.jornada deja de bajar del central a las filiales.
+--
+-- Bajaba por MAIN_TO_ALL desde V117, pero nadie la lee del otro lado: tanto la lista de
+-- horarios del desktop como el marcado --desktop, mobile y PWA-- consultan siempre al central
+-- (clientName "servidor" en el cliente de Apollo). En la filial la tabla solo se llena.
+--
+-- Y se llena rota: la marcacion no baja --es BRANCH_TO_MAIN-- asi que cada jornada que llega
+-- apunta a filas de administrativo.marcacion que en esa base no existen ni van a existir. La FK
+-- no lo impide porque los workers de replicacion corren con session_replication_role = replica,
+-- donde los triggers RI no se disparan. Cualquier consulta que cargue esas jornadas revienta con
+-- EntityNotFoundException: la asociacion es eager y se cae la consulta entera, no la fila.
+--
+-- Ademas el backend de la filial escribe jornada por su cuenta (MarcacionService.procesarJornada)
+-- con la misma PK (id, sucursal_id) que usa el central, asi que las dos fuentes pueden chocar y
+-- cortar la suscripcion. Sin la bajada, la tabla queda con un solo escritor en cada base.
+--
+-- No se toca ni una fila de datos: las jornadas que las filiales ya tienen quedan donde estan,
+-- simplemente dejan de crecer. Tampoco cambia nada del lado del central, que sigue siendo el
+-- unico que las calcula y el unico al que se le consultan.
+--
+-- Reversible: alcanza con volver enabled a true y correr "Sincronizar publicaciones", que la
+-- agrega de nuevo a central_pub.
+
+UPDATE configuraciones.replication_table
+   SET enabled = false
+ WHERE table_name = 'administrativo.jornada';
+
+-- Sacarla de central_pub. Es lo que corta el envio: desde aca el publisher no manda mas cambios
+-- de esta tabla a ninguna filial. enabled = false evita que el sync la vuelva a agregar
+-- (getMainToAllTableNames solo mira las habilitadas).
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_publication_tables
+         WHERE pubname = 'central_pub'
+           AND schemaname = 'administrativo'
+           AND tablename = 'jornada'
+    ) THEN
+        BEGIN
+            ALTER PUBLICATION central_pub DROP TABLE administrativo.jornada;
+            RAISE NOTICE 'administrativo.jornada sacada de central_pub';
+        EXCEPTION WHEN OTHERS THEN
+            RAISE NOTICE 'No se pudo sacar administrativo.jornada de central_pub: %', SQLERRM;
+        END;
+    ELSE
+        RAISE NOTICE 'administrativo.jornada no estaba en central_pub, nada que hacer';
+    END IF;
+END;
+$$;
+
+-- Del lado de cada filial queda un ALTER SUBSCRIPTION ... REFRESH PUBLICATION para que la saque
+-- de pg_subscription_rel. No es urgente --el publisher ya dejo de mandarla-- y lo hacen solos el
+-- boton "Sincronizar publicaciones" y ReplicationRefreshScheduler.
+
+
+-- Correccion de lo que dice V216.5. Su encabezado afirma que administrativo.marcacion "se
+-- replica en las dos direcciones: sube por BRANCH_TO_MAIN (ver V112) y baja por las
+-- publicaciones central_filialN_pub". La segunda mitad es falsa y lo fue siempre: marcacion no
+-- esta en central_pub ni en ninguna central_*_filialN_pub, asi que del central no baja nada.
+-- Esa migracion no se toca --Flyway compara checksums y ya corrio en todas las bases--, pero el
+-- dato correcto queda aca y en el comentario de la tabla, que es donde se lo va a buscar.
+--
+-- Que implica para una columna nueva en marcacion: el publisher es la FILIAL, no el central. Al
+-- central le pueden sobrar columnas (el suscriptor ignora las que no tiene mapeadas) pero no le
+-- pueden faltar, o su suscripcion se corta con "missing replicated column". Correr la migracion
+-- en las filiales sigue siendo necesario, pero por el codigo que escribe esas columnas, no por
+-- una bajada que no existe.
+COMMENT ON TABLE administrativo.marcacion IS
+    'Solo sube: BRANCH_TO_MAIN (filial -> central). No baja a las filiales, no esta en central_pub ni en las central_*_filialN_pub. El publisher es la filial, asi que una columna nueva tiene que existir en el central antes que en la filial. Lo que dice V216.5 sobre que baja por central_filialN_pub es incorrecto.';


### PR DESCRIPTION
## Qué resuelve

`administrativo.jornada` bajaba del central a todas las filiales por `MAIN_TO_ALL` (V117) y del otro lado no la lee nadie: la lista de horarios y el marcado —desktop, mobile y PWA— consultan siempre al central (`clientName: "servidor"` en `generic-crud.service.ts:139` → `graphql-connection.service.ts:268`). En la filial la tabla solo se llena.

Y se llena rota: `administrativo.marcacion` no baja —es `BRANCH_TO_MAIN`— así que cada jornada que llega apunta a filas de `marcacion` que en esa base no existen ni van a existir. La FK no lo impide porque los workers de replicación corren con `session_replication_role = replica`, donde los triggers RI no se disparan. Al cargar esas jornadas, Hibernate tira `EntityNotFoundException` (la asociación `@OneToOne` es eager) y **se cae la consulta entera, no la fila**:

```
Unable to find com.franco.dev.domain.administrativo.Marcacion with id EmbebedPrimaryKey(id=2947, sucursalId=13)
  at JornadaService.findByFechaRange(JornadaService.java:42)
  at JornadaGraphQL.jornadas(JornadaGraphQL.java:37)
```

Medido en un dump del 09-11 de una filial: **849 jornadas, las 849 huérfanas**, con `administrativo.marcacion` vacía.

Como efecto lateral, el backend de la filial escribe `jornada` por su cuenta (`MarcacionService.procesarJornada`) con la misma PK `(id, sucursal_id)` que usa el central. Hoy hay dos escritores sobre la misma tabla y un choque de PK corta la suscripción. Sin la bajada, cada base queda con un solo escritor.

## Cómo probarlo

```sql
-- antes
SELECT pubname FROM pg_publication_tables WHERE tablename = 'jornada';   -- central_pub
-- después de arrancar el backend (Flyway aplica V224.3)
SELECT pubname FROM pg_publication_tables WHERE tablename = 'jornada';   -- vacío
SELECT table_name, enabled FROM configuraciones.replication_table
 WHERE table_name = 'administrativo.jornada';                            -- enabled = f
SELECT count(*) FROM administrativo.jornada;                             -- sin cambios
```

Después, "Sincronizar publicaciones" no la repone (`getMainToAllTableNames()` filtra `enabled = true`). En la filial queda un `ALTER SUBSCRIPTION … REFRESH PUBLICATION` para sacarla de `pg_subscription_rel`; no es urgente porque el publisher ya dejó de mandarla, y lo hacen solos el botón de sincronizar y `ReplicationRefreshScheduler`.

Verificado contra una base real dentro de `BEGIN … ROLLBACK`, incluida una segunda corrida para confirmar idempotencia.

## Impacto en DB

- `UPDATE` de una fila de `configuraciones.replication_table` (config, no datos de negocio).
- `ALTER PUBLICATION central_pub DROP TABLE administrativo.jornada`, dentro de un `DO` guardado: si la tabla no está en la publicación, `NOTICE` y sigue.
- `COMMENT ON TABLE administrativo.marcacion`.
- **No toca ninguna fila de datos.** Las jornadas que las filiales ya tienen quedan donde están y dejan de crecer.
- Sin `DROP` / `RENAME` / cambio de tipo. Idempotente.

## Impacto en rollback

Ninguno hacia atrás: el JAR anterior funciona igual con la publicación sin esa tabla —el central sigue siendo el único que calcula y el único al que se le consultan las jornadas—. Para revertir el efecto, `enabled = true` en `replication_table` y "Sincronizar publicaciones", que la vuelve a agregar a `central_pub`.

## Riesgo

**Bajo.** Deja de replicarse una tabla que ningún cliente consulta en la filial y que allá solo puede estar rota. El único escenario que se pierde es leer jornadas desde una filial (p. ej. un modo offline), que hoy no existe.

## Nota sobre V216.5

Su encabezado afirma que `marcacion` "baja por las publicaciones `central_filialN_pub`". Es falso y lo fue siempre: no está en `central_pub` ni en ninguna `central_*_filialN_pub`. No se edita esa migración —ya corrió en todas las bases y Flyway compara checksums—, así que la corrección queda en el comentario de `V224.3` y en el `COMMENT ON TABLE`. De paso corrige la consecuencia práctica, que estaba al revés: el publisher es la filial, así que al central le pueden sobrar columnas pero no faltarle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MMbrBmGzKecxppxSUtNRUM
