### PR TITLE
fix(rrhh): espacio muerto en recibos de RRHH y encabezado faltante en ticket 80mm

### DIFF
--- a/src/main/resources/reports/recibo-finiquito.jrxml
+++ b/src/main/resources/reports/recibo-finiquito.jrxml
@@ -15,7 +15,7 @@
 	<field name="concepto" class="java.lang.String"/>
 	<field name="monto" class="java.lang.String"/>
 	<title>
-		<band height="238" splitType="Stretch">
+		<band height="196" splitType="Stretch">
 			<textField>
 				<reportElement x="0" y="0" width="380" height="22"/>
 				<textElement><font fontName="SansSerif" size="13" isBold="true"/></textElement>

--- a/src/main/resources/reports/recibo-rrhh.jrxml
+++ b/src/main/resources/reports/recibo-rrhh.jrxml
@@ -11,7 +11,7 @@
 	<field name="concepto" class="java.lang.String"/>
 	<field name="monto" class="java.lang.String"/>
 	<title>
-		<band height="150" splitType="Stretch">
+		<band height="108" splitType="Stretch">
 			<textField>
 				<reportElement x="0" y="0" width="555" height="18"/>
 				<textElement><font fontName="SansSerif" size="10" isBold="true"/></textElement>
@@ -123,6 +123,15 @@
 				<textElement textAlignment="Center"><font fontName="SansSerif" size="9"/></textElement>
 				<textFieldExpression><![CDATA["C.I. N: " + ($P{documento} != null ? $P{documento} : "")]]></textFieldExpression>
 			</textField>
+			<staticText>
+				<reportElement x="0" y="160" width="555" height="10"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font fontName="SansSerif" size="7"/></textElement>
+				<text><![CDATA[- - - - -  cortar por aqui  - - - - -]]></text>
+			</staticText>
+			<line>
+				<reportElement x="0" y="172" width="555" height="1"/>
+				<graphicElement><pen lineWidth="0.5" lineStyle="Dashed"/></graphicElement>
+			</line>
 		</band>
 	</summary>
 </jasperReport>

--- a/src/main/resources/reports/recibo-ticket-58.jrxml
+++ b/src/main/resources/reports/recibo-ticket-58.jrxml
@@ -11,7 +11,7 @@
 	<field name="concepto" class="java.lang.String"/>
 	<field name="monto" class="java.lang.String"/>
 	<title>
-		<band height="120" splitType="Stretch">
+		<band height="88" splitType="Stretch">
 			<textField isStretchWithOverflow="true">
 				<reportElement x="0" y="0" width="152" height="12"/>
 				<textElement textAlignment="Center"><font fontName="SansSerif" size="8" isBold="true"/></textElement>

--- a/src/main/resources/reports/recibo-ticket-80.jrxml
+++ b/src/main/resources/reports/recibo-ticket-80.jrxml
@@ -11,7 +11,7 @@
 	<field name="concepto" class="java.lang.String"/>
 	<field name="monto" class="java.lang.String"/>
 	<title>
-		<band height="93" splitType="Stretch">
+		<band height="95" splitType="Stretch">
 			<textField isStretchWithOverflow="true">
 				<reportElement x="0" y="0" width="215" height="12"/>
 				<textElement textAlignment="Center"><font fontName="SansSerif" size="9" isBold="true"/></textElement>
@@ -46,17 +46,17 @@
 				<graphicElement><pen lineWidth="0.75"/></graphicElement>
 			</line>
 			<staticText>
-				<reportElement x="0" y="77" width="140" height="12" positionType="Float"/>
+				<reportElement x="0" y="77" width="140" height="14" positionType="Float"/>
 				<textElement><font fontName="SansSerif" size="9" isBold="true"/></textElement>
 				<text><![CDATA[Concepto]]></text>
 			</staticText>
 			<staticText>
-				<reportElement x="140" y="77" width="75" height="12" positionType="Float"/>
+				<reportElement x="140" y="77" width="75" height="14" positionType="Float"/>
 				<textElement textAlignment="Right"><font fontName="SansSerif" size="9" isBold="true"/></textElement>
 				<text><![CDATA[Monto]]></text>
 			</staticText>
 			<line>
-				<reportElement x="0" y="90" width="215" height="1" positionType="Float"/>
+				<reportElement x="0" y="92" width="215" height="1" positionType="Float"/>
 				<graphicElement><pen lineWidth="0.5"/></graphicElement>
 			</line>
 		</band>

--- a/src/main/resources/reports/recibo-ticket-80.jrxml
+++ b/src/main/resources/reports/recibo-ticket-80.jrxml
@@ -11,7 +11,7 @@
 	<field name="concepto" class="java.lang.String"/>
 	<field name="monto" class="java.lang.String"/>
 	<title>
-		<band height="120" splitType="Stretch">
+		<band height="93" splitType="Stretch">
 			<textField isStretchWithOverflow="true">
 				<reportElement x="0" y="0" width="215" height="12"/>
 				<textElement textAlignment="Center"><font fontName="SansSerif" size="9" isBold="true"/></textElement>

--- a/src/test/java/com/franco/dev/reports/ReciboRrhhJrxmlTest.java
+++ b/src/test/java/com/franco/dev/reports/ReciboRrhhJrxmlTest.java
@@ -48,6 +48,30 @@ public class ReciboRrhhJrxmlTest {
             JasperPrint print = JasperFillManager.fillReport(jr, p, new JRBeanCollectionDataSource(rows));
             byte[] pdf = JasperExportManager.exportReportToPdf(print);
             org.junit.jupiter.api.Assertions.assertTrue(pdf != null && pdf.length > 0, "Fallo plantilla " + tpl);
+
+            // Un staticText cuyo alto no alcanza para su fuente se rellena VACIO, sin error:
+            // el recibo sale sin encabezado de columnas y solo se nota mirando el PDF.
+            // Ver que el texto sobrevivio al fill, no solo que el PDF pesa algo.
+            String textos = textosDelPrint(print);
+            for (String esperado : new String[]{"Concepto", "Monto"}) {
+                org.junit.jupiter.api.Assertions.assertTrue(textos.contains(esperado),
+                        "La plantilla " + tpl + " no imprime el encabezado '" + esperado
+                                + "'. Suele ser el alto del staticText, que no entra para su fuente"
+                                + " y Jasper lo recorta a vacio. Textos: " + textos);
+            }
         }
+    }
+
+    /** Concatena el texto de todos los elementos del print, para aseverar sobre el resultado del fill. */
+    private String textosDelPrint(JasperPrint print) {
+        StringBuilder sb = new StringBuilder();
+        for (net.sf.jasperreports.engine.JRPrintPage page : print.getPages()) {
+            for (Object o : page.getElements()) {
+                if (o instanceof net.sf.jasperreports.engine.JRPrintText) {
+                    sb.append(((net.sf.jasperreports.engine.JRPrintText) o).getFullText()).append(" | ");
+                }
+            }
+        }
+        return sb.toString();
     }
 }


### PR DESCRIPTION
Cierra #221.

## Qué resuelve

**1. El hueco del recibo A4 (lo que pedía la issue)** — `recibo-rrhh.jrxml`

La banda `title` declaraba `height="150"` pero su último elemento (la fila de `C.I. N`) termina en `y=104`: esos ~46 pt vacíos se imprimían como el hueco entre la tabla del funcionario y el encabezado `Concepto | Monto`. Banda a 108, el recibo se acorta ~42 pt.

Se agrega también la línea de corte punteada bajo el bloque firmado.

**No se toca** el espacio entre la cláusula y la línea de firma (`summary`, y=80→120): es donde se firma.

**2. El mismo patrón en otras tres plantillas**

| Plantilla | Banda `title` | Ahorro |
|---|---|---|
| `recibo-finiquito.jrxml` | 238 → 196 | −42 pt |
| `recibo-ticket-58.jrxml` | 120 → 88 | −32 pt |
| `recibo-ticket-80.jrxml` | 120 → 93 | −27 pt |

Los tickets 58/80 son las variantes térmicas del mismo comprobante de vale / adelanto / penalización, así que ahí el hueco costaba papel en cada impresión.

**3. Bug preexistente encontrado de paso: el ticket de 80mm no imprimía `Concepto | Monto`**

Los dos `staticText` de cabecera declaraban `height="12"` con `SansSerif` 9. El texto no entra en 12 pt y, al no tener `isStretchWithOverflow` (a diferencia de los `textField` vecinos, que por eso sí se ven), **Jasper los rellena vacíos sin error ni warning**: el elemento se genera con posición y ancho correctos pero sin texto. El PDF se genera igual y el comprobante sale sin encabezado de columnas.

Confirmado exportando el `JasperPrint`:

```
ticket-80:  y=83 h=12 x=6 w=140  JRTemplatePrintText   <- vacío
ticket-58:  y=79 h=11 x=6 w=100  JRTemplatePrintText  Concepto
```

Es anterior a este PR: se reproduce igual en la plantilla de `develop`. Afecta solo al de 80mm; el de 58mm usa 8 pt en 11 y entra.

Fix: `staticText` 12 → 14, línea separadora y=90 → 92, banda 93 → 95.

## Sobre la leyenda de corte

La issue pedía `✂`. El export a PDF usa iText con la fuente lógica `SansSerif` (Helvetica/WinAnsi), que **no tiene el glifo U+2702 y lo descarta en silencio** — verificado generando el PDF: salía "cortar por aqui" sin la tijera. Va con guiones, que es el "o similar" que la issue admite. Meter una fuente con ese glifo está prohibido por `CLAUDE.md` §Reportes.

## Verificación

- `ReciboRrhhJrxmlTest` pasa. Se le agregó una aserción de que `Concepto` y `Monto` **sobreviven al fill**, no solo que el PDF pesa algo — que es justamente lo que dejaba pasar el bug del ticket-80. Con la plantilla anterior el test falla; así se confirmó la causa.
- `recibo-finiquito.jrxml` no está cubierto por ningún test: se validó aparte compilando y generando el PDF con sus 12 parámetros y 6 filas de conceptos.
- Las cuatro plantillas se compararon en PDF contra la versión anterior.
- Probado en la app corriendo (central 8081 + filial 8082 + desktop).

## Pendiente, fuera de este PR

El mismo defecto de alto insuficiente puede afectar otros reportes: hay decenas de elementos de 9 pt en 12 en `reporte-ventas.jrxml` y `reporte-ventas-detallado.jrxml`, y de 7 pt en 9 en `transferencia.jrxml` y `pre-gasto.jrxml`. **No están verificados** — y como `SansSerif` es una fuente lógica, el alto real depende de la fuente física a la que la JVM la mapee, así que el resultado puede diferir entre entornos. Es una pista para revisar con el mismo método (fill + comparar el texto), no un diagnóstico.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
