### PR TITLE
fix(rrhh): anular los bonos pendientes al egresar a un funcionario

### DIFF
--- a/src/main/java/com/franco/dev/repository/rrhh/BonoRecurrenteRepository.java
+++ b/src/main/java/com/franco/dev/repository/rrhh/BonoRecurrenteRepository.java
@@ -19,6 +19,9 @@ public interface BonoRecurrenteRepository extends HelperRepository<BonoRecurrent
     @Query("select b.id from BonoRecurrente b where b.activo = true order by b.id asc")
     List<Long> idsActivos();
 
+    /** Plantillas vigentes de un funcionario. Las apaga el egreso: ver FuncionarioRrhhService. */
+    List<BonoRecurrente> findByFuncionarioIdAndActivoTrue(Long funcionarioId);
+
     /** Padron del SaaS: toda lista paginada y filtrada en el backend. */
     @Query("select b from BonoRecurrente b where " +
             "(:funcionarioId is null or b.funcionario.id = :funcionarioId) and " +

--- a/src/main/java/com/franco/dev/service/rrhh/FuncionarioRrhhService.java
+++ b/src/main/java/com/franco/dev/service/rrhh/FuncionarioRrhhService.java
@@ -10,6 +10,10 @@ import com.franco.dev.domain.personas.Cliente;
 import com.franco.dev.domain.rrhh.LiquidacionFinal;
 import com.franco.dev.domain.rrhh.enums.LiquidacionFinalEstado;
 import com.franco.dev.domain.rrhh.FuncionarioEgresoHistorico;
+import com.franco.dev.domain.rrhh.Bono;
+import com.franco.dev.domain.rrhh.BonoRecurrente;
+import com.franco.dev.repository.rrhh.BonoRecurrenteRepository;
+import com.franco.dev.repository.rrhh.BonoRepository;
 import com.franco.dev.repository.rrhh.FuncionarioEgresoHistoricoRepository;
 import com.franco.dev.repository.rrhh.LiquidacionFinalRepository;
 import com.franco.dev.service.empresarial.CargoService;
@@ -46,6 +50,8 @@ public class FuncionarioRrhhService {
     private final ClienteService clienteService;
     private final LiquidacionFinalRepository liquidacionFinalRepository;
     private final FuncionarioEgresoHistoricoRepository egresoHistoricoRepository;
+    private final BonoRepository bonoRepository;
+    private final BonoRecurrenteRepository bonoRecurrenteRepository;
 
     /**
      * Cambia el cargo del funcionario dejando rastro: cierra el histórico abierto
@@ -131,7 +137,42 @@ public class FuncionarioRrhhService {
         snap.setMotivoEgreso(guardado.getMotivoEgreso());
         snap.setEgresadoPor(usuarioAutenticado());
         egresoHistoricoRepository.save(snap);
+
+        cancelarBonosPendientes(funcionarioId);
         return guardado;
+    }
+
+    /**
+     * Lo que el funcionario no alcanzo a cobrar deja de corresponderle: anula sus bonos
+     * pendientes y apaga las plantillas que los generan.
+     *
+     * <p>Decision de negocio (issue #276): el finiquito NO paga bonos. Sin esto el bono del
+     * mes queda con {@code liquidacion_id} nulo para siempre -- no lo cobra nadie, porque la
+     * generacion masiva saltea a los inactivos, pero figura como pendiente en la grilla. La
+     * plantilla, por su lado, ya era inerte ({@code BonoRecurrenteService} exige
+     * {@code funcionario.activo}); apagarla es lo que hace visible que se cancelo.</p>
+     *
+     * <p><b>Un bono ya liquidado no se toca:</b> es plata que se pago.</p>
+     */
+    private void cancelarBonosPendientes(Long funcionarioId) {
+        int bonos = 0;
+        for (Bono b : bonoRepository.findByFuncionarioIdOrderByFechaDesc(funcionarioId)) {
+            if (Boolean.TRUE.equals(b.getAnulado())) continue;
+            if (b.getLiquidacionId() != null) continue;
+            b.setAnulado(true);
+            bonoRepository.save(b);
+            bonos++;
+        }
+        int plantillas = 0;
+        for (BonoRecurrente p : bonoRecurrenteRepository.findByFuncionarioIdAndActivoTrue(funcionarioId)) {
+            p.setActivo(false);
+            bonoRecurrenteRepository.save(p);
+            plantillas++;
+        }
+        if (bonos > 0 || plantillas > 0) {
+            log.info("Egreso funcionario={}: {} bono/s pendiente/s anulado/s, {} plantilla/s recurrente/s apagada/s",
+                    funcionarioId, bonos, plantillas);
+        }
     }
 
     /** Foto del estado que el egreso va a destruir. Se arma ANTES de guardar. */
@@ -174,6 +215,11 @@ public class FuncionarioRrhhService {
     /**
      * Revierte un egreso: deshace lo que {@link #egresar} dejo, incluido el dano
      * colateral que egresar provoca y que no se ve en la pantalla de egreso.
+     *
+     * <p><b>Excepcion declarada:</b> los bonos que el egreso anulo y las plantillas recurrentes
+     * que apago NO se restauran -- hay que recargarlos a mano desde la pantalla de Bonos.
+     * Guardar que anulo cada egreso exigiria columnas nuevas en el snapshot; se decidio no
+     * pagar esa migracion por un caso que se da muy de vez en cuando (issue #276).</p>
      *
      * <p>Existe porque no habia ninguna forma de revertir un egreso desde la aplicacion.
      * El 2026-08-21 se egreso por error a una funcionaria en farmacia y hubo que resolverlo

--- a/src/test/java/com/franco/dev/service/rrhh/AnularBonosAlEgresarTest.java
+++ b/src/test/java/com/franco/dev/service/rrhh/AnularBonosAlEgresarTest.java
@@ -1,0 +1,171 @@
+package com.franco.dev.service.rrhh;
+
+import com.franco.dev.domain.personas.Funcionario;
+import com.franco.dev.domain.personas.Persona;
+import com.franco.dev.domain.rrhh.Bono;
+import com.franco.dev.domain.rrhh.BonoRecurrente;
+import com.franco.dev.domain.rrhh.FuncionarioEgresoHistorico;
+import com.franco.dev.domain.rrhh.enums.BonoTipo;
+import com.franco.dev.repository.personas.FuncionarioRepository;
+import com.franco.dev.repository.rrhh.BonoRecurrenteRepository;
+import com.franco.dev.repository.rrhh.BonoRepository;
+import com.franco.dev.repository.rrhh.FuncionarioEgresoHistoricoRepository;
+import com.franco.dev.repository.rrhh.LiquidacionFinalRepository;
+import com.franco.dev.service.empresarial.CargoService;
+import com.franco.dev.service.financiero.MonedaService;
+import com.franco.dev.service.personas.ClienteService;
+import com.franco.dev.service.personas.FuncionarioService;
+import com.franco.dev.service.personas.UsuarioService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Al egresar, lo que el funcionario no alcanzo a cobrar deja de corresponderle: los bonos
+ * pendientes se anulan y la plantilla que los genera todos los meses se apaga.
+ *
+ * <p>Decision de negocio (issue #276): el finiquito NO paga bonos. Sin esto el bono del mes
+ * queda con liquidacion_id nulo para siempre -- nadie lo paga, pero figura como pendiente
+ * en la grilla, y la plantilla sigue en "activa" aunque el generador ya la saltee por
+ * funcionario.activo.</p>
+ */
+class AnularBonosAlEgresarTest {
+
+    private static final Long FUNC_ID = 1L;
+    private static final Long PERSONA_ID = 7L;
+
+    private FuncionarioRepository funcionarioRepository;
+    private BonoRepository bonoRepository;
+    private BonoRecurrenteRepository bonoRecurrenteRepository;
+    private FuncionarioRrhhService service;
+
+    private Funcionario funcionario;
+
+    @BeforeEach
+    void setUp() {
+        funcionarioRepository = mock(FuncionarioRepository.class);
+        bonoRepository = mock(BonoRepository.class);
+        bonoRecurrenteRepository = mock(BonoRecurrenteRepository.class);
+        UsuarioService usuarioService = mock(UsuarioService.class);
+        ClienteService clienteService = mock(ClienteService.class);
+        FuncionarioEgresoHistoricoRepository egresoHistoricoRepository =
+                mock(FuncionarioEgresoHistoricoRepository.class);
+
+        FuncionarioService funcionarioService =
+                new FuncionarioService(funcionarioRepository, usuarioService, clienteService);
+
+        service = new FuncionarioRrhhService(
+                funcionarioService,
+                mock(CargoService.class),
+                mock(MonedaService.class),
+                usuarioService,
+                mock(FuncionarioCargoHistoricoService.class),
+                mock(FuncionarioSalarioHistoricoService.class),
+                clienteService,
+                mock(LiquidacionFinalRepository.class),
+                egresoHistoricoRepository,
+                bonoRepository,
+                bonoRecurrenteRepository);
+
+        Persona persona = new Persona();
+        persona.setId(PERSONA_ID);
+
+        funcionario = new Funcionario();
+        funcionario.setId(FUNC_ID);
+        funcionario.setPersona(persona);
+        funcionario.setActivo(true);
+        funcionario.setCredito(0f);
+
+        when(funcionarioRepository.findById(FUNC_ID)).thenReturn(Optional.of(funcionario));
+        when(funcionarioRepository.save(any(Funcionario.class))).thenAnswer(i -> i.getArgument(0));
+        when(egresoHistoricoRepository.save(any(FuncionarioEgresoHistorico.class)))
+                .thenAnswer(i -> i.getArgument(0));
+        when(bonoRepository.save(any(Bono.class))).thenAnswer(i -> i.getArgument(0));
+        when(bonoRecurrenteRepository.save(any(BonoRecurrente.class))).thenAnswer(i -> i.getArgument(0));
+        when(bonoRepository.findByFuncionarioIdOrderByFechaDesc(FUNC_ID))
+                .thenReturn(Collections.emptyList());
+        when(bonoRecurrenteRepository.findByFuncionarioIdAndActivoTrue(FUNC_ID))
+                .thenReturn(Collections.emptyList());
+    }
+
+    private Bono bono(Long id, Boolean anulado, Long liquidacionId) {
+        Bono b = new Bono();
+        b.setId(id);
+        b.setFuncionario(funcionario);
+        b.setTipo(BonoTipo.PRODUCTIVIDAD);
+        b.setMonto(new BigDecimal("150000"));
+        b.setFecha(LocalDate.of(2026, 9, 1));
+        b.setAnulado(anulado);
+        b.setLiquidacionId(liquidacionId);
+        return b;
+    }
+
+    private BonoRecurrente plantilla(Long id) {
+        BonoRecurrente p = new BonoRecurrente();
+        p.setId(id);
+        p.setFuncionario(funcionario);
+        p.setTipo(BonoTipo.PRODUCTIVIDAD);
+        p.setMonto(new BigDecimal("150000"));
+        p.setActivo(true);
+        return p;
+    }
+
+    @Test
+    void anulaElBonoPendienteDelFuncionarioQueEgresa() {
+        Bono pendiente = bono(10L, false, null);
+        when(bonoRepository.findByFuncionarioIdOrderByFechaDesc(FUNC_ID))
+                .thenReturn(new ArrayList<>(Collections.singletonList(pendiente)));
+
+        service.egresar(FUNC_ID, LocalDate.of(2026, 9, 12), "renuncia");
+
+        assertTrue(Boolean.TRUE.equals(pendiente.getAnulado()),
+                "el bono sin liquidar tiene que quedar anulado");
+        verify(bonoRepository).save(pendiente);
+    }
+
+    @Test
+    void noTocaElBonoYaLiquidadoNiElYaAnulado() {
+        Bono liquidado = bono(11L, false, 500L);
+        Bono yaAnulado = bono(12L, true, null);
+        when(bonoRepository.findByFuncionarioIdOrderByFechaDesc(FUNC_ID))
+                .thenReturn(new ArrayList<>(Arrays.asList(liquidado, yaAnulado)));
+
+        service.egresar(FUNC_ID, LocalDate.of(2026, 9, 12), "renuncia");
+
+        assertFalse(Boolean.TRUE.equals(liquidado.getAnulado()),
+                "un bono ya liquidado es plata pagada: no se anula");
+        verify(bonoRepository, never()).save(any(Bono.class));
+    }
+
+    @Test
+    void apagaLaPlantillaRecurrenteDelFuncionarioQueEgresa() {
+        BonoRecurrente p = plantilla(77L);
+        when(bonoRecurrenteRepository.findByFuncionarioIdAndActivoTrue(FUNC_ID))
+                .thenReturn(new ArrayList<>(Collections.singletonList(p)));
+
+        service.egresar(FUNC_ID, LocalDate.of(2026, 9, 12), "renuncia");
+
+        assertFalse(Boolean.TRUE.equals(p.getActivo()),
+                "la plantilla recurrente tiene que quedar inactiva");
+        verify(bonoRecurrenteRepository).save(p);
+    }
+
+    @Test
+    void elEgresoSigueFuncionandoSinBonosNiPlantillas() {
+        Funcionario r = service.egresar(FUNC_ID, LocalDate.of(2026, 9, 12), "renuncia");
+
+        assertFalse(Boolean.TRUE.equals(r.getActivo()), "el funcionario tiene que quedar inactivo");
+        assertNotNull(r.getFechaEgreso(), "la fecha de egreso tiene que quedar cargada");
+    }
+}

--- a/src/test/java/com/franco/dev/service/rrhh/RevertirEgresoFuncionarioTest.java
+++ b/src/test/java/com/franco/dev/service/rrhh/RevertirEgresoFuncionarioTest.java
@@ -9,6 +9,8 @@ import com.franco.dev.domain.rrhh.FuncionarioEgresoHistorico;
 import com.franco.dev.domain.rrhh.LiquidacionFinal;
 import com.franco.dev.domain.rrhh.enums.LiquidacionFinalEstado;
 import com.franco.dev.repository.personas.FuncionarioRepository;
+import com.franco.dev.repository.rrhh.BonoRecurrenteRepository;
+import com.franco.dev.repository.rrhh.BonoRepository;
 import com.franco.dev.repository.rrhh.FuncionarioEgresoHistoricoRepository;
 import com.franco.dev.repository.rrhh.LiquidacionFinalRepository;
 import com.franco.dev.service.empresarial.CargoService;
@@ -49,6 +51,8 @@ class RevertirEgresoFuncionarioTest {
     private ClienteService clienteService;
     private LiquidacionFinalRepository liquidacionFinalRepository;
     private FuncionarioEgresoHistoricoRepository egresoHistoricoRepository;
+    private BonoRepository bonoRepository;
+    private BonoRecurrenteRepository bonoRecurrenteRepository;
     private FuncionarioService funcionarioService;
     private FuncionarioRrhhService service;
 
@@ -64,6 +68,8 @@ class RevertirEgresoFuncionarioTest {
         clienteService = mock(ClienteService.class);
         liquidacionFinalRepository = mock(LiquidacionFinalRepository.class);
         egresoHistoricoRepository = mock(FuncionarioEgresoHistoricoRepository.class);
+        bonoRepository = mock(BonoRepository.class);
+        bonoRecurrenteRepository = mock(BonoRecurrenteRepository.class);
 
         funcionarioService = new FuncionarioService(funcionarioRepository, usuarioService, clienteService);
 
@@ -76,7 +82,9 @@ class RevertirEgresoFuncionarioTest {
                 mock(FuncionarioSalarioHistoricoService.class),
                 clienteService,
                 liquidacionFinalRepository,
-                egresoHistoricoRepository);
+                egresoHistoricoRepository,
+                bonoRepository,
+                bonoRecurrenteRepository);
 
         persona = new Persona();
         persona.setId(PERSONA_ID);


### PR DESCRIPTION
Cierra #276.

## Qué resuelve

Un bono no liquidado al momento del egreso no lo pagaba nadie y quedaba en `rrhh.bono` con `liquidacion_id` nulo para siempre: el finiquito no incluye bonos y la generación masiva saltea a los inactivos.

**Decisión de negocio (consultada):** el finiquito **no** paga bonos. Lo que el funcionario no alcanzó a cobrar deja de corresponderle. Así que en vez de sumarlo al finiquito, el egreso lo cancela.

Eso descarta las dos primeras opciones que planteaba la issue. La segunda —meter a los egresados en la generación masiva— además pagaba el salario del mes dos veces: el finiquito ya liquida `SALARIO_MES` proporcional (`LiquidacionFinalService:168-175`) y el borrador de sueldo siempre agrega `SALARIO_BASE` (`LiquidacionSueldoService:224-225`).

## Qué cambia

`FuncionarioRrhhService.egresar()`, en la misma transacción:

- anula los bonos pendientes del funcionario (`anulado != true` y `liquidacionId == null`), sin filtro de fecha;
- pone `activo=false` en sus plantillas `BonoRecurrente`;
- loguea cuántos tocó.

**Un bono ya liquidado no se toca**: es plata pagada. La plantilla ya era inerte —`BonoRecurrenteService` exige `funcionario.activo`— pero seguía figurando como activa en la pantalla; apagarla es lo que hace visible que se canceló.

`LiquidacionFinalService` **no se toca**: su comportamiento actual ya es el correcto.

## Limitación declarada

`revertirEgreso()` **no** restaura lo anulado: hay que recargarlo a mano desde la pantalla de Bonos. Queda escrito en su javadoc. Guardar qué anuló cada egreso exigiría columnas nuevas en el snapshot, y se decidió no pagar esa migración por un caso que se da muy de vez en cuando. El desktop avisa de esto en los dos diálogos (PR hermano).

## Cómo probarlo

1. Funcionario activo con un bono vigente sin liquidar, y si se quiere una plantilla recurrente.
2. Egresarlo desde el legajo.
3. En la grilla de Bonos ese bono queda **ANULADO** y la plantilla **inactiva**; un bono ya liquidado sigue intacto.
4. El finiquito no muestra ninguna línea de bono.

Probado en la app corriendo (central 8081 + desktop): bono pendiente anulado, bono liquidado intacto, plantilla apagada, finiquito con SALARIO DEL MES / INDEMNIZACIÓN / PREAVISO / AGUINALDO y ningún bono.

## Impacto

- **DB:** ninguno. Sin migración — solo actualiza filas existentes.
- **API GraphQL:** ninguno. Sin cambios de schema, no afecta a desktop ni PWA.
- **Rollback:** limpio. Volver a la versión anterior deja de anular; los bonos ya anulados se desanulan a mano si hiciera falta.
- **Riesgo:** bajo.

## Verificación

`./mvnw clean verify -DskipFlyway=true` → **616 tests, 0 fallos**. Incluye `AnularBonosAlEgresarTest` (4 casos, escritos antes de la implementación y vistos fallar).

## PR hermano

GabFrank/frc-sistemas-integrados-angular — misma rama: avisa en el diálogo de egreso que los bonos pendientes se anulan, y en el de revertir que no vuelven solos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWt857ee4NRkZffjAovb7y